### PR TITLE
feat: enforce fail-closed migration validation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,8 +55,12 @@ The CLI flow is:
 6. `cli._verify_rewrites()` builds a temporary target overlay, compiles migrated
    sources under the target compiler, and compares ABI, method identifiers, and
    storage layout.
-7. The CLI writes diffs, in-place changes, human reports, and JSON reports only
-   after validation has completed.
+7. `validation.decide_run_validation()` turns compiler and artifact outcomes
+   into a typed, fail-closed write decision. Rule selection and diagnostic
+   version gating do not participate in this safety decision.
+8. The CLI writes in-place changes only when the validation decision passes or
+   every blocker has a matching explicit waiver; reports record the decision
+   either way.
 
 Important files:
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ satisfying compiler no newer than the requested target.
 For each file, `vyupgrade` compiles the original under its source compiler and
 the rewritten output under the target compiler, then compares the two
 artifacts. A migration is only written back when every file still compiles
-under the target. Differences in ABI, method identifiers, or storage layout are
-surfaced as diagnostics rather than silently accepted.
+under the target, the source validation succeeded, every required artifact is
+available, and ABI, method identifiers, and storage layout compare equal. This
+write decision is independent of diagnostic selection and rule version gating.
+Standalone `.vyi` inputs are target-compiled through a generated import harness.
 
 Compiler subprocesses run through the bundled `uv`, using
 `uv run --no-project --with vyper==<version>` so each side gets the exact
@@ -76,8 +78,15 @@ For `0.1.0b*` source compilers, `vyupgrade` runs the compiler through a
 `typed-ast` compatibility wrapper so the legacy compiler sees pre-Python-3.8
 AST node classes without requiring a local Python 3.6 or 3.7 interpreter. When
 an old compiler cannot produce a modern validation output format, that format is
-dropped for source validation instead of blocking a compile check that the
-compiler never supported.
+dropped and reported as unavailable. Writes then remain blocked unless the
+source-validation gap is explicitly accepted with `--allow-unvalidated-source`.
+Target compilers must produce every requested validation output.
+
+The target compiler receives the exact migrated source bytes. Historical
+normalization is limited to copied dependencies in the temporary validation
+overlay and is not applied to files that would be written.
+Optional `--format mamushi` output is still produced after this validation and
+is not recompiled; post-format validation remains separate follow-up work.
 
 Dependency inference is intentionally conservative. Exact requirements,
 ordinary version ranges, and Git dependencies are supported. Project-specific
@@ -90,7 +99,7 @@ Poetry caret requirements, are skipped; use `--compiler-search-paths`,
 - `--target-version` — target Vyper version or spec (default `0.4.3`).
 - `--source-version` — override the per-file inferred source version.
 - `--diff` — print a unified diff instead of the report.
-- `--write` — apply changes in place (only when every file compiles).
+- `--write` — apply changes in place only after the validation decision passes.
 - `--check` — exit non-zero if any file would change; write nothing.
 - `--aggressive` — enable rewrites that change behavior or are not provably safe (e.g. `enum` → `flag`).
 - `--split-interfaces` — move top-level `interface` blocks into sibling `.vyi` files and import them.
@@ -102,6 +111,10 @@ Poetry caret requirements, are skipped; use `--compiler-search-paths`,
 - `--source-vyper` / `--target-vyper` — pin the exact compiler version for each side.
 - `--source-python` / `--target-python` — pin the Python interpreter for each compiler subprocess.
 - `--compiler-search-paths` — extra import search paths for the compiler.
+- `--allow-unvalidated-source` — write despite a failed source compile or unavailable source artifacts.
+- `--allow-abi-change` — write despite an ABI comparison mismatch.
+- `--allow-method-id-change` — write despite a method-identifier comparison mismatch.
+- `--allow-storage-layout-change` — write despite a storage-layout comparison mismatch.
 - `--config PATH` — read configuration from a specific `pyproject.toml`.
 
 ### Configuration
@@ -118,16 +131,22 @@ report-json = "vyupgrade-report.json"
 aggressive = false
 split-interfaces = false
 format = "none"
