### PR TITLE
fix: match version specs with compiler pragma semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Fixed source-version inference so version specs are matched with the
+  compiler's own PEP 440 pragma semantics; prerelease targets such as
+  `0.5.0a3` are no longer selected as the source validation compiler for
+  stable pragmas like `^0.4.2`.
+
 ## 0.4.2 - 2026-07-07
 
 - Added opt-in support for targeting Vyper `0.5.0a3`; custom error syntax is

--- a/src/vyupgrade/versions.py
+++ b/src/vyupgrade/versions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 
@@ -193,6 +194,11 @@ def default_evm_version(version: VyperVersion | None) -> str | None:
 def known_versions_satisfying(spec: str | None) -> tuple[VyperVersion, ...]:
     if not spec:
         return ()
+    specifiers = _specifier_set(spec)
+    if specifiers is not None:
+        return tuple(
+            version for version in KNOWN_VERSIONS if specifiers.contains(version, prereleases=True)
+        )
     clauses = _parse_clauses(spec)
     if not clauses:
         version = parse_version(spec)
@@ -202,6 +208,23 @@ def known_versions_satisfying(spec: str | None) -> tuple[VyperVersion, ...]:
         for version in KNOWN_VERSIONS
         if all(_satisfies(version, op, bound) for op, bound in clauses)
     )
+
+
+def _specifier_set(spec: str) -> SpecifierSet | None:
+    # Match the compiler's own pragma check (vyper.ast.pre_parser): a bare
+    # version pins exactly, an npm-style caret becomes a PEP 440
+    # compatible-release clause, and candidates are tested with
+    # SpecifierSet.contains(..., prereleases=True). PEP 440 ordered exclusive
+    # comparisons still reject prereleases of their bound, so "<0.5.0" never
+    # admits "0.5.0a3" even though it sorts lower.
+    normalized = spec.strip()
+    if re.match(r"[v0-9]", normalized):
+        normalized = f"=={normalized}"
+    normalized = re.sub(r"^\^", "~=", normalized)
+    try:
+        return SpecifierSet(normalized)
+    except InvalidSpecifier:
+        return None
 
 
 def is_supported_source_version(version: str | None) -> bool:

--- a/src/vyupgrade/versions.py
+++ b/src/vyupgrade/versions.py
@@ -256,7 +256,18 @@ def _parse_clauses(spec: str) -> list[tuple[str, VyperVersion]]:
 
 
 def _has_lower_bound(spec: str) -> bool:
+    specifiers = _specifier_set(spec)
+    if specifiers is not None:
+        return any(_specifier_is_lower_bound(specifier.operator, specifier.version) for specifier in specifiers)
     return any(op in {">=", ">", "=="} for op, _version in _parse_clauses(spec))
+
+
+def _specifier_is_lower_bound(operator: str, version: str) -> bool:
+    if operator in {"~=", ">=", ">"}:
+        return True
+    if operator in {"==", "==="}:
+        return "*" not in version
+    return False
 
 
 def _caret_upper_bound(version: VyperVersion) -> VyperVersion:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -56,6 +56,9 @@ def test_version_specs_pick_lowest_satisfying_source_floor() -> None:
     assert compiler_version_for_spec(">=0.5.0a1,<0.6.0") == "0.5.0a1"
     assert compiler_version_for_spec("<=0.5.0a2") == "0.5.0a2"
     assert compiler_version_for_spec("<=0.5.0a3") == "0.5.0a3"
+    assert compiler_version_for_spec("~=0.4") == "0.4.0"
+    assert compiler_version_for_spec("~=0.4.2") == "0.4.2"
+    assert compiler_version_for_spec("==0.4.*") == "0.4.3"
 
 
 def test_source_syntax_hints_raise_broad_pragma_compiler_floor() -> None:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -37,8 +37,12 @@ def test_known_versions_cover_full_supported_range() -> None:
     assert VyperVersion("0.1.0b1") in known_versions_satisfying(">=0.1.0b1,<0.2.1")
     assert VyperVersion("0.2.1") in known_versions_satisfying(">=0.2.1,<0.2.3")
     assert VyperVersion("0.4.3") in known_versions_satisfying(">=0.4.0")
-    assert VyperVersion("0.5.0a2") in known_versions_satisfying(">=0.5.0a1,<0.5.0")
-    assert VyperVersion("0.5.0a3") in known_versions_satisfying(">=0.5.0a1,<0.5.0")
+    assert VyperVersion("0.5.0a2") in known_versions_satisfying(">=0.5.0a1,<0.6.0")
+    assert VyperVersion("0.5.0a3") in known_versions_satisfying(">=0.5.0a1,<0.6.0")
+    assert VyperVersion("0.5.0a3") in known_versions_satisfying("^0.5.0a1")
+    # PEP 440 exclusive ordered bounds reject prereleases of the bound itself,
+    # exactly like the compiler's own pragma check does.
+    assert known_versions_satisfying(">=0.5.0a1,<0.5.0") == ()
 
 
 def test_version_specs_pick_lowest_satisfying_source_floor() -> None:
