### PR TITLE
feat: collapse sentinel range breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Added opt-in support for targeting Vyper `0.5.0a3`; custom error syntax is
   treated as newly accepted source and broad alpha pragmas compile with `a3`
   when needed.
-- Added a range migration that collapses leading loop sentinel `if`/`break`
-  blocks into `range(..., bound=...)` when the bounded stop is inferable.
+- Added a range diagnostic for leading loop sentinel `if`/`break` blocks, with
+  an aggressive-mode migration to collapse them into `range(..., bound=...)`
+  when the bounded stop is inferable.
 
 ## 0.4.1 - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added opt-in support for targeting Vyper `0.5.0a3`; custom error syntax is
   treated as newly accepted source and broad alpha pragmas compile with `a3`
   when needed.
+- Added a range migration that collapses leading loop sentinel `if`/`break`
+  blocks into `range(..., bound=...)` when the bounded stop is inferable.
 
 ## 0.4.1 - 2026-06-06
 

--- a/docs/migration-coverage.md
+++ b/docs/migration-coverage.md
@@ -205,7 +205,9 @@ modern Python interpreter.
 - Interface-typed storage assignments are checked more strictly: `VY019`
   rewrites mismatched constructor casts to the declared storage interface type.
 - Dynamic `range` bounds: `VY071` adds inferred `bound=` for two-argument
-  ranges. `VYD011` flags two-argument ranges where the bound is not inferable.
+  ranges, and collapses leading `if`/`break` sentinel loops into bounded
+  single-argument ranges when the removed block is behavior-preserving.
+  `VYD011` flags two-argument ranges where the bound is not inferable.
 - Builtin ERC interface import path changed: `VY020` rewrites known imports and
   interface type names. Legacy built-in interfaces used in `implements` are
   preserved as local interfaces when modern `ethereum.ercs` definitions are

--- a/docs/migration-coverage.md
+++ b/docs/migration-coverage.md
@@ -205,9 +205,11 @@ modern Python interpreter.
 - Interface-typed storage assignments are checked more strictly: `VY019`
   rewrites mismatched constructor casts to the declared storage interface type.
 - Dynamic `range` bounds: `VY071` adds inferred `bound=` for two-argument
-  ranges, and collapses leading `if`/`break` sentinel loops into bounded
-  single-argument ranges when the removed block is behavior-preserving.
-  `VYD011` flags two-argument ranges where the bound is not inferable.
+  ranges. In aggressive mode, `VY071` also collapses leading `if`/`break`
+  sentinel loops into bounded single-argument ranges when the removed block is
+  behavior-preserving. `VYD011` flags two-argument ranges where the bound is not
+  inferable. `VYD017` flags sentinel loops that can be collapsed only under
+  `--aggressive`.
 - Builtin ERC interface import path changed: `VY020` rewrites known imports and
   interface type names. Legacy built-in interfaces used in `implements` are
   preserved as local interfaces when modern `ethereum.ercs` definitions are

