### PR TITLE
fix: enforce source-safe rule rewrites

### DIFF
--- a/src/vyupgrade/analysis.py
+++ b/src/vyupgrade/analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
-from .source import code_mask, span_is_code
+from .source import code_mask, find_matching, span_is_code
 from .source import split_top_level_args
 from .vyper_builtins import (
     BUILTIN_INTERFACE_PARAMS,
@@ -370,12 +370,31 @@ def iterable_element_type(type_name: str | None) -> str | None:
     if type_name is None:
         return None
     type_name = type_name.strip()
-    dyn_match = re.match(r"DynArray\[\s*([^,\]]+)", type_name)
-    if dyn_match:
-        return dyn_match.group(1).strip()
-    static_match = re.match(r"(.+)\[[^\]]+\]$", type_name)
-    if static_match and not type_name.startswith(("HashMap[", "Bytes[", "String[")):
-        return static_match.group(1).strip()
+    if type_name.startswith("DynArray["):
+        open_index = type_name.find("[")
+        close_index = find_matching(type_name, open_index, "[", "]")
+        if close_index == len(type_name) - 1:
+            parts = split_top_level_args(type_name[open_index + 1 : close_index])
+            if parts is not None and len(parts) == 2:
+                return parts[0].strip()
+    if type_name.endswith("]"):
+        depth = 0
+        for index in range(len(type_name) - 1, -1, -1):
+            char = type_name[index]
+            if char == "]":
+                depth += 1
+            elif char == "[":
+                depth -= 1
+                if depth == 0:
+                    element = type_name[:index].strip()
+                    length = type_name[index + 1 : -1].strip()
+                    if (
+                        element
+                        and length
+                        and element not in {"Bytes", "DynArray", "HashMap", "String"}
+                    ):
+                        return element
+                    break
     return None
 
 

--- a/src/vyupgrade/rule_groups/data_lifecycle.py
+++ b/src/vyupgrade/rule_groups/data_lifecycle.py
@@ -78,11 +78,15 @@ def _constructor_deploy(rule_context: RuleContext) -> tuple[str, list[Fix], list
 
 def _constructor_value_returns(source: str) -> list[tuple[int, int, str, str]]:
     edits: list[tuple[int, int, str, str]] = []
+    mask = code_mask(source)
     offset = 0
     in_constructor = False
     constructor_indent = 0
     for raw_line in source.splitlines(keepends=True):
         line = raw_line.rstrip("\n")
+        if not _line_match_starts_outside_string(source, mask, offset):
+            offset += len(raw_line)
+            continue
         stripped = line.strip()
         indent = len(line) - len(line.lstrip(" \t"))
         if in_constructor and stripped and not stripped.startswith("#") and indent <= constructor_indent:
@@ -165,15 +169,28 @@ def _enum_to_flag(rule_context: RuleContext) -> tuple[str, list[Fix], list[Diagn
 
 def _remove_internal_nonreentrant(source: str) -> tuple[str, list[Fix]]:
     lines = source.splitlines(keepends=True)
+    mask = code_mask(source)
+    offsets: list[int] = []
+    cursor = 0
+    for line in lines:
+        offsets.append(cursor)
+        cursor += len(line)
     fixes: list[Fix] = []
     out = list(lines)
     offset = 0
     for index, line in enumerate(lines):
-        if not re.match(r"\s*def\s+[A-Za-z_][A-Za-z0-9_]*\s*\(", line):
+        if not re.match(
+            r"\s*def\s+[A-Za-z_][A-Za-z0-9_]*\s*\(", line
+        ) or not _line_match_starts_outside_string(source, mask, offsets[index]):
             continue
         start = index
-        while start > 0 and re.match(
-            r"\s*@[A-Za-z_][A-Za-z0-9_]*(?:\(.*\))?\s*(?:#.*)?$", lines[start - 1]
+        while (
+            start > 0
+            and re.match(
+                r"\s*@[A-Za-z_][A-Za-z0-9_]*(?:\(.*\))?\s*(?:#.*)?$",
+                lines[start - 1],
+            )
+            and _line_match_starts_outside_string(source, mask, offsets[start - 1])
         ):
             start -= 1
         decorators = [
@@ -259,7 +276,10 @@ def _reserved_flag_storage(rule_context: RuleContext) -> tuple[str, list[Fix], l
     )
     if declaration is None or not span_is_code(mask, declaration.start(), declaration.end()):
         return source, [], []
-    if re.search(r"^[ \t]*def\s+flag\s*\(", source, re.MULTILINE):
+    if any(
+        span_is_code(mask, match.start(), match.end())
+        for match in re.finditer(r"^[ \t]*def\s+flag\s*\(", source, re.MULTILINE)
+    ):
         return source, [], []
     edits: list[TextEdit] = []
     fixes: list[Fix] = []
@@ -358,9 +378,13 @@ def _unbounded_dynarray_limits(rule_context: RuleContext) -> tuple[str, list[Fix
 
 
 def _first_top_level_function_offset(source: str) -> int:
+    mask = code_mask(source)
     offset = 0
     pending_decorator = 0
     for line in source.splitlines(keepends=True):
+        if not _line_match_starts_outside_string(source, mask, offset):
+            offset += len(line)
+            continue
         stripped = line.strip()
         if line[:1] not in {" ", "\t"} and stripped.startswith("@"):
             if pending_decorator == 0:
@@ -874,18 +898,24 @@ def _nonreentrant(
 ) -> tuple[str, list[Fix], list[Diagnostic]]:
     source = rule_context.source
     pattern = re.compile(r"@nonreentrant\(\s*([\"'])(.+?)\1\s*\)")
-    locks = [match.group(2) for match in pattern.finditer(source)]
+    mask = rule_context.code_mask
+    matches = [
+        match
+        for match in pattern.finditer(source)
+        if span_is_code(mask, match.start(), match.start() + len("@nonreentrant"))
+    ]
+    locks = [match.group(2) for match in matches]
     diagnostics: list[Diagnostic] = []
     fixes: list[Fix] = []
     if not locks:
         return source, fixes, diagnostics
     counts = Counter(locks)
-    if len(counts) > 1:
-        first = pattern.search(source)
+    if len(counts) > 1 and rule_context.is_enabled("VYD002"):
+        first = matches[0]
         diagnostics.append(
             Diagnostic(
                 "VYD002",
-                line_number(source, first.start() if first else 0),
+                line_number(source, first.start()),
                 "multiple named reentrancy locks found; 0.4.x uses a global lock",
             )
         )
@@ -897,10 +927,10 @@ def _nonreentrant(
             line_number(source, match.start()),
             "single named nonreentrant lock rewritten; review callback assumptions",
         )
-        for match in pattern.finditer(source)
+        for match in matches
     )
-
-    def repl(match: re.Match[str]) -> str:
+    edits: list[TextEdit] = []
+    for match in matches:
         fixes.append(
             Fix(
                 "VY090",
@@ -910,12 +940,16 @@ def _nonreentrant(
                 "@nonreentrant",
             )
         )
-        return "@nonreentrant"
+        edits.append(TextEdit(match.start(), match.end(), "@nonreentrant"))
 
-    current = pattern.sub(repl, source)
+    current = apply_edits(source, edits)
     current, internal_fixes = _remove_internal_nonreentrant(current)
     fixes.extend(internal_fixes)
-    if "@nonreentrant" not in current:
+    current_mask = code_mask(current)
+    if not any(
+        span_is_code(current_mask, match.start(), match.end())
+        for match in re.finditer(r"@nonreentrant\b", current)
+    ):
         current, gap_fixes = _insert_nonreentrant_storage_gaps(current, len(counts))
         fixes.extend(gap_fixes)
     return current, fixes, diagnostics
@@ -968,6 +1002,7 @@ def _storage_gap_insert_offset(source: str) -> int | None:
         if not type_name.startswith(("constant(", "immutable("))
     }
     lines = source.splitlines(keepends=True)
+    mask = code_mask(source)
     offsets: list[int] = []
     cursor = 0
     for line in lines:
@@ -975,14 +1010,22 @@ def _storage_gap_insert_offset(source: str) -> int | None:
         cursor += len(line)
     for index, line in enumerate(lines):
         stripped = line.strip()
-        if not stripped or line[:1].isspace():
+        if (
+            not stripped
+            or line[:1].isspace()
+            or not _line_match_starts_outside_string(source, mask, offsets[index])
+        ):
             continue
         match = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*:", stripped)
         if match and match.group(1) in storage_names:
             return offsets[index]
     for index, line in enumerate(lines):
         stripped = line.strip()
-        if not stripped or line[:1].isspace():
+        if (
+            not stripped
+            or line[:1].isspace()
+            or not _line_match_starts_outside_string(source, mask, offsets[index])
+        ):
             continue
         if stripped.startswith("@") or re.match(r"def\s+[A-Za-z_][A-Za-z0-9_]*\s*\(", stripped):
             return offsets[index]

--- a/src/vyupgrade/rule_groups/external_calls.py
+++ b/src/vyupgrade/rule_groups/external_calls.py
@@ -23,6 +23,7 @@ def ignored_external_call_results(
 ) -> tuple[str, list[Fix], list[Diagnostic]]:
     source = rule_context.source
     facts = rule_context.facts
+    mask = rule_context.code_mask
     taken_names = code_identifiers(source)
     edits: list[TextEdit] = []
     fixes: list[Fix] = []
@@ -41,6 +42,9 @@ def ignored_external_call_results(
             continue
         indent = code_part[: len(code_part) - len(code_part.lstrip(" \t"))]
         expr_start = offset + len(indent)
+        if not span_is_code(mask, expr_start, expr_start + len("staticcall")):
+            offset += len(raw_line)
+            continue
         keyword_match = re.match(r"(?:staticcall|extcall)\s+", source[expr_start:])
         if keyword_match is None:
             offset += len(raw_line)

--- a/src/vyupgrade/rule_groups/interfaces.py
+++ b/src/vyupgrade/rule_groups/interfaces.py
@@ -488,13 +488,17 @@ def _implemented_interface_methods(
 
 
 def _implemented_interface_names(source: str) -> set[str]:
+    mask = code_mask(source)
     names: set[str] = set()
     for match in re.finditer(r"^[ \t]*implements:[ \t]*(.+?)[ \t]*(?:#.*)?$", source, re.MULTILINE):
+        if not span_is_code(mask, match.start(1), match.end(1)):
+            continue
         names.update(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", match.group(1)))
     return names
 
 
 def _view_implementation_names(source: str) -> set[str]:
+    mask = code_mask(source)
     names = {
         match.group(1)
         for match in re.finditer(
@@ -502,9 +506,13 @@ def _view_implementation_names(source: str) -> set[str]:
             source,
             re.MULTILINE,
         )
+        if span_is_code(mask, match.start(1), match.end(1))
     }
     decorators: set[str] = set()
-    for line in source.splitlines():
+    offsets = _line_offsets(source)
+    for index, line in enumerate(source.splitlines(keepends=True)):
+        if not _line_match_starts_outside_string(source, mask, offsets[index]):
+            continue
         stripped = line.strip()
         decorator = re.fullmatch(r"@([A-Za-z_][A-Za-z0-9_]*)", stripped)
         if decorator is not None:
@@ -1159,6 +1167,7 @@ def _interface_default_function(
     source = rule_context.source
     lines = source.splitlines(keepends=True)
     offsets = _line_offsets(source)
+    mask = rule_context.code_mask
     interface_indent: int | None = None
     edits: list[TextEdit] = []
     fixes: list[Fix] = []
@@ -1168,6 +1177,9 @@ def _interface_default_function(
         line = lines[index]
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+        if not _line_match_starts_outside_string(source, mask, offsets[index]):
             index += 1
             continue
         indent = len(line) - len(line.lstrip(" \t"))

--- a/src/vyupgrade/rule_groups/legacy.py
+++ b/src/vyupgrade/rule_groups/legacy.py
@@ -1004,14 +1004,22 @@ def _rewrite_legacy_event_declarations(source: str) -> tuple[str, list[Fix]]:
 
 def _collect_event_fields(source: str) -> dict[str, list[str]]:
     events: dict[str, list[str]] = {}
-    lines = source.splitlines()
+    lines = source.splitlines(keepends=True)
+    mask = code_mask(source)
+    offsets: list[int] = []
+    cursor = 0
+    for line in lines:
+        offsets.append(cursor)
+        cursor += len(line)
     index = 0
     while index < len(lines):
         line = lines[index]
         match = re.match(
             r"^(?P<indent>\s*)event\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?:#.*)?$", line
         )
-        if match is None:
+        if match is None or not _line_match_starts_outside_string(
+            source, mask, offsets[index]
+        ):
             index += 1
             continue
         indent = len(match.group("indent"))
@@ -1026,7 +1034,9 @@ def _collect_event_fields(source: str) -> dict[str, list[str]]:
             if child_indent <= indent:
                 break
             field = re.match(r"^\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*:", child)
-            if field is not None:
+            if field is not None and _line_match_starts_outside_string(
+                source, mask, offsets[index]
+            ):
                 fields.append(field.group("name"))
             index += 1
         if fields:

--- a/src/vyupgrade/rule_groups/numeric_context_casts.py
+++ b/src/vyupgrade/rule_groups/numeric_context_casts.py
@@ -288,7 +288,11 @@ def _typed_external_call_arguments(
                 cursor += len(arg) + 1
                 continue
             vars_for_arg = _vars_for_argument(source, arg_start, arg, vars_for_line)
-            bytes_replacement = _dynamic_bytes_hex_arg_replacement(arg, expected)
+            bytes_replacement = (
+                _dynamic_bytes_hex_arg_replacement(arg, expected)
+                if rule_context.is_enabled("VY053")
+                else None
+            )
             if bytes_replacement is not None:
                 edits.append(TextEdit(arg_start, arg_start + len(arg), bytes_replacement))
                 fixes.append(
@@ -300,6 +304,9 @@ def _typed_external_call_arguments(
                         bytes_replacement,
                     )
                 )
+                cursor = arg_start + len(arg) + 1
+                continue
+            if not rule_context.is_enabled("VY052"):
                 cursor = arg_start + len(arg) + 1
                 continue
             replacement = cast_integer_arg_to_expected(arg, expected, vars_for_arg, facts)

--- a/src/vyupgrade/rule_groups/numeric_ranges.py
+++ b/src/vyupgrade/rule_groups/numeric_ranges.py
@@ -435,13 +435,16 @@ def _sentinel_range_bound(
         ):
             continue
         if not config.aggressive:
-            diagnostics.append(
-                Diagnostic(
-                    "VYD017",
-                    line_number(source, match.start()),
-                    "sentinel range break can be collapsed with bound=... under --aggressive",
+            if rule_context.is_enabled("VYD017"):
+                diagnostics.append(
+                    Diagnostic(
+                        "VYD017",
+                        line_number(source, match.start()),
+                        "sentinel range break can be collapsed with bound=... under --aggressive",
+                    )
                 )
-            )
+            continue
+        if not rule_context.is_enabled("VY071"):
             continue
         stop = _bounded_sentinel_stop(sentinel.stop, bound_arg, bound_value, constant_values)
         edits.append(TextEdit(match.end() + arg_start, match.end() + arg_end, stop))
@@ -621,13 +624,16 @@ def _range_bound(
             args[0], args[1], integer_constant_values(source, config.source_ast)
         )
         if bound is None:
-            diagnostics.append(
-                Diagnostic(
-                    "VYD011",
-                    line_number(source, match.start()),
-                    "range(start, stop) has runtime bounds; add bound=... manually",
+            if rule_context.is_enabled("VYD011"):
+                diagnostics.append(
+                    Diagnostic(
+                        "VYD011",
+                        line_number(source, match.start()),
+                        "range(start, stop) has runtime bounds; add bound=... manually",
+                    )
                 )
-            )
+            continue
+        if not rule_context.is_enabled("VY071"):
             continue
         vars_for_line = facts.vars_at_line(line_number(source, match.start()))
         for cast_edit, before, after in _range_stop_max_value_cast_edits(

--- a/src/vyupgrade/rule_groups/numeric_signedness.py
+++ b/src/vyupgrade/rule_groups/numeric_signedness.py
@@ -23,6 +23,7 @@ from ..source import (
     code_mask,
     find_matching,
     line_number,
+    line_starts_in_code,
     split_top_level_arg_spans,
     split_top_level_args,
     span_is_code,
@@ -45,10 +46,14 @@ def _mixed_signed_unsigned_arithmetic(
     config = rule_context.config
     facts = rule_context.facts
     constant_values = integer_constant_values(source, config.source_ast)
+    mask = rule_context.code_mask
     fixes: list[Fix] = []
     edits: list[TextEdit] = []
     offset = 0
     for raw_line in source.splitlines(keepends=True):
+        if not line_starts_in_code(source, mask, offset):
+            offset += len(raw_line)
+            continue
         line = raw_line.rstrip("\n")
         code_line = line.split("#", 1)[0]
         if not code_line.startswith((" ", "\t")) or not (

--- a/src/vyupgrade/rule_helpers.py
+++ b/src/vyupgrade/rule_helpers.py
@@ -5,18 +5,19 @@ from pathlib import Path
 
 from .analysis import SourceFacts, indexed_value_type
 from .models import Config, Fix
-from .source import TextEdit, apply_edits, code_mask, line_number, span_is_code
+from .source import (
+    TextEdit,
+    apply_edits,
+    code_mask,
+    line_number,
+    line_starts_in_code,
+    span_is_code,
+)
 from .versions import MigrationContext, VyperVersion
 
 
 def line_match_starts_outside_string(source: str, mask: list[bool], start: int) -> bool:
-    line_start = source.rfind("\n", 0, start) + 1
-    if line_start > 0 and not mask[line_start - 1]:
-        return False
-    first = line_start
-    while first < len(source) and source[first] in " \t":
-        first += 1
-    return span_is_code(mask, line_start, first)
+    return line_starts_in_code(source, mask, start)
 
 
 def pre_021_context(context: MigrationContext) -> bool:
@@ -137,16 +138,25 @@ def remove_constructor_decorators(
     add_deploy: bool = False,
 ) -> tuple[str, list[Fix], list[Fix]]:
     lines = source.splitlines(keepends=True)
+    mask = code_mask(source)
+    offsets = line_offsets(source)
     fixes: list[Fix] = []
     insertions: list[Fix] = []
     out = list(lines)
     offset = 0
     for index, line in enumerate(lines):
-        if not re.match(r"\s*def\s+__init__\s*\(", line):
+        if not re.match(r"\s*def\s+__init__\s*\(", line) or not line_starts_in_code(
+            source, mask, offsets[index]
+        ):
             continue
         start = index
-        while start > 0 and re.match(
-            r"\s*@[A-Za-z_][A-Za-z0-9_]*(?:\(.*\))?\s*(?:#.*)?$", lines[start - 1]
+        while (
+            start > 0
+            and re.match(
+                r"\s*@[A-Za-z_][A-Za-z0-9_]*(?:\(.*\))?\s*(?:#.*)?$",
+                lines[start - 1],
+            )
+            and line_starts_in_code(source, mask, offsets[start - 1])
         ):
             start -= 1
         decorators = [decor.strip() for decor in lines[start:index]]

--- a/src/vyupgrade/source.py
+++ b/src/vyupgrade/source.py
@@ -67,6 +67,17 @@ def span_is_code(mask: list[bool], start: int, end: int) -> bool:
     return start >= 0 and end <= len(mask) and all(mask[start:end])
 
 
+def line_starts_in_code(source: str, mask: list[bool], offset: int) -> bool:
+    """Return whether the line containing ``offset`` begins outside a string."""
+    line_start = source.rfind("\n", 0, offset) + 1
+    if line_start > 0 and not mask[line_start - 1]:
+        return False
+    first = line_start
+    while first < len(source) and source[first] in " \t":
+        first += 1
+    return span_is_code(mask, line_start, first)
+
+
 def code_identifiers(source: str) -> set[str]:
     mask = code_mask(source)
     return {

--- a/src/vyupgrade/versions.py
+++ b/src/vyupgrade/versions.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
+from .source import code_mask, line_starts_in_code
+
 
 PRAGMA_RE = re.compile(r"^\s*#\s*(?:@version|pragma\s+version)\s+(.+?)\s*$", re.MULTILINE)
 VERSION_RE = re.compile(r"0\.(?:1|2|3|4|5)\.\d+(?:(?:a|b|rc)\d+)?")
@@ -73,8 +75,11 @@ class MigrationContext:
 
 
 def infer_pragma(source: str) -> str | None:
-    match = PRAGMA_RE.search(source)
-    return match.group(1).strip() if match else None
+    mask = code_mask(source)
+    for match in PRAGMA_RE.finditer(source):
+        if line_starts_in_code(source, mask, match.start()):
+            return match.group(1).strip()
+    return None
 
 
 def parse_version(raw: str | None) -> VyperVersion | None:

--- a/tests/rule_groups/test_data_lifecycle.py
+++ b/tests/rule_groups/test_data_lifecycle.py
@@ -85,6 +85,32 @@ def read_flag() -> bool:
     assert any(fix.rule == "VY093" for fix in result.fixes)
 
 
+def test_reserved_flag_getter_ignores_documented_function_examples(config) -> None:
+    source = '''# @version 0.2.12
+"""
+@external
+def flag():
+    pass
+"""
+flag: public(bool)
+
+@external
+def set_flag():
+    self.flag = True
+'''
+    selected = config(source_version="0.2.12", select=frozenset({"VY093"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+    _before_doc, documented, migrated = first.source.split('"""', 2)
+
+    assert "@external\ndef flag():\n    pass" in documented
+    assert "def flag() -> bool:" not in documented
+    assert "_flag: bool" in migrated
+    assert "def flag() -> bool:" in migrated
+    assert second.source == first.source
+
+
 def test_unbounded_dynarray_int128_limit_is_capped(config) -> None:
     source = """# @version 0.3.6
 struct Pair:
@@ -452,6 +478,31 @@ def __init__(owner: address) -> bool:
     assert any(fix.rule == "VY002" and "return value" in fix.message for fix in result.fixes)
 
 
+def test_constructor_decorator_rewrite_ignores_docstrings(config) -> None:
+    source = '''# @version 0.3.10
+"""
+@external
+def __init__():
+    return documented_value
+"""
+
+@external
+def __init__():
+    pass
+'''
+    selected = config(source_version="0.3.10", select=frozenset({"VY002"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+
+    assert (
+        '"""\n@external\ndef __init__():\n    return documented_value\n"""'
+        in first.source
+    )
+    assert "@deploy\ndef __init__():" in first.source
+    assert second.source == first.source
+
+
 def test_pr_3769_single_named_reentrancy_lock_is_rewritten(config) -> None:
     source = """# @version 0.3.10
 @nonreentrant("lock")
@@ -464,6 +515,38 @@ def f():
 
     assert '@nonreentrant("lock")' not in result.source
     assert "@nonreentrant\n@external" in result.source
+
+
+def test_nonreentrant_rewrite_ignores_non_code_text(config) -> None:
+    source = '''# @version 0.3.10
+"""
+@internal
+@nonreentrant("docstring")
+def documented_example():
+    pass
+"""
+NOTE: constant(String[64]) = '@nonreentrant("literal")'
+# @nonreentrant("comment")
+
+@internal
+@nonreentrant("actual")
+def f():
+    pass
+'''
+    selected = config(source_version="0.3.10", select=frozenset({"VY090"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+
+    assert '@nonreentrant("docstring")' in first.source
+    assert '''NOTE: constant(String[64]) = '@nonreentrant("literal")' '''.strip() in first.source
+    assert '# @nonreentrant("comment")' in first.source
+    assert '@nonreentrant("actual")' not in first.source
+    assert "_vyupgrade_reentrancy_lock_slot: uint256" in first.source
+    assert first.source.index('"""\nNOTE:') < first.source.index(
+        "_vyupgrade_reentrancy_lock_slot"
+    )
+    assert second.source == first.source
 
 
 def test_named_reentrancy_lock_reserves_legacy_storage_slot(config) -> None:

--- a/tests/rule_groups/test_external_calls.py
+++ b/tests/rule_groups/test_external_calls.py
@@ -22,6 +22,32 @@ def set_delegation(delegation: address):
     assert any(fix.rule == "VY057" for fix in result.fixes)
 
 
+def test_ignored_external_call_results_ignore_non_code_text(config) -> None:
+    source = '''# @version 0.3.10
+interface Target:
+    def balanceOf(owner: address) -> uint256: view
+
+@external
+def f(target: address):
+    """
+    staticcall Target(target).balanceOf(self)
+    """
+    note: String[64] = "staticcall Target(target).balanceOf(self)"
+    # staticcall Target(target).balanceOf(self)
+    staticcall Target(target).balanceOf(self)
+'''
+    selected = config(source_version="0.3.10", select=frozenset({"VY057"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+
+    assert '"""\n    staticcall Target(target).balanceOf(self)\n    """' in first.source
+    assert 'note: String[64] = "staticcall Target(target).balanceOf(self)"' in first.source
+    assert "# staticcall Target(target).balanceOf(self)" in first.source
+    assert "__vyupgrade_discard_12: uint256 = staticcall Target(target).balanceOf(self)" in first.source
+    assert second.source == first.source
+
+
 def test_ignored_external_call_without_return_stays_statement(config) -> None:
     source = """# @version 0.3.10
 interface Token:

--- a/tests/rule_groups/test_interfaces.py
+++ b/tests/rule_groups/test_interfaces.py
@@ -65,6 +65,31 @@ interface PayableReceiver:
     assert any(fix.rule == "VY123" for fix in result.fixes)
 
 
+def test_interface_default_function_ignores_docstrings(config) -> None:
+    source = '''#pragma version ^0.3.0
+"""
+interface Documented:
+    def __default__(): payable
+"""
+# interface Commented:
+#     def __default__(): payable
+
+interface PayableReceiver:
+    def __default__(): payable
+    def ping() -> bool: view
+'''
+    selected = config(source_version="0.3.0", select=frozenset({"VY123"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+
+    assert 'interface Documented:\n    def __default__(): payable\n"""' in first.source
+    assert "#     def __default__(): payable" in first.source
+    assert "interface PayableReceiver:\n    def __default__(): payable" not in first.source
+    assert "    def ping() -> bool: view" in first.source
+    assert second.source == first.source
+
+
 def test_modern_erc_interface_imports(config) -> None:
     source = """# @version 0.3.10
 from vyper.interfaces import ERC4626, ERC721
@@ -76,6 +101,46 @@ asset: public(ERC4626)
 
     assert "from ethereum.ercs import IERC4626, IERC721" in result.source
     assert "asset: public(IERC4626)" in result.source
+
+
+def test_interface_imports_ignore_documented_implements_declarations(config) -> None:
+    source = '''# @version 0.3.10
+"""
+implements: ERC721
+"""
+from vyper.interfaces import ERC721
+
+token: ERC721
+'''
+    selected = config(source_version="0.3.10", select=frozenset({"VY020"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+
+    assert '"""\nimplements: ERC721\n"""' in first.source
+    assert "from ethereum.ercs import IERC721" in first.source
+    assert "token: IERC721" in first.source
+    assert "interface ERC721:" not in first.source
+    assert second.source == first.source
+
+
+def test_interface_view_mutability_ignores_documented_implementations(config) -> None:
+    source = '''# @version 0.3.10
+interface Target:
+    def value() -> uint256: nonpayable
+
+"""
+@view
+def value() -> uint256:
+    return 1
+"""
+'''
+    selected = config(source_version="0.3.10", select=frozenset({"VY014"}))
+
+    result = apply_rules(source, selected)
+
+    assert "def value() -> uint256: nonpayable" in result.source
+    assert not result.fixes
 
 
 def test_interface_storage_assignment_cast_matches_declared_type(config) -> None:

--- a/tests/rule_groups/test_legacy.py
+++ b/tests/rule_groups/test_legacy.py
@@ -66,6 +66,31 @@ def f(receiver: address, value: uint256):
     assert "log Transfer(sender=msg.sender, receiver=receiver, value=value)" in result.source
 
 
+def test_event_field_collection_ignores_docstrings(config) -> None:
+    source = '''# @version 0.3.10
+event Transfer:
+    sender: indexed(address)
+    receiver: indexed(address)
+
+@external
+def f(sender: address, receiver: address):
+    """
+    event Transfer:
+        receiver: indexed(address)
+        sender: indexed(address)
+    """
+    log Transfer(sender, receiver)
+'''
+    selected = config(source_version="0.3.10", select=frozenset({"VY112"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+
+    assert "log Transfer(sender=sender, receiver=receiver)" in first.source
+    assert "        receiver: indexed(address)\n        sender: indexed(address)" in first.source
+    assert second.source == first.source
+
+
 def test_timestamp_parameter_name_is_not_rewritten_as_type(config) -> None:
     source = """# @version 0.2.8
 @view

--- a/tests/rule_groups/test_numeric_constants.py
+++ b/tests/rule_groups/test_numeric_constants.py
@@ -179,6 +179,38 @@ def f(geyser: address):
     assert any(fix.rule == "VY053" for fix in result.fixes)
 
 
+def test_typed_external_call_argument_selection_isolated_by_code(config) -> None:
+    source = """# @version 0.3.10
+interface Target:
+    def f(value: uint256, data: Bytes[32]): nonpayable
+
+@external
+def g(target: address, value: int128):
+    Target(target).f(value, 0x00)
+"""
+
+    bytes_only = apply_rules(source, config(select=frozenset({"VY053"})))
+    integers_only = apply_rules(source, config(select=frozenset({"VY052"})))
+    without_bytes = apply_rules(source, config(ignore=frozenset({"VY053"})))
+    without_integers = apply_rules(source, config(ignore=frozenset({"VY052"})))
+
+    assert 'Target(target).f(value, b"\\x00")' in bytes_only.source
+    assert "convert(value, uint256)" not in bytes_only.source
+    assert "Target(target).f(convert(value, uint256), 0x00)" in integers_only.source
+    assert "convert(value, uint256)" in without_bytes.source
+    assert 'b"\\x00"' not in without_bytes.source
+    assert "convert(value, uint256)" not in without_integers.source
+    assert 'b"\\x00"' in without_integers.source
+    assert (
+        apply_rules(bytes_only.source, config(select=frozenset({"VY053"}))).source
+        == bytes_only.source
+    )
+    assert (
+        apply_rules(integers_only.source, config(select=frozenset({"VY052"}))).source
+        == integers_only.source
+    )
+
+
 def test_fixed_bytes_hex_literal_is_left_alone(config) -> None:
     source = """# @version 0.3.10
 value: bytes32 = 0x00

--- a/tests/rule_groups/test_numeric_ranges.py
+++ b/tests/rule_groups/test_numeric_ranges.py
@@ -16,6 +16,32 @@ def f(items: DynArray[address, 10]):
     assert "for item: address in items:" in result.source
 
 
+def test_nested_dynarray_loop_type_inference(config) -> None:
+    source = """# @version 0.3.10
+@external
+def f(items: DynArray[DynArray[uint256, 2], 3]):
+    for item in items:
+        pass
+"""
+
+    result = apply_rules(source, config())
+
+    assert "for item: DynArray[uint256, 2] in items:" in result.source
+
+
+def test_nested_static_array_loop_type_inference(config) -> None:
+    source = """# @version 0.3.10
+@external
+def f(items: uint256[2][3]):
+    for item in items:
+        pass
+"""
+
+    result = apply_rules(source, config())
+
+    assert "for item: uint256[2] in items:" in result.source
+
+
 def test_range_loop_uses_known_bound_integer_type(config) -> None:
     source = """# @version 0.3.10
 N_COINS: constant(int128) = 2
@@ -347,6 +373,27 @@ def f(start: uint256):
     assert "for i: uint256 in range" in result.source
 
 
+def test_range_bound_selection_does_not_leak_fix_edits(config) -> None:
+    source = """# @version 0.3.10
+@external
+def f(start: uint256):
+    for i in range(start, start + 101):
+        pass
+"""
+
+    selected_diagnostic = apply_rules(source, config(select=frozenset({"VYD011"})))
+    ignored_fix = apply_rules(source, config(ignore=frozenset({"VY071"})))
+    fix_only_config = config(
+        source_version="0.3.10", select=frozenset({"VY071"})
+    )
+    fix_only = apply_rules(source, fix_only_config)
+
+    assert selected_diagnostic.source == source
+    assert "bound=101" not in ignored_fix.source
+    assert not [fix for fix in ignored_fix.fixes if fix.rule == "VY071"]
+    assert apply_rules(fix_only.source, fix_only_config).source == fix_only.source
+
+
 def test_sentinel_break_range_warns_without_rewrite_by_default(config) -> None:
     source = """# @version 0.3.10
 MAX_POOLS: constant(uint256) = 2000
@@ -389,6 +436,34 @@ def f(pool_count: uint256) -> uint256:
     assert "if i == pool_count" not in result.source
     assert any(fix.rule == "VY071" for fix in result.fixes)
     assert not [diag for diag in result.diagnostics if diag.rule == "VYD017"]
+
+
+def test_sentinel_range_selection_does_not_leak_aggressive_edits(config) -> None:
+    source = """# @version 0.3.10
+MAX_POOLS: constant(uint256) = 2000
+
+@external
+def f(pool_count: uint256):
+    for i in range(MAX_POOLS):
+        if i == pool_count:
+            break
+        pass
+"""
+
+    selected_diagnostic = apply_rules(
+        source, config(select=frozenset({"VYD017"}), aggressive=True)
+    )
+    ignored_fix = apply_rules(source, config(ignore=frozenset({"VY071"}), aggressive=True))
+    fix_only_config = config(
+        source_version="0.3.10", select=frozenset({"VY071"}), aggressive=True
+    )
+    fix_only = apply_rules(source, fix_only_config)
+
+    assert selected_diagnostic.source == source
+    assert "if i == pool_count:" in ignored_fix.source
+    assert "bound=MAX_POOLS" not in ignored_fix.source
+    assert not [fix for fix in ignored_fix.fixes if fix.rule == "VY071"]
+    assert apply_rules(fix_only.source, fix_only_config).source == fix_only.source
 
 
 def test_sentinel_break_range_skips_min_when_constant_stop_is_within_bound(config) -> None:

--- a/tests/rule_groups/test_numeric_signedness.py
+++ b/tests/rule_groups/test_numeric_signedness.py
@@ -3,6 +3,28 @@ from __future__ import annotations
 from vyupgrade.rules import apply_rules
 
 
+def test_mixed_signedness_rewrite_ignores_docstrings(config) -> None:
+    source = '''# @version 0.3.10
+SIGNED: constant(int128) = 1
+
+@external
+def f():
+    """
+    documented: uint256 = SIGNED
+    """
+    actual: uint256 = SIGNED
+'''
+    selected = config(source_version="0.3.10", select=frozenset({"VY052"}))
+
+    first = apply_rules(source, selected)
+    second = apply_rules(first.source, selected)
+
+    assert "documented: uint256 = SIGNED" in first.source
+    assert "documented: uint256 = convert" not in first.source
+    assert "actual: uint256 = convert(SIGNED, uint256)" in first.source
+    assert second.source == first.source
+
+
 def test_signed_constant_converted_in_uint_arithmetic(config) -> None:
     source = """# @version 0.2.8
 N_COINS: constant(int128) = 3

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from vyupgrade.analysis import iterable_element_type
+
+
+@pytest.mark.parametrize(
+    ("type_name", "expected"),
+    [
+        ("DynArray[DynArray[uint256, 2], 3]", "DynArray[uint256, 2]"),
+        ("DynArray[uint256[2], 3]", "uint256[2]"),
+        ("uint256[2][3]", "uint256[2]"),
+        ("DynArray[uint256, 2][3]", "DynArray[uint256, 2]"),
+        ("(uint256, address)[3]", "(uint256, address)"),
+        ("Bytes[32]", None),
+        ("String[32]", None),
+        ("HashMap[address, uint256]", None),
+    ],
+)
+def test_iterable_element_type_balances_nested_types(
+    type_name: str, expected: str | None
+) -> None:
+    assert iterable_element_type(type_name) == expected

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -11,6 +11,7 @@ from vyupgrade.versions import (
     compiler_version_for_source_validation,
     compiler_version_for_spec,
     default_evm_version_for_spec,
+    infer_pragma,
     is_supported_source_version,
     known_versions_satisfying,
     minimum_satisfying_version,
@@ -59,6 +60,18 @@ def test_version_specs_pick_lowest_satisfying_source_floor() -> None:
     assert compiler_version_for_spec("~=0.4") == "0.4.0"
     assert compiler_version_for_spec("~=0.4.2") == "0.4.2"
     assert compiler_version_for_spec("==0.4.*") == "0.4.3"
+
+
+def test_infer_pragma_ignores_string_and_docstring_contents() -> None:
+    source = '''"""
+# @version 0.4.3
+"""
+VERSION: constant(String[32]) = "# pragma version 0.4.2"
+# @version 0.3.10
+'''
+
+    assert infer_pragma(source) == "0.3.10"
+    assert infer_pragma('''"""\n# @version 0.4.3\n"""\n''') is None
 
 
 def test_source_syntax_hints_raise_broad_pragma_compiler_floor() -> None:


### PR DESCRIPTION
## What

- make line-oriented rules ignore comments, strings, and docstrings consistently
- isolate edits emitted by multi-code rule descriptors so `--select` and `--ignore` cannot leak disabled fixes
- parse nested `DynArray` and static-array element types without truncating nested brackets
- add regressions for constructors, events, interfaces, nonreentrant locks, numeric signedness/ranges, external-call results, and pragma inference

## Why

Several rules used raw line or regex scans before applying compiler-backed validation. Non-code examples could therefore poison source facts or edits, including changing positional event arguments to the wrong named fields. Descriptor-level rule gating could also run a shared implementation while applying edits for a code the user had disabled.

## Impact

Rewrites are now confined to source code and remain idempotent. Rule-code selection controls both reporting and mutations. The change is intentionally limited to rule safety and parsing; compiler validation policy is handled separately.

## Checks

- `uv run --locked pytest` (507 passed)
- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py`
- `git diff --check`