@@ -49,7 +53,7 @@ def test_version_specs_pick_lowest_satisfying_source_floor() -> None:
     assert minimum_satisfying_version(">=0.3.4,<0.4.0") == VyperVersion("0.3.4")
     assert minimum_satisfying_version(">0.3.10") == VyperVersion("0.4.0")
     assert compiler_version_for_spec("<=0.3.10") == "0.3.10"
-    assert compiler_version_for_spec(">=0.5.0a1,<0.5.0") == "0.5.0a1"
+    assert compiler_version_for_spec(">=0.5.0a1,<0.6.0") == "0.5.0a1"
     assert compiler_version_for_spec("<=0.5.0a2") == "0.5.0a2"
     assert compiler_version_for_spec("<=0.5.0a3") == "0.5.0a3"
 
@@ -66,7 +70,7 @@ def test_source_syntax_hints_raise_broad_pragma_compiler_floor() -> None:
     assert compiler_version_for_source(">=0.3.0,<0.3.4", "enum Side:\n    BUY\n") == "0.3.0"
     assert (
         compiler_version_for_source(
-            ">=0.5.0a1,<0.5.0", "error Unauthorized:\n    caller: address\n"
+            ">=0.5.0a1,<0.6.0", "error Unauthorized:\n    caller: address\n"
         )
         == "0.5.0a3"
     )
@@ -77,6 +81,16 @@ def test_source_validation_compiler_uses_newest_target_bounded_version() -> None
     assert compiler_version_for_source_validation(">0.3.10", "0.4.3", "") == "0.4.3"
     assert compiler_version_for_source_validation(">=0.4.0", "0.4.3", "") == "0.4.3"
     assert compiler_version_for_source_validation(">=0.4.0", "0.5.0a2", "") == "0.5.0a2"
+
+
+def test_prerelease_targets_never_satisfy_bounded_stable_pragmas() -> None:
+    assert known_versions_satisfying("^0.4.2") == (VyperVersion("0.4.2"), VyperVersion("0.4.3"))
+    assert compiler_version_for_spec("<0.5.0") == "0.4.3"
+    source = "# pragma version ^0.4.2\n\n@external\ndef value() -> uint256:\n    return 1\n"
+    assert compiler_version_for_source_validation("^0.4.2", "0.5.0a3", source) == "0.4.3"
+    # Legacy caret pragmas that name a prerelease still resolve to prereleases.
+    assert minimum_satisfying_version("^0.1.0b14") == VyperVersion("0.1.0b14")
+    assert VyperVersion("0.1.0b17") in known_versions_satisfying("^0.1.0b14")
 
 
 def test_migration_context_tracks_patch_level_crossings() -> None:


### PR DESCRIPTION
Fixes #6.

## Problem

Source-version inference selected the prerelease target `0.5.0a3` as the source validation compiler for a `^0.4.2` pragma, so the source compile failed with:

```
vyper.exceptions.VersionException: Version specification "~=0.4.2" is not compatible with compiler version "0.5.0a3"
```

## Root cause

`known_versions_satisfying()` expanded `^0.4.2` to `>=0.4.2, <0.5.0` and evaluated the clauses with raw PEP 440 **ordering** comparisons. Under PEP 440 ordering, `0.5.0a3 < 0.5.0` is true, so the `0.5.0` alphas leaked through the caret's upper bound and `compiler_version_for_source_validation()` picked the newest one.

Vyper itself checks pragmas differently (`vyper.ast.pre_parser.validate_version_pragma`): it normalizes `^X.Y.Z` to `~=X.Y.Z` and bare versions to `==X.Y.Z`, then tests `SpecifierSet.contains(compiler_version, prereleases=True)`. PEP 440 **specifier** semantics reject a prerelease at an exclusive ordered bound (`<0.5.0` never admits `0.5.0a3`), so vyupgrade's matcher was strictly more permissive than the compiler it invokes.

## Fix

`known_versions_satisfying()` now mirrors the compiler's check exactly: the spec is normalized the same way and candidates are tested with `SpecifierSet.contains(..., prereleases=True)`. The old clause-based matcher is kept only as a fallback for specs `SpecifierSet` cannot parse. With this, membership in the candidate list is equivalent to "this compiler accepts this pragma", so this class of divergence cannot recur.

For the issue's repro, source validation now picks `0.4.3`:

```
Repro.vy
  VY001 modernized version pragma (line 1)
  source compile (0.4.3): passed
  target compile: passed
  ABI unchanged: True
```

This also corrects `compiler_version_for_spec("<0.5.0")`, which previously resolved to `0.5.0a3` (same bug class).

## Test updates

Two existing assertions used `>=0.5.0a1,<0.5.0` as a broad alpha pragma, but the real compiler rejects that spec (`0.5.0aN` is a prerelease of the excluded bound `0.5.0` — verified against vyper 0.5.0a3). They now use `>=0.5.0a1,<0.6.0`, the form the CLI fixtures already use, plus an explicit assertion that `>=0.5.0a1,<0.5.0` matches nothing. A new regression test covers the `^0.4.2` / `0.5.0a3` scenario and legacy `^0.1.0b14` caret pragmas.

`ruff check`, the full unit suite (484 passed), and `tests/test_cli_integration.py` (real compilers) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtAsisni8yijKyn2e29q1R

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtAsisni8yijKyn2e29q1R)_