--- a/src/vyupgrade/analysis.py
+++ b/src/vyupgrade/analysis.py
@@ -415,6 +415,9 @@ def infer_expr_type(
     expr = _strip_outer_parens(expr)
     if re.fullmatch(r"\d(?:_?\d)*", expr):
         return "uint256"
+    minmax_type = _infer_minmax_type(expr, vars_for_line, facts)
+    if minmax_type is not None:
+        return minmax_type
     if expr in {
         "block.timestamp",
         "block.number",
@@ -464,6 +467,32 @@ def infer_expr_type(
     if indexed_type is not None:
         return indexed_type
     return None
+
+
+def _infer_minmax_type(
+    expr: str, vars_for_line: dict[str, str], facts: SourceFacts | None
+) -> str | None:
+    match = re.fullmatch(r"(?:min|max)\s*\((.*)\)", expr, re.DOTALL)
+    if match is None:
+        return None
+    args = split_top_level_args(match.group(1))
+    if args is None or len(args) < 2:
+        return None
+    arg_types: list[tuple[str, str]] = []
+    for arg in args:
+        arg_type = infer_expr_type(arg, vars_for_line, facts)
+        if arg_type is None or not is_integer_type(arg_type):
+            return None
+        arg_types.append((arg.strip(), normalize_type(arg_type)))
+    concrete_types = {
+        type_name
+        for arg, type_name in arg_types
+        if not re.fullmatch(r"\d(?:_?\d)*", arg)
+    }
+    if len(concrete_types) == 1:
+        return next(iter(concrete_types))
+    all_types = {type_name for _arg, type_name in arg_types}
+    return next(iter(all_types)) if len(all_types) == 1 else None
 
 
 def _balanced_parens(value: str) -> bool:

--- a/src/vyupgrade/rule_groups/numeric_ranges.py
+++ b/src/vyupgrade/rule_groups/numeric_ranges.py
@@ -386,6 +386,189 @@ def _range_loop_var_type(iterable: str, vars_for_line: dict[str, str]) -> str:
     return bound_type if is_integer_type(bound_type) else "uint256"
 
 
+def _sentinel_range_bound(
+    rule_context: RuleContext,
+) -> tuple[str, list[Fix], list[Diagnostic]]:
+    source = rule_context.source
+    config = rule_context.config
+    mask = rule_context.code_mask
+    constant_values = integer_constant_values(source, config.source_ast)
+    fixes: list[Fix] = []
+    edits: list[TextEdit] = []
+    lines = source.splitlines(keepends=True)
+    line_offsets = _line_offsets(lines)
+    pattern = re.compile(
+        r"^(?P<indent>[ \t]*)for[ \t]+(?P<var>[A-Za-z_][A-Za-z0-9_]*)(?:[ \t]*:[^:\n]+?)?[ \t]+in[ \t]+range[ \t]*\(",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(source):
+        if not span_is_code(mask, match.start(), match.end()):
+            continue
+        close = find_matching(source, match.end() - 1)
+        if close is None:
+            continue
+        line_end = source.find("\n", match.start())
+        if line_end == -1:
+            line_end = len(source)
+        if re.fullmatch(r"\s*:\s*(?:#.*)?", source[close + 1 : line_end]) is None:
+            continue
+        raw_args = source[match.end() : close]
+        if "bound" in raw_args:
+            continue
+        arg_spans = split_top_level_arg_spans(raw_args)
+        if arg_spans is None or len(arg_spans) != 1:
+            continue
+        arg_start, arg_end, bound_arg = arg_spans[0]
+        if re.match(r"[A-Za-z_][A-Za-z0-9_]*\s*=", bound_arg):
+            continue
+        bound_value = eval_integer_constant_expr(bound_arg, constant_values)
+        if bound_value is None or bound_value < 0:
+            continue
+        loop_line = line_number(source, match.start()) - 1
+        sentinel = _sentinel_break_for_loop(lines, line_offsets, loop_line, match.group("var"))
+        if sentinel is None:
+            continue
+        vars_for_line = rule_context.facts.vars_at_line(loop_line + 1)
+        if _sentinel_stop_may_be_negative(
+            sentinel.stop, constant_values, vars_for_line, rule_context.facts
+        ):
+            continue
+        stop = _bounded_sentinel_stop(sentinel.stop, bound_arg, bound_value, constant_values)
+        edits.append(TextEdit(match.end() + arg_start, match.end() + arg_end, stop))
+        edits.append(TextEdit(close, close, f", bound={bound_arg}"))
+        edits.append(TextEdit(sentinel.start, sentinel.end, ""))
+        fixes.append(
+            Fix(
+                "VY071",
+                line_number(source, match.start()),
+                "collapsed sentinel break into bounded range",
+                source[match.start() : sentinel.end].rstrip("\n"),
+                source[match.start() : match.end()]
+                + stop
+                + f", bound={bound_arg}"
+                + source[close:line_end],
+            )
+        )
+    return apply_edits(source, edits), fixes, []
+
+
+@dataclass(frozen=True)
+class _SentinelBreak:
+    start: int
+    end: int
+    stop: str
+
+
+def _bounded_sentinel_stop(
+    stop: str, bound_arg: str, bound_value: int, constant_values: dict[str, int]
+) -> str:
+    stop_value = eval_integer_constant_expr(stop, constant_values)
+    if stop_value is not None and stop_value <= bound_value:
+        return stop
+    return f"min({stop}, {bound_arg})"
+
+
+def _sentinel_stop_may_be_negative(
+    stop: str,
+    constant_values: dict[str, int],
+    vars_for_line: dict[str, str],
+    facts: SourceFacts,
+) -> bool:
+    stop_value = eval_integer_constant_expr(stop, constant_values)
+    if stop_value is not None:
+        return stop_value < 0
+    stop_type = normalize_type(infer_expr_type(stop, vars_for_line, facts) or "")
+    return not stop_type or _is_signed_integer_type(stop_type)
+
+
+def _sentinel_break_for_loop(
+    lines: list[str], line_offsets: list[int], loop_line: int, loop_var: str
+) -> _SentinelBreak | None:
+    if loop_line < 0 or loop_line >= len(lines):
+        return None
+    loop_indent = _line_indent(lines[loop_line])
+    if_line = _next_significant_line(lines, loop_line + 1)
+    if if_line is None:
+        return None
+    if_indent = _line_indent(lines[if_line])
+    if if_indent <= loop_indent:
+        return None
+    if "#" in lines[if_line]:
+        return None
+    stop = _sentinel_stop_expr(lines[if_line].strip(), loop_var)
+    if stop is None:
+        return None
+    block_end = _block_end(lines, if_line + 1, if_indent)
+    if _block_contains_comment(lines, if_line, block_end):
+        return None
+    break_line = _next_significant_line(lines, if_line + 1, block_end)
+    if break_line is None:
+        return None
+    if _line_indent(lines[break_line]) <= if_indent:
+        return None
+    if lines[break_line].strip() != "break":
+        return None
+    if _next_significant_line(lines, break_line + 1, block_end) is not None:
+        return None
+    return _SentinelBreak(line_offsets[if_line], line_offsets[block_end], stop)
+
+
+def _sentinel_stop_expr(statement: str, loop_var: str) -> str | None:
+    match = re.fullmatch(r"if\s+(.+?)\s*(==|>=|<=)\s*(.+?)\s*:", statement)
+    if match is None:
+        return None
+    left, op, right = (part.strip() for part in match.groups())
+    if not left or not right or any(token in left + right for token in {" and ", " or "}):
+        return None
+    if op == "==":
+        if left == loop_var and right != loop_var:
+            return right
+        if right == loop_var and left != loop_var:
+            return left
+    if op == ">=" and left == loop_var and right != loop_var:
+        return right
+    if op == "<=" and right == loop_var and left != loop_var:
+        return left
+    return None
+
+
+def _line_offsets(lines: list[str]) -> list[int]:
+    offsets: list[int] = []
+    cursor = 0
+    for line in lines:
+        offsets.append(cursor)
+        cursor += len(line)
+    offsets.append(cursor)
+    return offsets
+
+
+def _line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" \t"))
+
+
+def _next_significant_line(
+    lines: list[str], start: int, end: int | None = None
+) -> int | None:
+    limit = len(lines) if end is None else min(end, len(lines))
+    for index in range(start, limit):
+        stripped = lines[index].strip()
+        if stripped and not stripped.startswith("#"):
+            return index
+    return None
+
+
+def _block_end(lines: list[str], start: int, parent_indent: int) -> int:
+    for index in range(start, len(lines)):
+        stripped = lines[index].strip()
+        if stripped and not stripped.startswith("#") and _line_indent(lines[index]) <= parent_indent:
+            return index
+    return len(lines)
+
+
+def _block_contains_comment(lines: list[str], start: int, end: int) -> bool:
+    return any("#" in lines[index] for index in range(start, min(end, len(lines))))
+
+
 def _range_bound(
     rule_context: RuleContext,
 ) -> tuple[str, list[Fix], list[Diagnostic]]:
@@ -588,6 +771,11 @@ RULES = (
         "signed_negative_range_bounds",
         runner=_signed_negative_range_bounds,
         changes=(crossing("VY052", (0, 4, 0)),),
+    ),
+    Rule(
+        "sentinel_range_bound",
+        runner=_sentinel_range_bound,
+        changes=(crossing("VY071", (0, 4, 0)),),
     ),
     Rule(
         "range_bound",

--- a/src/vyupgrade/rule_groups/numeric_ranges.py
+++ b/src/vyupgrade/rule_groups/numeric_ranges.py
@@ -394,6 +394,7 @@ def _sentinel_range_bound(
     mask = rule_context.code_mask
     constant_values = integer_constant_values(source, config.source_ast)
     fixes: list[Fix] = []
+    diagnostics: list[Diagnostic] = []
     edits: list[TextEdit] = []
     lines = source.splitlines(keepends=True)
     line_offsets = _line_offsets(lines)
@@ -433,6 +434,15 @@ def _sentinel_range_bound(
             sentinel.stop, constant_values, vars_for_line, rule_context.facts
         ):
             continue
+        if not config.aggressive:
+            diagnostics.append(
+                Diagnostic(
+                    "VYD017",
+                    line_number(source, match.start()),
+                    "sentinel range break can be collapsed with bound=... under --aggressive",
+                )
+            )
+            continue
         stop = _bounded_sentinel_stop(sentinel.stop, bound_arg, bound_value, constant_values)
         edits.append(TextEdit(match.end() + arg_start, match.end() + arg_end, stop))
         edits.append(TextEdit(close, close, f", bound={bound_arg}"))
@@ -449,7 +459,7 @@ def _sentinel_range_bound(
                 + source[close:line_end],
             )
         )
-    return apply_edits(source, edits), fixes, []
+    return apply_edits(source, edits), fixes, diagnostics
 
 
 @dataclass(frozen=True)
@@ -775,7 +785,7 @@ RULES = (
     Rule(
         "sentinel_range_bound",
         runner=_sentinel_range_bound,
-        changes=(crossing("VY071", (0, 4, 0)),),
+        changes=(crossing("VY071", (0, 4, 0)), crossing("VYD017", (0, 4, 0))),
     ),
     Rule(
         "range_bound",

--- a/tests/rule_groups/test_numeric_ranges.py
+++ b/tests/rule_groups/test_numeric_ranges.py
@@ -347,6 +347,145 @@ def f(start: uint256):
     assert "for i: uint256 in range" in result.source
 
 
+def test_sentinel_break_range_uses_min_with_bound(config) -> None:
+    source = """# @version 0.3.10
+MAX_POOLS: constant(uint256) = 2000
+
+@external
+def f(pool_count: uint256) -> uint256:
+    total: uint256 = 0
+    for i in range(MAX_POOLS):
+        if i == pool_count:
+            break
+        total += i
+    return total
+"""
+
+    result = apply_rules(source, config())
+
+    assert "for i: uint256 in range(min(pool_count, MAX_POOLS), bound=MAX_POOLS):" in result.source
+    assert "if i == pool_count" not in result.source
+    assert any(fix.rule == "VY071" for fix in result.fixes)
+
+
+def test_sentinel_break_range_skips_min_when_constant_stop_is_within_bound(config) -> None:
+    source = """# @version 0.3.10
+MAX_POOLS: constant(uint256) = 2000
+POOL_COUNT: constant(uint256) = 17
+
+@external
+def f() -> uint256:
+    total: uint256 = 0
+    for i in range(MAX_POOLS):
+        if i == POOL_COUNT:
+            break
+        total += i
+    return total
+"""
+
+    result = apply_rules(source, config())
+
+    assert "for i: uint256 in range(POOL_COUNT, bound=MAX_POOLS):" in result.source
+    assert "min(POOL_COUNT, MAX_POOLS)" not in result.source
+
+
+def test_sentinel_break_range_handles_reversed_greater_equal(config) -> None:
+    source = """# @version 0.3.10
+@external
+def f(_n_gauge_types: uint256) -> uint256:
+    total: uint256 = 0
+    for gauge_type in range(100):
+        if _n_gauge_types <= gauge_type:
+            break
+        total += gauge_type
+    return total
+"""
+
+    result = apply_rules(source, config())
+
+    assert (
+        "for gauge_type: uint256 in range(min(_n_gauge_types, 100), bound=100):"
+        in result.source
+    )
+    assert "if _n_gauge_types <= gauge_type" not in result.source
+
+
+def test_sentinel_break_range_skips_runtime_signed_stop(config) -> None:
+    source = """# @version 0.3.10
+MAX_COINS: constant(int128) = 8
+
+@external
+def f(n_coins: int128) -> int128:
+    total: int128 = 0
+    for i in range(MAX_COINS):
+        if i >= n_coins:
+            break
+        total += i
+    return total
+"""
+
+    result = apply_rules(source, config())
+
+    assert "if i >= n_coins:" in result.source
+    assert "min(n_coins, MAX_COINS)" not in result.source
+
+
+def test_sentinel_break_range_is_idempotent(config) -> None:
+    source = """# @version 0.3.10
+MAX_POOLS: constant(uint256) = 2000
+
+@external
+def f(pool_count: uint256):
+    for i in range(MAX_POOLS):
+        if i == pool_count:
+            break
+        pass
+"""
+
+    first = apply_rules(source, config())
+    second = apply_rules(first.source, config())
+
+    assert second.source == first.source
+
+
+def test_sentinel_break_range_preserves_commented_break_blocks(config) -> None:
+    source = """# @version 0.3.10
+MAX_POOLS: constant(uint256) = 2000
+
+@external
+def f(pool_count: uint256):
+    for i in range(MAX_POOLS):
+        if i == pool_count:
+            # keep this review note
+            break
+        pass
+"""
+
+    result = apply_rules(source, config())
+
+    assert "if i == pool_count:" in result.source
+    assert "# keep this review note" in result.source
+
+
+def test_sentinel_break_range_ignores_non_break_only_blocks(config) -> None:
+    source = """# @version 0.3.10
+MAX_POOLS: constant(uint256) = 2000
+
+@external
+def f(pool_count: uint256):
+    for i in range(MAX_POOLS):
+        if i == pool_count:
+            pool_count = 0
+            break
+        pass
+"""
+
+    result = apply_rules(source, config())
+
+    assert "if i == pool_count:" in result.source
+    assert "pool_count = 0" in result.source
+
+
 def test_range_runtime_stop_with_constant_delta_gets_bound_keyword(config) -> None:
     source = """# @version 0.3.10
 MAX_COINS: constant(int128) = 8

--- a/tests/rule_groups/test_numeric_ranges.py
+++ b/tests/rule_groups/test_numeric_ranges.py
@@ -347,7 +347,7 @@ def f(start: uint256):
     assert "for i: uint256 in range" in result.source
 
 
-def test_sentinel_break_range_uses_min_with_bound(config) -> None:
+def test_sentinel_break_range_warns_without_rewrite_by_default(config) -> None:
     source = """# @version 0.3.10
 MAX_POOLS: constant(uint256) = 2000
 
@@ -363,9 +363,32 @@ def f(pool_count: uint256) -> uint256:
 
     result = apply_rules(source, config())
 
+    assert "for i: uint256 in range(MAX_POOLS):" in result.source
+    assert "if i == pool_count:" in result.source
+    assert any(diag.rule == "VYD017" for diag in result.diagnostics)
+    assert not [fix for fix in result.fixes if fix.rule == "VY071"]
+
+
+def test_sentinel_break_range_uses_min_with_bound_in_aggressive_mode(config) -> None:
+    source = """# @version 0.3.10
+MAX_POOLS: constant(uint256) = 2000
+
+@external
+def f(pool_count: uint256) -> uint256:
+    total: uint256 = 0
+    for i in range(MAX_POOLS):
+        if i == pool_count:
+            break
+        total += i
+    return total
+"""
+
+    result = apply_rules(source, config(aggressive=True))
+
     assert "for i: uint256 in range(min(pool_count, MAX_POOLS), bound=MAX_POOLS):" in result.source
     assert "if i == pool_count" not in result.source
     assert any(fix.rule == "VY071" for fix in result.fixes)
+    assert not [diag for diag in result.diagnostics if diag.rule == "VYD017"]
 
 
 def test_sentinel_break_range_skips_min_when_constant_stop_is_within_bound(config) -> None:
@@ -383,7 +406,7 @@ def f() -> uint256:
     return total
 """
 
-    result = apply_rules(source, config())
+    result = apply_rules(source, config(aggressive=True))
 
     assert "for i: uint256 in range(POOL_COUNT, bound=MAX_POOLS):" in result.source
     assert "min(POOL_COUNT, MAX_POOLS)" not in result.source
@@ -401,7 +424,7 @@ def f(_n_gauge_types: uint256) -> uint256:
     return total
 """
 
-    result = apply_rules(source, config())
+    result = apply_rules(source, config(aggressive=True))
 
     assert (
         "for gauge_type: uint256 in range(min(_n_gauge_types, 100), bound=100):"

--- a/tests/rule_groups/test_numeric_signedness.py
+++ b/tests/rule_groups/test_numeric_signedness.py
@@ -265,7 +265,8 @@ def f() -> uint256:
 
     result = apply_rules(source, config())
 
-    assert "if i == N_COINS:" in result.source
+    assert "for i: int128 in range(N_COINS, bound=N_COINS):" in result.source
+    assert "if i == N_COINS:" not in result.source
     assert "if i == convert(N_COINS, uint256):" not in result.source
 
 

--- a/tests/rule_groups/test_numeric_signedness.py
+++ b/tests/rule_groups/test_numeric_signedness.py
@@ -265,8 +265,7 @@ def f() -> uint256:
 
     result = apply_rules(source, config())
 
-    assert "for i: int128 in range(N_COINS, bound=N_COINS):" in result.source
-    assert "if i == N_COINS:" not in result.source
+    assert "if i == N_COINS:" in result.source
     assert "if i == convert(N_COINS, uint256):" not in result.source
 
 


### PR DESCRIPTION
## Summary

- Add a default `VYD017` diagnostic for leading range-loop sentinel `if`/`break` blocks that can be collapsed into bounded `range(...)` calls.
- Gate the deletion/collapse rewrite behind `--aggressive`, where `VY071` produces `range(..., bound=...)` and uses `min(stop, bound)` unless compile-time constants prove the sentinel stop is within the original bound.
- Skip commented or multi-statement break blocks, unknown stop types, and runtime signed stops to avoid changing behavior when the sentinel can be negative.
- Teach lightweight type inference about homogeneous `min(...)`/`max(...)` expressions so aggressive rewrites keep the right iterator type.

## Validation

- `uv run --locked pytest tests/rule_groups/test_numeric_ranges.py tests/rule_groups/test_numeric_signedness.py tests/test_docs.py tests/test_rule_registry.py` (110 passed)
- `uv run --locked pytest` (483 passed)
- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py`
- Full local corpus sentinel pass: 59,419 `.vy` files scanned; 29,652 range-bearing files; 6,960 files eligible for aggressive sentinel handling; 13,629 aggressive sentinel rewrites found; 0 exceptions.
- Default-mode corpus smoke on 6 representative matched ChainSecurity contracts: 6/6 source and target compiles passed; ABI, method IDs, and storage layout unchanged; `VYD017` reported for sentinel candidates.
- Aggressive `--check` on a representative ChainSecurity contract: source and target compiles passed; ABI, method IDs, and storage layout unchanged; exit 1 was expected because `--check` found changes.
- `scripts/smoke-wheel.sh` (passed after rerun with network access for PyPI dependency installation).