+allow-unvalidated-source = false
+allow-abi-change = false
+allow-method-id-change = false
+allow-storage-layout-change = false
 ```
 
 ### Exit codes
 
 - `0` — success.
 - `1` — `--check` found files that would change.
-- `2` — a file failed to compile under the target compiler.
-- `3` — a file failed to compile under the source compiler.
+- `2` — target compilation or required target artifacts failed validation.
+- `3` — source compilation or source artifact availability failed validation.
 - `4` — usage error (no paths, or conflicting flags).
 - `5` — an error-severity diagnostic was raised.
+- `6` — the requested formatter failed.
+- `7` — an unwaived ABI, method-identifier, or storage-layout mismatch blocked the write.
 
 ## Coverage
 

--- a/src/vyupgrade/cli.py
+++ b/src/vyupgrade/cli.py
@@ -18,6 +18,7 @@ from .compiler import (
     compile_source_file,
     compile_target_source,
     target_overlay,
+    unavailable_validation_artifacts,
 )
 from .interfaces import split_interfaces_to_vyi
 from .models import Config, Diagnostic, FileReport, RewriteResult, RunReport
@@ -25,6 +26,7 @@ from .project import discover_files
 from .reporting import HumanReporter, write_json_report
 from .rule_registry import is_enabled
 from .rules import RULE_CHANGES, apply_rules
+from .validation import decide_run_validation, validation_exit_code
 from .versions import (
     MigrationContext,
     compiler_version_for_source_validation,
@@ -79,6 +81,14 @@ def main(argv: list[str] | None = None) -> int:
         enable_decimals=args.enable_decimals,
         split_interfaces=args.split_interfaces or bool(pyproject.get("split-interfaces", False)),
         format=args.format or pyproject.get("format", "none"),
+        allow_unvalidated_source=args.allow_unvalidated_source
+        or bool(pyproject.get("allow-unvalidated-source", False)),
+        allow_abi_change=args.allow_abi_change
+        or bool(pyproject.get("allow-abi-change", False)),
+        allow_method_id_change=args.allow_method_id_change
+        or bool(pyproject.get("allow-method-id-change", False)),
+        allow_storage_layout_change=args.allow_storage_layout_change
+        or bool(pyproject.get("allow-storage-layout-change", False)),
     )
 
     if config.write and config.check:
@@ -89,16 +99,15 @@ def main(argv: list[str] | None = None) -> int:
     reports: list[FileReport] = []
     diff_chunks: list[str] = []
     write_back: list[tuple[Path, str]] = []
-    any_target_failed = False
-    any_source_failed = False
     human_reporter = None if config.diff else HumanReporter(sys.stdout)
     if human_reporter:
         human_reporter.start(config.source_version, config.target_version)
 
     rewrites = _prepare_rewrites(files, config)
-    any_source_failed = any(work.source_compile.status == "failed" for work in rewrites)
-
-    any_target_failed = _verify_rewrites(rewrites, config)
+    _verify_rewrites(rewrites, config)
+    validation_decision = decide_run_validation(
+        (work.report for work in rewrites), config
+    )
 
     for work in rewrites:
         if work.report.changed:
@@ -132,14 +141,15 @@ def main(argv: list[str] | None = None) -> int:
         target_version=config.target_version,
         files=reports,
         write_requested=config.write,
-        wrote_changes=config.write and not any_target_failed,
+        wrote_changes=config.write and validation_decision.write_allowed,
+        validation_decision=validation_decision,
         test_command=config.test_command,
     )
 
     if config.diff and diff_chunks:
         _write_diff(diff_chunks, sys.stdout)
 
-    if config.write and not any_target_failed:
+    if config.write and validation_decision.write_allowed:
         for path, content in write_back:
             path.write_text(content, encoding="utf-8")
         if config.format == "mamushi" and write_back:
@@ -147,7 +157,12 @@ def main(argv: list[str] | None = None) -> int:
 
     formatter_failed = run_report.formatter_status == "failed"
 
-    if config.test_command and config.write and not any_target_failed and not formatter_failed:
+    if (
+        config.test_command
+        and config.write
+        and validation_decision.write_allowed
+        and not formatter_failed
+    ):
         proc = subprocess.run(
             config.test_command, shell=True, capture_output=True, text=True, timeout=600
         )
@@ -160,12 +175,10 @@ def main(argv: list[str] | None = None) -> int:
     if human_reporter:
         human_reporter.summary(run_report)
 
-    if any_target_failed:
-        return 2
+    if (exit_code := validation_exit_code(validation_decision)) is not None:
+        return exit_code
     if formatter_failed:
         return 6
-    if any_source_failed:
-        return 3
     if config.check and any(file.changed for file in reports):
         return 1
     if any(diag.severity == "error" for file in reports for diag in file.diagnostics):
@@ -230,6 +243,11 @@ def _prepare_rewrites(files: list[Path], config: Config) -> list[RewriteWork]:
             source_compiler=source_compiler,
         )
         file_report.source_compile = source_compile.status
+        if source_compile.status != "skipped":
+            file_report.source_unavailable_artifacts = unavailable_validation_artifacts(
+                source_compile
+            )
+        file_report.source_unavailable_formats = list(source_compile.unavailable_formats)
         file_report.source_error = (
             source_compile.stderr if source_compile.status == "failed" else None
         )
@@ -247,8 +265,7 @@ def _prepare_rewrites(files: list[Path], config: Config) -> list[RewriteWork]:
     return rewrites
 
 
-def _verify_rewrites(rewrites: list[RewriteWork], config: Config) -> bool:
-    any_target_failed = False
+def _verify_rewrites(rewrites: list[RewriteWork], config: Config) -> None:
     target_sources = {work.path: work.rewrite.source for work in rewrites}
     for work in rewrites:
         target_sources.update(
@@ -263,11 +280,13 @@ def _verify_rewrites(rewrites: list[RewriteWork], config: Config) -> bool:
                 continue
             target_compile = compile_target_source(work.path, work.rewrite.source, config, overlay)
             work.report.target_compile = target_compile.status
+            work.report.target_unavailable_artifacts = unavailable_validation_artifacts(
+                target_compile
+            )
+            work.report.target_unavailable_formats = list(target_compile.unavailable_formats)
             work.report.target_error = (
                 target_compile.stderr if target_compile.status == "failed" else None
             )
-            any_target_failed = any_target_failed or target_compile.status == "failed"
-
             abi_equal, method_ids_equal, storage_layout_equal = compare_artifacts(
                 work.source_compile, target_compile
             )
@@ -284,7 +303,6 @@ def _verify_rewrites(rewrites: list[RewriteWork], config: Config) -> bool:
             _add_validation_diagnostics(
                 work.report, work.source_version, config, work.source_compiler
             )
-    return any_target_failed
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -308,6 +326,10 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--enable-decimals", action="store_true")
     parser.add_argument("--split-interfaces", "--interfaces-to-vyi", action="store_true")
     parser.add_argument("--format", choices=["none", "mamushi"])
+    parser.add_argument("--allow-unvalidated-source", action="store_true")
+    parser.add_argument("--allow-abi-change", action="store_true")
+    parser.add_argument("--allow-method-id-change", action="store_true")
+    parser.add_argument("--allow-storage-layout-change", action="store_true")
     parser.add_argument("--config", help="path to a pyproject.toml file")
     return parser
 

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -60,6 +60,7 @@ class CompileResult:
     artifacts: dict[str, object] | None = None
     stderr: str | None = None
     command: list[str] | None = None
+    unavailable_formats: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -68,6 +69,96 @@ class TargetOverlay:
     paths: Mapping[Path, Path]
     source_roots: tuple[Path, ...]
     search_paths: tuple[Path, ...]
+
+
+def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
+    artifacts = result.artifacts or {}
+    validators: dict[str, Callable[[object], bool]] = {
+        "abi": _valid_abi_artifact,
+        "method_identifiers": _valid_method_identifiers_artifact,
+        "layout": _valid_layout_artifact,
+    }
+    return [
+        name
+        for name, validator in validators.items()
+        if not validator(artifacts.get(name))
+    ]
+
+
+def _valid_abi_artifact(value: object) -> bool:
+    if not isinstance(value, list):
+        return False
+    return all(_valid_abi_entry(entry) for entry in value)
+
+
+def _valid_abi_entry(value: object) -> bool:
+    if not isinstance(value, dict) or not _nonempty_string(value.get("type")):
+        return False
+    if "name" in value and not isinstance(value["name"], str):
+        return False
+    for field in ("inputs", "outputs"):
+        if field in value and not _valid_abi_parameters(value[field]):
+            return False
+    return True
+
+
+def _valid_abi_parameters(value: object) -> bool:
+    if not isinstance(value, list):
+        return False
+    for parameter in value:
+        if not isinstance(parameter, dict) or not _nonempty_string(parameter.get("type")):
+            return False
+        if "name" in parameter and not isinstance(parameter["name"], str):
+            return False
+        if "components" in parameter and not _valid_abi_parameters(parameter["components"]):
+            return False
+    return True
+
+
+def _valid_method_identifiers_artifact(value: object) -> bool:
+    return isinstance(value, dict) and all(
+        _nonempty_string(signature) and _nonempty_string(selector)
+        for signature, selector in value.items()
+    )
+
+
+def _valid_layout_artifact(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if "storage_layout" in value:
+        storage = value["storage_layout"]
+        transient = value.get("transient_storage_layout", {})
+        return _valid_storage_entries(storage) and _valid_storage_entries(transient)
+    return _valid_storage_entries(value)
+
+
+def _valid_storage_entries(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return all(
+        isinstance(name, str)
+        and isinstance(entry, dict)
+        and _valid_storage_slot(entry.get("slot"))
+        and _nonempty_string(entry.get("type"))
+        for name, entry in value.items()
+    )
+
+
+def _valid_storage_slot(value: object) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value >= 0
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        return int(value, 0) >= 0
+    except ValueError:
+        return False
+
+
+def _nonempty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
 
 
 def compile_source_file(path: Path, config: Config, source_version: str | None) -> CompileResult:
@@ -85,6 +176,7 @@ def compile_source_file(path: Path, config: Config, source_version: str | None) 
         SOURCE_FORMATS,
         (),
         suppress_warnings,
+        allow_unsupported_formats=True,
     )
     if _should_retry_source_with_final_newline(path, result):
         return _compile_source_file_with_final_newline(command, path, config, suppress_warnings)
@@ -118,6 +210,7 @@ def _compile_source_file_with_final_newline(
             SOURCE_FORMATS,
             (),
             suppress_warnings,
+            allow_unsupported_formats=True,
         )
     finally:
         with suppress(OSError):
@@ -138,24 +231,30 @@ def _should_retry_source_with_final_newline(path: Path, result: CompileResult) -
 def compile_target_source(
     path: Path, source: str, config: Config, overlay: TargetOverlay | None = None
 ) -> CompileResult:
-    if path.suffix != ".vy":
+    if path.suffix not in {".vy", ".vyi"}:
         return CompileResult("skipped")
-    compile_source = _target_validation_source(
-        source, config.target_version, is_interface=path.suffix == ".vyi"
-    )
     if overlay is not None:
         tmp_path = overlay.paths.get(path.resolve())
         if tmp_path is not None:
             command, suppress_warnings = _prepare_command(
                 config.target_vyper, config.target_version, config.target_python
             )
-            compile_config = _target_compile_config(compile_source, config)
+            compile_config = _target_compile_config(source, config)
             compile_config = replace(
                 compile_config,
                 compiler_search_paths=_overlay_search_paths(
                     overlay, compile_config.compiler_search_paths
                 ),
             )
+            if path.suffix == ".vyi":
+                return _compile_target_interface(
+                    command,
+                    tmp_path,
+                    source,
+                    compile_config,
+                    (),
+                    suppress_warnings,
+                )
             return _run_compile(
                 command,
                 tmp_path,
@@ -163,6 +262,19 @@ def compile_target_source(
                 extra_paths=(),
                 suppress_warnings=suppress_warnings,
             )
+    command, suppress_warnings = _prepare_command(
+        config.target_vyper, config.target_version, config.target_python
+    )
+    compile_config = _target_compile_config(source, config)
+    if path.suffix == ".vyi":
+        return _compile_target_interface(
+            command,
+            path,
+            source,
+            compile_config,
+            (path.parent,),
+            suppress_warnings,
+        )
     try:
         tmp = tempfile.NamedTemporaryFile(
             "w",
@@ -181,13 +293,9 @@ def compile_target_source(
             delete=False,
         )
     with tmp:
-        tmp.write(compile_source)
+        tmp.write(source)
         tmp_path = Path(tmp.name)
     try:
-        command, suppress_warnings = _prepare_command(
-            config.target_vyper, config.target_version, config.target_python
-        )
-        compile_config = _target_compile_config(compile_source, config)
         return _run_compile(
             command,
             tmp_path,
@@ -197,6 +305,64 @@ def compile_target_source(
         )
     finally:
         tmp_path.unlink(missing_ok=True)
+
+
+def _compile_target_interface(
+    command: list[str],
+    path: Path,
+    source: str,
+    config: Config,
+    extra_paths: tuple[Path, ...],
+    suppress_warnings: bool,
+) -> CompileResult:
+    try:
+        interface_file = tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            prefix="vyupgrade_interface_",
+            suffix=".vyi",
+            dir=path.parent,
+            delete=False,
+        )
+    except OSError as exc:
+        return CompileResult(
+            "failed", stderr=f"could not stage interface for target validation: {exc}"
+        )
+    interface_path = Path(interface_file.name)
+    harness_path: Path | None = None
+    try:
+        with interface_file:
+            interface_file.write(source)
+        harness_file = tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            prefix="vyupgrade_interface_harness_",
+            suffix=".vy",
+            dir=path.parent,
+            delete=False,
+        )
+        harness_path = Path(harness_file.name)
+        with harness_file:
+            harness_file.write(
+                f"#pragma version {config.target_version}\n"
+                f"import {interface_path.stem} as InterfaceUnderTest\n"
+            )
+        interface_command = _with_project_import_dependencies(command, interface_path)
+        return _run_compile(
+            interface_command,
+            harness_path,
+            config,
+            extra_paths=tuple(dict.fromkeys((path.parent, *extra_paths))),
+            suppress_warnings=suppress_warnings,
+        )
+    except OSError as exc:
+        return CompileResult(
+            "failed", stderr=f"could not create interface validation harness: {exc}"
+        )
+    finally:
+        interface_path.unlink(missing_ok=True)
+        if harness_path is not None:
+            harness_path.unlink(missing_ok=True)
 
 
 @contextmanager
@@ -243,15 +409,7 @@ def target_overlay(
                 continue
             target = root / relative
             target.parent.mkdir(parents=True, exist_ok=True)
-            validation_source = _standard_json_package_dependency_source(path, source, common)
-            target.write_text(
-                _target_validation_source(
-                    validation_source,
-                    target_version,
-                    is_interface=path.suffix == ".vyi",
-                ),
-                encoding="utf-8",
-            )
+            target.write_text(source, encoding="utf-8")
             paths[path] = target
             overlay_search_paths.add(target.parent)
         _copy_project_configs(common, root)
@@ -583,6 +741,7 @@ def compile_source_ast(path: Path, config: Config, source_version: str | None) -
         ("ast",),
         (),
         suppress_warnings,
+        allow_unsupported_formats=True,
     )
 
 
@@ -1310,6 +1469,9 @@ def _run_compile_with_formats(
     formats: tuple[str, ...],
     extra_paths: tuple[Path, ...],
     suppress_warnings: bool,
+    *,
+    allow_unsupported_formats: bool = False,
+    unavailable_formats: tuple[str, ...] = (),
 ) -> CompileResult:
     full = [*_with_project_import_dependencies(command, path), "-f", ",".join(formats)]
     if _supports_search_paths(command):
@@ -1338,32 +1500,90 @@ def _run_compile_with_formats(
         stderr = proc.stderr.strip() or proc.stdout.strip()
         unsupported = _unsupported_output_format(stderr, formats)
         if unsupported is not None:
+            unavailable = tuple(dict.fromkeys((*unavailable_formats, unsupported)))
+            if not allow_unsupported_formats:
+                return CompileResult(
+                    "failed",
+                    stderr=f"target compiler did not support required output format '{unsupported}': {stderr}",
+                    command=full,
+                    unavailable_formats=unavailable,
+                )
             fallback_formats = tuple(name for name in formats if name != unsupported)
+            if not fallback_formats:
+                return CompileResult(
+                    "failed",
+                    stderr="source compiler did not support any requested output formats",
+                    command=full,
+                    unavailable_formats=unavailable,
+                )
             return _run_compile_with_formats(
-                command, path, config, fallback_formats, extra_paths, suppress_warnings
+                command,
+                path,
+                config,
+                fallback_formats,
+                extra_paths,
+                suppress_warnings,
+                allow_unsupported_formats=True,
+                unavailable_formats=unavailable,
             )
-        span_error_format = _legacy_span_error_format(stderr, formats)
+        span_error_format = (
+            _legacy_span_error_format(stderr, formats) if allow_unsupported_formats else None
+        )
         if span_error_format is not None:
+            unavailable = tuple(
+                dict.fromkeys((*unavailable_formats, span_error_format))
+            )
             fallback_formats = tuple(name for name in formats if name != span_error_format)
+            if not fallback_formats:
+                return CompileResult(
+                    "failed",
+                    stderr="source compiler could not produce any requested output formats",
+                    command=full,
+                    unavailable_formats=unavailable,
+                )
             return _run_compile_with_formats(
-                command, path, config, fallback_formats, extra_paths, suppress_warnings
+                command,
+                path,
+                config,
+                fallback_formats,
+                extra_paths,
+                suppress_warnings,
+                allow_unsupported_formats=True,
+                unavailable_formats=unavailable,
             )
         retry_command = _command_with_missing_module_dependency(command, path, stderr)
         if retry_command is not None:
             return _run_compile_with_formats(
-                retry_command, path, config, formats, extra_paths, suppress_warnings
+                retry_command,
+                path,
+                config,
+                formats,
+                extra_paths,
+                suppress_warnings,
+                allow_unsupported_formats=allow_unsupported_formats,
+                unavailable_formats=unavailable_formats,
             )
         return CompileResult(
-            "failed", stderr=proc.stderr.strip() or proc.stdout.strip(), command=full
+            "failed",
+            stderr=proc.stderr.strip() or proc.stdout.strip(),
+            command=full,
+            unavailable_formats=unavailable_formats,
         )
     try:
         artifacts = _parse_outputs(proc.stdout, formats)
-    except json.JSONDecodeError as exc:
+    except ValueError as exc:
         return CompileResult(
-            "failed", stderr=f"could not parse compiler output: {exc}", command=full
+            "failed",
+            stderr=f"could not parse compiler output: {exc}",
+            command=full,
+            unavailable_formats=unavailable_formats,
         )
     return CompileResult(
-        "passed", artifacts=artifacts, stderr=proc.stderr.strip() or None, command=full
+        "degraded" if unavailable_formats else "passed",
+        artifacts=artifacts,
+        stderr=proc.stderr.strip() or None,
+        command=full,
+        unavailable_formats=unavailable_formats,
     )
 
 
@@ -1589,7 +1809,11 @@ def _package_with_version(name: str, version: str) -> str | None:
 
 def _parse_outputs(stdout: str, formats: tuple[str, ...] = FORMATS) -> dict[str, object]:
     chunks = [line for line in stdout.splitlines() if line.strip()]
+    if len(chunks) != len(formats):
+        raise ValueError(
+            f"expected {len(formats)} compiler outputs, received {len(chunks)}"
+        )
     artifacts: dict[str, object] = {}
-    for name, raw in zip(formats, chunks, strict=False):
+    for name, raw in zip(formats, chunks, strict=True):
         artifacts[name] = json.loads(raw)
     return artifacts

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -6,6 +6,17 @@ from typing import Any, Literal
 
 
 Severity = Literal["info", "warning", "error"]
+ValidationDecisionStatus = Literal["not-required", "passed", "waived", "blocked"]
+ValidationIssueCode = Literal[
+    "target_compile_failed",
+    "target_artifacts_unavailable",
+    "source_compile_failed",
+    "source_artifacts_unavailable",
+    "artifact_comparison_unavailable",
+    "abi_changed",
+    "method_identifiers_changed",
+    "storage_layout_changed",
+]
 
 
 @dataclass(frozen=True)
@@ -40,6 +51,38 @@ class RewriteResult:
     generated_files: list[GeneratedFile] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class ValidationIssue:
+    code: ValidationIssueCode
+    message: str
+    path: Path
+    waiver: str | None = None
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "path": str(self.path),
+            "waiver": self.waiver,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationDecision:
+    status: ValidationDecisionStatus = "not-required"
+    write_allowed: bool = True
+    blockers: tuple[ValidationIssue, ...] = ()
+    waivers: tuple[ValidationIssue, ...] = ()
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "write_allowed": self.write_allowed,
+            "blockers": [issue.to_json_obj() for issue in self.blockers],
+            "waivers": [issue.to_json_obj() for issue in self.waivers],
+        }
+
+
 @dataclass
 class FileReport:
     path: Path
@@ -58,6 +101,11 @@ class FileReport:
     abi_diff: list[str] = field(default_factory=list)
     method_id_diff: list[str] = field(default_factory=list)
     storage_layout_diff: list[str] = field(default_factory=list)
+    source_unavailable_artifacts: list[str] = field(default_factory=list)
+    target_unavailable_artifacts: list[str] = field(default_factory=list)
+    source_unavailable_formats: list[str] = field(default_factory=list)
+    target_unavailable_formats: list[str] = field(default_factory=list)
+    validation_decision: ValidationDecision = field(default_factory=ValidationDecision)
 
 
 @dataclass(frozen=True)
@@ -81,6 +129,10 @@ class Config:
     enable_decimals: bool = False
     split_interfaces: bool = False
     format: str = "none"
+    allow_unvalidated_source: bool = False
+    allow_abi_change: bool = False
+    allow_method_id_change: bool = False
+    allow_storage_layout_change: bool = False
     source_ast: dict[str, Any] | None = None
 
 
@@ -91,6 +143,7 @@ class RunReport:
     files: list[FileReport]
     write_requested: bool = False
     wrote_changes: bool = False
+    validation_decision: ValidationDecision = field(default_factory=ValidationDecision)
     formatter_command: str | None = None
     formatter_status: str = "skipped"
     formatter_output: str | None = None
@@ -116,6 +169,7 @@ class RunReport:
             "target_version": self.target_version,
             "write_requested": self.write_requested,
             "wrote_changes": self.wrote_changes,
+            "validation_decision": self.validation_decision.to_json_obj(),
             "files": [
                 {
                     "path": str(file.path),
@@ -133,6 +187,11 @@ class RunReport:
                         "abi_diff": file.abi_diff,
                         "method_id_diff": file.method_id_diff,
                         "storage_layout_diff": file.storage_layout_diff,
+                        "source_unavailable_artifacts": file.source_unavailable_artifacts,
+                        "target_unavailable_artifacts": file.target_unavailable_artifacts,
+                        "source_unavailable_formats": file.source_unavailable_formats,
+                        "target_unavailable_formats": file.target_unavailable_formats,
+                        "decision": file.validation_decision.to_json_obj(),
                     },
                     "source_error": file.source_error,
                     "target_error": file.target_error,

--- a/src/vyupgrade/reporting.py
+++ b/src/vyupgrade/reporting.py
@@ -131,10 +131,26 @@ def _render_text_file(file: FileReport) -> str:
         if status == "failed" and error:
             lines.append(f"  {error_label}:")
             lines.extend(f"    {line}" for line in error.splitlines())
+    if file.source_unavailable_formats:
+        lines.append(
+            "  source unavailable outputs: " + ", ".join(file.source_unavailable_formats)
+        )
+    if file.target_unavailable_formats:
+        lines.append(
+            "  target unavailable outputs: " + ", ".join(file.target_unavailable_formats)
+        )
     for label, equal, diff in _artifact_checks(file):
         if equal is not None:
             lines.append(f"  {label}: {equal}")
             lines.extend(f"    {line}" for line in diff)
+    lines.append(f"  validation decision: {file.validation_decision.status}")
+    lines.extend(
+        f"  validation blocker: {issue.message}" for issue in file.validation_decision.blockers
+    )
+    lines.extend(
+        f"  validation waiver: {issue.waiver} ({issue.message})"
+        for issue in file.validation_decision.waivers
+    )
     return "\n".join(lines) + "\n"
 
 
@@ -143,7 +159,13 @@ def _render_text_summary(report: RunReport) -> str:
         "",
         *(f"{verb} {count} {label}" for verb, count, label in _summary_items(report)),
         f"left {report.diagnostic_count} review diagnostics",
+        f"write validation: {report.validation_decision.status}",
     ]
+    waiver_flags = sorted(
+        {issue.waiver for issue in report.validation_decision.waivers if issue.waiver}
+    )
+    if waiver_flags:
+        lines.append(f"validation waivers: {', '.join(waiver_flags)}")
     if not report.write_requested and report.changed_count:
         lines.append("run with --write to apply these changes")
     if report.formatter_command:
@@ -169,6 +191,18 @@ def _render_summary(console: Console, report: RunReport) -> None:
             _count_style(report.diagnostic_count),
         )
     )
+    console.print(
+        _label_value(
+            "write validation",
+            report.validation_decision.status,
+            _status_style(report.validation_decision.status),
+        )
+    )
+    waiver_flags = sorted(
+        {issue.waiver for issue in report.validation_decision.waivers if issue.waiver}
+    )
+    if waiver_flags:
+        console.print(_label_value("validation waivers", ", ".join(waiver_flags), "vy.warning"))
     if not report.write_requested and report.changed_count:
         console.print(Text("run with --write to apply these changes", style="vy.muted"))
     if report.formatter_command:
@@ -200,10 +234,39 @@ def _render_file(console: Console, file: FileReport) -> None:
             console.print(_indented(f"{error_label}:", "vy.error"))
             for line in error.splitlines():
                 console.print(_indented(f"  {line}", "vy.error"))
+    if file.source_unavailable_formats:
+        console.print(
+            _indented(
+                "source unavailable outputs: " + ", ".join(file.source_unavailable_formats),
+                "vy.warning",
+            )
+        )
+    if file.target_unavailable_formats:
+        console.print(
+            _indented(
+                "target unavailable outputs: " + ", ".join(file.target_unavailable_formats),
+                "vy.error",
+            )
+        )
     for label, equal, diff in _artifact_checks(file):
         if equal is not None:
             console.print(_bool_line(label, equal))
             _render_detail_lines(console, diff)
+    console.print(
+        _label_value(
+            "  validation decision",
+            file.validation_decision.status,
+            _status_style(file.validation_decision.status),
+        )
+    )
+    for issue in file.validation_decision.blockers:
+        console.print(_indented(f"validation blocker: {issue.message}", "vy.error"))
+    for issue in file.validation_decision.waivers:
+        console.print(
+            _indented(
+                f"validation waiver: {issue.waiver} ({issue.message})", "vy.warning"
+            )
+        )
 
 
 def _compile_outputs(file: FileReport) -> tuple[tuple[str, str, str, str | None], ...]:
@@ -311,6 +374,10 @@ def _count_style(count: int) -> str:
 def _status_style(status: str) -> str:
     return {
         "passed": "vy.success",
+        "waived": "vy.warning",
+        "blocked": "vy.error",
+        "not-required": "vy.muted",
+        "degraded": "vy.warning",
         "failed": "vy.error",
         "skipped": "vy.muted",
     }.get(status, "vy.warning")

--- a/src/vyupgrade/validation.py
+++ b/src/vyupgrade/validation.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .models import (
+    Config,
+    FileReport,
+    ValidationDecision,
+    ValidationIssue,
+    ValidationIssueCode,
+)
+
+
+def decide_run_validation(
+    reports: Iterable[FileReport], config: Config
+) -> ValidationDecision:
+    decisions: list[ValidationDecision] = []
+    for report in reports:
+        decision = decide_file_validation(report, config)
+        report.validation_decision = decision
+        decisions.append(decision)
+
+    blockers = tuple(issue for decision in decisions for issue in decision.blockers)
+    waivers = tuple(issue for decision in decisions for issue in decision.waivers)
+    if blockers:
+        return ValidationDecision("blocked", False, blockers, waivers)
+    if waivers:
+        return ValidationDecision("waived", True, (), waivers)
+    if any(decision.status != "not-required" for decision in decisions):
+        return ValidationDecision("passed", True)
+    return ValidationDecision()
+
+
+def decide_file_validation(report: FileReport, config: Config) -> ValidationDecision:
+    if report.source_compile == "skipped" and report.target_compile == "skipped":
+        return ValidationDecision()
+
+    blockers: list[ValidationIssue] = []
+    waivers: list[ValidationIssue] = []
+
+    def require(
+        code: ValidationIssueCode,
+        message: str,
+        *,
+        allowed: bool = False,
+        waiver: str | None = None,
+    ) -> None:
+        issue = ValidationIssue(code, message, report.path, waiver if allowed else None)
+        (waivers if allowed else blockers).append(issue)
+
+    if report.target_compile != "passed":
+        require("target_compile_failed", "target compilation did not pass")
+    elif report.target_unavailable_artifacts:
+        require(
+            "target_artifacts_unavailable",
+            "target compiler did not produce required artifacts: "
+            + ", ".join(report.target_unavailable_artifacts),
+        )
+
+    # Interfaces have no deployable source artifacts to compare. Their safety
+    # boundary is successful target compilation through an import harness.
+    if report.path.suffix == ".vyi":
+        return _decision(blockers, waivers)
+
+    source_validated = report.source_compile in {"passed", "degraded"}
+    if not source_validated:
+        require(
+            "source_compile_failed",
+            "source compilation did not pass",
+            allowed=config.allow_unvalidated_source,
+            waiver="--allow-unvalidated-source",
+        )
+    elif report.source_unavailable_artifacts:
+        require(
+            "source_artifacts_unavailable",
+            "source compiler did not produce required artifacts: "
+            + ", ".join(report.source_unavailable_artifacts),
+            allowed=config.allow_unvalidated_source,
+            waiver="--allow-unvalidated-source",
+        )
+
+    comparisons = (
+        (
+            "abi_changed",
+            "ABI changed after migration",
+            report.abi_equal,
+            config.allow_abi_change,
+            "--allow-abi-change",
+        ),
+        (
+            "method_identifiers_changed",
+            "method identifiers changed after migration",
+            report.method_ids_equal,
+            config.allow_method_id_change,
+            "--allow-method-id-change",
+        ),
+        (
+            "storage_layout_changed",
+            "storage layout changed after migration",
+            report.storage_layout_equal,
+            config.allow_storage_layout_change,
+            "--allow-storage-layout-change",
+        ),
+    )
+    for code, message, equal, allowed, waiver in comparisons:
+        if equal is False:
+            require(code, message, allowed=allowed, waiver=waiver)
+
+    if (
+        source_validated
+        and not report.source_unavailable_artifacts
+        and report.target_compile == "passed"
+        and not report.target_unavailable_artifacts
+        and any(equal is None for _, _, equal, _, _ in comparisons)
+    ):
+        require(
+            "artifact_comparison_unavailable",
+            "one or more artifact comparisons were unavailable",
+            allowed=config.allow_unvalidated_source,
+            waiver="--allow-unvalidated-source",
+        )
+
+    return _decision(blockers, waivers)
+
+
+def validation_exit_code(decision: ValidationDecision) -> int | None:
+    if decision.status != "blocked":
+        return None
+    codes = {issue.code for issue in decision.blockers}
+    if codes & {"target_compile_failed", "target_artifacts_unavailable"}:
+        return 2
+    if codes & {
+        "source_compile_failed",
+        "source_artifacts_unavailable",
+        "artifact_comparison_unavailable",
+    }:
+        return 3
+    return 7
+
+
+def _decision(
+    blockers: list[ValidationIssue], waivers: list[ValidationIssue]
+) -> ValidationDecision:
+    if blockers:
+        return ValidationDecision("blocked", False, tuple(blockers), tuple(waivers))
+    if waivers:
+        return ValidationDecision("waived", True, (), tuple(waivers))
+    return ValidationDecision("passed", True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,9 @@ from vyupgrade.compiler import CompileResult
 from vyupgrade.models import Config, FileReport
 
 
+VALIDATION_ARTIFACTS = {"abi": [], "method_identifiers": {}, "layout": {}}
+
+
 class TtyStringIO(StringIO):
     def isatty(self) -> bool:
         return True
@@ -22,7 +25,7 @@ def passing_compiler(monkeypatch):
     def compile_source_file(
         path: Path, config: Config, source_version: str | None
     ) -> CompileResult:
-        return CompileResult("passed", artifacts={})
+        return CompileResult("passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}})
 
     def compile_target_source(
         path: Path,
@@ -30,7 +33,7 @@ def passing_compiler(monkeypatch):
         config: Config,
         overlay=None,
     ) -> CompileResult:
-        return CompileResult("passed", artifacts={})
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
 
     monkeypatch.setattr(cli, "compile_source_file", compile_source_file)
     monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
@@ -121,7 +124,7 @@ def f() -> uint256:
         path: Path, config: Config, source_version: str | None
     ) -> CompileResult:
         seen["source_version"] = source_version
-        return CompileResult("passed", artifacts={})
+        return CompileResult("passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}})
 
     def compile_target_source(
         path: Path,
@@ -129,7 +132,7 @@ def f() -> uint256:
         config: Config,
         overlay=None,
     ) -> CompileResult:
-        return CompileResult("passed", artifacts={})
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
 
     monkeypatch.setattr(cli, "compile_source_file", compile_source_file)
     monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
@@ -167,7 +170,7 @@ def f() -> uint256:
     ) -> CompileResult:
         seen["source_version"] = source_version
         seen["source_vyper"] = config.source_vyper
-        return CompileResult("passed", artifacts={})
+        return CompileResult("passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}})
 
     def compile_target_source(
         path: Path,
@@ -175,7 +178,7 @@ def f() -> uint256:
         config: Config,
         overlay=None,
     ) -> CompileResult:
-        return CompileResult("passed", artifacts={})
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
 
     monkeypatch.setattr(cli, "compile_source_file", compile_source_file)
     monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
@@ -291,6 +294,339 @@ def f(target: address):
     assert contract.read_text(encoding="utf-8") == original
 
 
+def test_write_mode_does_not_write_when_source_compile_fails(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "bad-source.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult("failed", stderr="source failed"),
+    )
+
+    code = main([str(contract), "--write", "--report-json", str(report)])
+
+    assert code == 3
+    assert contract.read_text(encoding="utf-8") == original
+    data = json.loads(report.read_text())
+    assert data["wrote_changes"] is False
+    assert data["validation_decision"]["status"] == "blocked"
+    assert data["validation_decision"]["blockers"][0]["code"] == "source_compile_failed"
+
+
+def test_allow_unvalidated_source_waives_source_failure(
+    tmp_path: Path, monkeypatch, passing_compiler, capsys
+) -> None:
+    contract = tmp_path / "bad-source.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n", encoding="utf-8"
+    )
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult("failed", stderr="source failed"),
+    )
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--allow-unvalidated-source",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 0
+    assert "#pragma version 0.4.3" in contract.read_text(encoding="utf-8")
+    data = json.loads(report.read_text())
+    assert data["wrote_changes"] is True
+    assert data["validation_decision"]["status"] == "waived"
+    assert data["validation_decision"]["waivers"][0]["waiver"] == (
+        "--allow-unvalidated-source"
+    )
+    assert "write validation: waived" in capsys.readouterr().out
+
+
+def test_patch_level_abi_mismatch_blocks_even_when_diagnostic_is_ignored(
+    tmp_path: Path, monkeypatch
+) -> None:
+    contract = tmp_path / "patch-level.vy"
+    original = "#pragma version 0.4.2\n@external\ndef f():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult(
+            "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "compile_target_source",
+        lambda *_args: CompileResult(
+            "passed",
+            artifacts={
+                **VALIDATION_ARTIFACTS,
+                "abi": [{"type": "function", "name": "changed", "inputs": []}],
+            },
+        ),
+    )
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--ignore",
+            "VYD007",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 7
+    assert contract.read_text(encoding="utf-8") == original
+    data = json.loads(report.read_text())
+    assert not [diag for diag in data["files"][0]["diagnostics"] if diag["rule"] == "VYD007"]
+    assert data["validation_decision"]["blockers"][0]["code"] == "abi_changed"
+
+
+@pytest.mark.parametrize(
+    ("target_artifacts", "flag", "code"),
+    [
+        (
+            {
+                **VALIDATION_ARTIFACTS,
+                "abi": [{"type": "function", "name": "changed", "inputs": []}],
+            },
+            "--allow-abi-change",
+            "abi_changed",
+        ),
+        (
+            {**VALIDATION_ARTIFACTS, "method_identifiers": {"changed()": "0x12345678"}},
+            "--allow-method-id-change",
+            "method_identifiers_changed",
+        ),
+        (
+            {
+                **VALIDATION_ARTIFACTS,
+                "layout": {"changed": {"slot": 0, "type": "uint256"}},
+            },
+            "--allow-storage-layout-change",
+            "storage_layout_changed",
+        ),
+    ],
+)
+def test_artifact_change_waivers_are_narrow_and_reported(
+    tmp_path: Path,
+    monkeypatch,
+    target_artifacts: dict[str, object],
+    flag: str,
+    code: str,
+) -> None:
+    contract = tmp_path / f"{code}.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n", encoding="utf-8"
+    )
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult(
+            "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "compile_target_source",
+        lambda *_args: CompileResult("passed", artifacts=target_artifacts),
+    )
+
+    assert main([str(contract), "--write", flag, "--report-json", str(report)]) == 0
+
+    data = json.loads(report.read_text())
+    assert data["validation_decision"]["status"] == "waived"
+    assert data["validation_decision"]["waivers"] == [
+        {
+            "code": code,
+            "message": {
+                "abi_changed": "ABI changed after migration",
+                "method_identifiers_changed": "method identifiers changed after migration",
+                "storage_layout_changed": "storage layout changed after migration",
+            }[code],
+            "path": str(contract),
+            "waiver": flag,
+        }
+    ]
+
+
+def test_artifact_waiver_does_not_cover_other_diff_classes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    contract = tmp_path / "multiple-diffs.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult(
+            "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "compile_target_source",
+        lambda *_args: CompileResult(
+            "passed",
+            artifacts={
+                "abi": [{"type": "function", "name": "changed", "inputs": []}],
+                "method_identifiers": {"changed()": "0x12345678"},
+                "layout": {"changed": {"slot": 0, "type": "uint256"}},
+            },
+        ),
+    )
+
+    assert (
+        main(
+            [
+                str(contract),
+                "--write",
+                "--allow-abi-change",
+                "--report-json",
+                str(report),
+            ]
+        )
+        == 7
+    )
+
+    assert contract.read_text(encoding="utf-8") == original
+    decision = json.loads(report.read_text())["validation_decision"]
+    assert [issue["code"] for issue in decision["waivers"]] == ["abi_changed"]
+    assert [issue["code"] for issue in decision["blockers"]] == [
+        "method_identifiers_changed",
+        "storage_layout_changed",
+    ]
+
+
+def test_missing_source_artifact_blocks_without_source_waiver(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "missing-source-artifact.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult(
+            "degraded",
+            artifacts={"abi": [], "layout": {}, "ast": {}},
+            unavailable_formats=("method_identifiers",),
+        ),
+    )
+
+    assert main([str(contract), "--write", "--report-json", str(report)]) == 3
+    assert contract.read_text(encoding="utf-8") == original
+    validation = json.loads(report.read_text())["files"][0]["validation"]
+    assert validation["source_compile"] == "degraded"
+    assert validation["source_unavailable_artifacts"] == ["method_identifiers"]
+    assert validation["source_unavailable_formats"] == ["method_identifiers"]
+
+
+def test_optional_source_ast_unavailability_is_degraded_but_safe(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "missing-source-ast.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n", encoding="utf-8"
+    )
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult(
+            "degraded",
+            artifacts=VALIDATION_ARTIFACTS,
+            unavailable_formats=("ast",),
+        ),
+    )
+
+    assert main([str(contract), "--write", "--report-json", str(report)]) == 0
+
+    validation = json.loads(report.read_text())["files"][0]["validation"]
+    assert validation["source_compile"] == "degraded"
+    assert validation["source_unavailable_artifacts"] == []
+    assert validation["source_unavailable_formats"] == ["ast"]
+    assert validation["decision"]["status"] == "passed"
+
+
+def test_missing_target_artifact_is_not_waived_by_source_or_diff_flags(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "missing-target-artifact.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_target_source",
+        lambda *_args: CompileResult(
+            "passed", artifacts={"abi": [], "method_identifiers": {}}
+        ),
+    )
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--allow-unvalidated-source",
+            "--allow-storage-layout-change",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 2
+    assert contract.read_text(encoding="utf-8") == original
+    blockers = json.loads(report.read_text())["validation_decision"]["blockers"]
+    assert [blocker["code"] for blocker in blockers] == ["target_artifacts_unavailable"]
+
+
+def test_malformed_target_artifacts_block_write(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "malformed-target-artifacts.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli,
+        "compile_target_source",
+        lambda *_args: CompileResult(
+            "passed",
+            artifacts={
+                "abi": [None],
+                "method_identifiers": {},
+                "layout": {"storage_layout": []},
+            },
+        ),
+    )
+
+    code = main([str(contract), "--write", "--report-json", str(report)])
+
+    assert code == 2
+    assert contract.read_text(encoding="utf-8") == original
+    validation = json.loads(report.read_text())["files"][0]["validation"]
+    assert validation["target_unavailable_artifacts"] == ["abi", "layout"]
+    assert validation["decision"]["blockers"][0]["code"] == "target_artifacts_unavailable"
+
+
 def test_split_interfaces_writes_sibling_vyi_files(tmp_path: Path, passing_compiler) -> None:
     contract = tmp_path / "Main.vy"
     contract.write_text(
@@ -388,6 +724,36 @@ report-json = "{report}"
 
     assert code == 1
     assert report.exists()
+
+
+def test_pyproject_can_waive_unvalidated_source(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n", encoding="utf-8"
+    )
+    report = tmp_path / "configured-report.json"
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        f'''[tool.vyupgrade]
+paths = ["{contract}"]
+report-json = "{report}"
+allow-unvalidated-source = true
+''',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        cli,
+        "compile_source_file",
+        lambda *_args: CompileResult("failed", stderr="source failed"),
+    )
+
+    code = main(["--config", str(pyproject), "--write"])
+
+    assert code == 0
+    assert "#pragma version 0.4.3" in contract.read_text(encoding="utf-8")
+    assert json.loads(report.read_text())["validation_decision"]["status"] == "waived"
 
 
 def test_select_limits_applied_rules(tmp_path: Path, passing_compiler) -> None:

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -12,9 +12,17 @@ def test_write_mode_validates_against_target_compiler(tmp_path: Path) -> None:
     shutil.copyfile(Path("tests/fixtures/migration_03.vy"), contract)
 
     report = tmp_path / "report.json"
-    code = main([str(contract), "--write", "--report-json", str(report)])
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--allow-unvalidated-source",
+            "--report-json",
+            str(report),
+        ]
+    )
 
-    assert code in {0, 3}
+    assert code == 0
     rewritten = contract.read_text()
     assert "#pragma version 0.4.3" in rewritten
     assert "staticcall self.token.balanceOf(msg.sender)" in rewritten
@@ -22,6 +30,7 @@ def test_write_mode_validates_against_target_compiler(tmp_path: Path) -> None:
     data = json.loads(report.read_text())
     assert data["write_requested"] is True
     assert data["wrote_changes"] is True
+    assert data["validation_decision"]["status"] == "waived"
     assert data["files"][0]["validation"]["target_compile"] == "passed"
 
 
@@ -82,3 +91,51 @@ def f(x: uint256) -> uint256:
     file = data["files"][0]
     assert file["validation"]["target_compile"] == "passed"
     assert any(fix["rule"] == "VY101" for fix in file["fixes"])
+
+
+def test_standalone_interface_receives_target_validation(tmp_path: Path) -> None:
+    interface = tmp_path / "IToken.vyi"
+    interface.write_text(
+        """# @version 0.3.10
+@view
+@external
+def balanceOf(owner: address) -> uint256: ...
+""",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    code = main([str(interface), "--check", "--report-json", str(report)])
+
+    assert code == 1
+    file = json.loads(report.read_text())["files"][0]
+    assert file["validation"]["source_compile"] == "skipped"
+    assert file["validation"]["source_unavailable_artifacts"] == []
+    assert file["validation"]["target_compile"] == "passed"
+    assert file["validation"]["decision"]["status"] == "passed"
+
+
+def test_invalid_standalone_interface_is_not_written(tmp_path: Path) -> None:
+    interface = tmp_path / "IBroken.vyi"
+    original = "# @version 0.3.10\n@external\ndef broken(: ...\n"
+    interface.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    code = main([str(interface), "--write", "--report-json", str(report)])
+
+    assert code == 2
+    assert interface.read_text(encoding="utf-8") == original
+    file = json.loads(report.read_text())["files"][0]
+    assert file["validation"]["target_compile"] == "failed"
+    assert file["validation"]["decision"]["status"] == "blocked"
+
+
+def test_target_validation_does_not_normalize_selected_candidate(tmp_path: Path) -> None:
+    contract = tmp_path / "selected.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+
+    code = main([str(contract), "--write", "--select", "VY002"])
+
+    assert code == 2
+    assert contract.read_text(encoding="utf-8") == original

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -114,23 +114,90 @@ def test_explicit_compiler_path_skips_uv_wrapper() -> None:
     assert _compiler_command("/tmp/vyper", "0.3.7", "3.11") == ["/tmp/vyper"]
 
 
-def test_compile_retries_without_unsupported_layout(monkeypatch) -> None:
+def test_target_compile_fails_on_unsupported_required_layout(monkeypatch) -> None:
     calls: list[list[str]] = []
 
     def fake_run(command, **kwargs):
         calls.append(command)
-        if "-f" in command and command[command.index("-f") + 1] == "abi,method_identifiers,layout":
-            return subprocess.CompletedProcess(command, 1, "", "ValueError: Unsupported format type 'layout'")
-        return subprocess.CompletedProcess(command, 0, "[]\n{}\n", "")
+        return subprocess.CompletedProcess(
+            command, 1, "", "ValueError: Unsupported format type 'layout'"
+        )
 
     monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
 
     result = _run_compile(["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),)))
 
-    assert result.status == "passed"
-    assert result.artifacts == {"abi": [], "method_identifiers": {}}
+    assert result.status == "failed"
+    assert result.unavailable_formats == ("layout",)
+    assert "required output format 'layout'" in (result.stderr or "")
     assert calls[0][calls[0].index("-f") + 1] == "abi,method_identifiers,layout"
-    assert calls[1][calls[1].index("-f") + 1] == "abi,method_identifiers"
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "artifacts, unavailable",
+    [
+        (
+            {"abi": [None], "method_identifiers": {}, "layout": {}},
+            ["abi"],
+        ),
+        (
+            {
+                "abi": [{"type": "function", "inputs": [None]}],
+                "method_identifiers": {},
+                "layout": {},
+            },
+            ["abi"],
+        ),
+        (
+            {"abi": [], "method_identifiers": {"f()": None}, "layout": {}},
+            ["method_identifiers"],
+        ),
+        (
+            {"abi": [], "method_identifiers": {}, "layout": {"storage_layout": []}},
+            ["layout"],
+        ),
+        (
+            {
+                "abi": [],
+                "method_identifiers": {},
+                "layout": {"storage_layout": {"owner": {"slot": 0}}},
+            },
+            ["layout"],
+        ),
+    ],
+)
+def test_validation_artifacts_reject_malformed_nested_schemas(
+    artifacts, unavailable
+) -> None:
+    from vyupgrade.compiler import unavailable_validation_artifacts
+
+    result = CompileResult("passed", artifacts=artifacts)
+
+    assert unavailable_validation_artifacts(result) == unavailable
+
+
+def test_source_compile_degrades_on_unsupported_legacy_layout(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if command[command.index("-f") + 1] == "abi,method_identifiers,layout":
+            return subprocess.CompletedProcess(
+                command, 1, "", "ValueError: Unsupported format type 'layout'"
+            )
+        return subprocess.CompletedProcess(command, 0, "[]\n{}\n", "")
+
+    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+
+    result = _run_compile_with_formats_for_test(
+        ["vyper"], Path("/tmp/contract.vy"), ("abi", "method_identifiers", "layout")
+    )
+
+    assert result.status == "degraded"
+    assert result.artifacts == {"abi": [], "method_identifiers": {}}
+    assert result.unavailable_formats == ("layout",)
+    assert calls[-1][calls[-1].index("-f") + 1] == "abi,method_identifiers"
 
 
 def test_compile_retries_without_legacy_keyerror_format(monkeypatch) -> None:
@@ -149,7 +216,8 @@ def test_compile_retries_without_legacy_keyerror_format(monkeypatch) -> None:
 
     result = _run_compile_with_formats_for_test(["vyper"], Path("/tmp/contract.vy"), ("abi", "method_identifiers", "ast"))
 
-    assert result.status == "passed"
+    assert result.status == "degraded"
+    assert result.unavailable_formats == ("method_identifiers", "ast")
     assert calls[-1][calls[-1].index("-f") + 1] == "abi"
 
 
@@ -178,15 +246,38 @@ def test_compile_retries_without_ast_for_legacy_span_error(monkeypatch) -> None:
         ["vyper"], Path("/tmp/contract.vy"), ("abi", "method_identifiers", "layout", "ast")
     )
 
-    assert result.status == "passed"
+    assert result.status == "degraded"
     assert result.artifacts == {"abi": []}
+    assert result.unavailable_formats == ("ast", "layout", "method_identifiers")
     assert calls[-1][calls[-1].index("-f") + 1] == "abi"
 
 
 def _run_compile_with_formats_for_test(command: list[str], path: Path, formats: tuple[str, ...]) -> CompileResult:
     from vyupgrade.compiler import _run_compile_with_formats
 
-    return _run_compile_with_formats(command, path, Config(paths=(path,)), formats, (), False)
+    return _run_compile_with_formats(
+        command,
+        path,
+        Config(paths=(path,)),
+        formats,
+        (),
+        False,
+        allow_unsupported_formats=True,
+    )
+
+
+def test_target_compile_fails_when_compiler_omits_requested_output(monkeypatch) -> None:
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, "[]\n{}\n", "")
+
+    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+
+    result = _run_compile(
+        ["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),))
+    )
+
+    assert result.status == "failed"
+    assert result.stderr == "could not parse compiler output: expected 3 compiler outputs, received 2"
 
 
 def test_compile_installs_declared_vyper_import_dependencies(monkeypatch, tmp_path) -> None:
@@ -412,6 +503,7 @@ def test_compile_source_ast_requests_ast_format(monkeypatch, tmp_path) -> None:
         formats: tuple[str, ...],
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["run"] = (command, path, formats, extra_paths, suppress_warnings)
         return CompileResult("passed", artifacts={"ast": {"ast_type": "Module"}})
@@ -442,6 +534,7 @@ def test_compile_source_file_requests_ast_with_validation_outputs(monkeypatch, t
         formats: tuple[str, ...],
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["run"] = (command, path, formats, extra_paths, suppress_warnings)
         return CompileResult("passed", artifacts={"ast": {"ast_type": "Module"}})
@@ -471,6 +564,7 @@ def test_compile_source_file_retries_legacy_span_error_with_final_newline(
         formats: tuple[str, ...],
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls.append((path, path.read_bytes()))
         if len(calls) == 1:
@@ -555,7 +649,7 @@ def test_compile_target_source_enables_decimals_for_math_import(monkeypatch, tmp
     assert calls["enable_decimals"] is True
 
 
-def test_compile_target_source_bumps_temp_pragma_for_validation(monkeypatch, tmp_path) -> None:
+def test_compile_target_source_compiles_exact_candidate_bytes(monkeypatch, tmp_path) -> None:
     contract = tmp_path / "contract.vy"
     contract.write_text("# @version 0.2.11\n", encoding="utf-8")
     calls: dict[str, object] = {}
@@ -581,8 +675,37 @@ def test_compile_target_source_bumps_temp_pragma_for_validation(monkeypatch, tmp
     )
 
     assert result.status == "passed"
-    assert "#pragma version 0.4.3" in calls["source"]
-    assert "#pragma version 0.2.11" not in calls["source"]
+    assert calls["source"] == "#pragma version 0.2.11\n@external\ndef f():\n    pass\n"
+
+
+def test_compile_target_interface_uses_import_harness(monkeypatch, tmp_path) -> None:
+    interface = tmp_path / "IToken.vyi"
+    source = "@external\ndef balanceOf(owner: address) -> uint256: ...\n"
+    interface.write_text(source, encoding="utf-8")
+    calls: dict[str, str] = {}
+
+    monkeypatch.setattr("vyupgrade.compiler._prepare_command", lambda *_args: (["vyper"], True))
+
+    def fake_run_compile(
+        command: list[str],
+        path: Path,
+        config: Config,
+        extra_paths: tuple[Path, ...],
+        suppress_warnings: bool,
+    ) -> CompileResult:
+        calls["harness"] = path.read_text(encoding="utf-8")
+        module = calls["harness"].split("import ", 1)[1].split(" as ", 1)[0]
+        calls["interface"] = (path.parent / f"{module}.vyi").read_text(encoding="utf-8")
+        return CompileResult("passed", artifacts={"abi": [], "method_identifiers": {}, "layout": {}})
+
+    monkeypatch.setattr("vyupgrade.compiler._run_compile", fake_run_compile)
+
+    result = compile_target_source(interface, source, Config(paths=(interface,)))
+
+    assert result.status == "passed"
+    assert calls["interface"] == source
+    assert calls["harness"].startswith("#pragma version 0.4.3\nimport vyupgrade_interface_")
+    assert not list(tmp_path.glob("vyupgrade_interface_*"))
 
 
 def test_target_validation_source_removes_duplicate_vyper_pragmas() -> None:
@@ -1043,7 +1166,7 @@ def test_target_overlay_rewrites_standard_json_src_package_imports(tmp_path) -> 
         assert (overlay.root / "utils" / "interfaces" / "IERC5267.vyi").exists()
 
 
-def test_target_overlay_rewrites_local_sibling_absolute_imports(tmp_path) -> None:
+def test_target_overlay_preserves_exact_override_bytes(tmp_path) -> None:
     package = tmp_path / "package"
     contract = package / "multijson.vy"
     math = package / "math.vy"
@@ -1058,7 +1181,9 @@ def test_target_overlay_rewrites_local_sibling_absolute_imports(tmp_path) -> Non
     ) as overlay:
         assert overlay is not None
         contract_overlay = overlay.root / "multijson.vy"
-        assert "from . import math" in contract_overlay.read_text(encoding="utf-8")
+        assert contract_overlay.read_text(encoding="utf-8") == (
+            "#pragma version 0.4.3\nimport math\n"
+        )
         assert (overlay.root / "math.vy").exists()
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -6,7 +6,14 @@ from pathlib import Path
 from rich.console import Console
 
 from vyupgrade import __version__
-from vyupgrade.models import Diagnostic, FileReport, Fix, RunReport
+from vyupgrade.models import (
+    Diagnostic,
+    FileReport,
+    Fix,
+    RunReport,
+    ValidationDecision,
+    ValidationIssue,
+)
 from vyupgrade.reporting import (
     THEME,
     HumanReporter,
@@ -76,6 +83,38 @@ def test_render_text_labels_resolved_source_compiler() -> None:
     text = render_text(report)
 
     assert "source compile (0.4.3): passed" in text
+
+
+def test_render_text_records_validation_blockers_and_waivers() -> None:
+    path = Path("changed.vy")
+    blocker = ValidationIssue("abi_changed", "ABI changed after migration", path)
+    waiver = ValidationIssue(
+        "source_compile_failed",
+        "source compilation did not pass",
+        path,
+        "--allow-unvalidated-source",
+    )
+    file_report = FileReport(
+        path=path,
+        changed=True,
+        source_compile="failed",
+        target_compile="passed",
+        validation_decision=ValidationDecision("blocked", False, (blocker,), (waiver,)),
+    )
+    report = RunReport(
+        source_version=None,
+        target_version="0.4.3",
+        files=[file_report],
+        validation_decision=file_report.validation_decision,
+    )
+
+    text = render_text(report)
+
+    assert "validation decision: blocked" in text
+    assert "validation blocker: ABI changed after migration" in text
+    assert "validation waiver: --allow-unvalidated-source" in text
+    assert "write validation: blocked" in text
+    assert "validation waivers: --allow-unvalidated-source" in text
 
 
 def test_render_text_groups_repeated_fixes_and_diagnostics_by_rule_message() -> None:


### PR DESCRIPTION
## What

- introduce typed per-file and run-level validation decisions
- block writes on source/target compiler failures, missing or malformed required artifacts, and ABI/method/storage mismatches
- add four narrow, explicit waiver flags and record every blocker/waiver in human and JSON reports
- require exact target candidate bytes and strict compiler output cardinality/schema
- distinguish degraded legacy source output support from successful full validation
- compile standalone `.vyi` inputs through an import harness

## Why

The existing CLI only blocked writes when the target compiler process failed. Source failures, unavailable artifacts, and public/storage artifact changes were report-only, so a migration could be written without the safety proof the CLI promises. Compiler output parsing also accepted missing or malformed artifacts too loosely.

## Impact

Validation is fail-closed and independent of rule selection or diagnostic gating. Existing migrations with unverifiable legacy source artifacts now require `--allow-unvalidated-source`; observable artifact changes require their matching explicit waiver. Target compilation and target artifact availability cannot be waived.

Formatting remains after validation in this PR and is documented as a boundary; the follow-up transactional-write PR stages, formats, and revalidates the final bytes.

## Checks

- `uv run --locked pytest` (531 passed)
- focused compiler/CLI/interface/report suite (117 passed)
- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py`
- `git diff --check`
