### PR TITLE
feat: harden corpus and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
-      - run: uv run --locked ruff check src tests scripts/corpus.py
+      - run: uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py
       - run: uv run --locked pytest
       - run: scripts/smoke-wheel.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,18 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
-      - run: uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py
+      - run: uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py
       - run: uv run --locked pytest
       - run: scripts/smoke-wheel.sh
+      - run: uv run --locked python scripts/release_preflight.py "$GITHUB_REF_NAME" --dist dist --notes-output release-notes.md
       - uses: actions/upload-artifact@v7.0.1
         with:
           name: dist
           path: dist/*
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-notes
+          path: release-notes.md
 
   publish:
     needs: build
@@ -48,10 +53,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/download-artifact@v8.0.1
         with:
-          python-version: "3.11"
-      - run: python scripts/release_notes.py "$GITHUB_REF_NAME" > release-notes.md
+          name: release-notes
+          path: .
       - run: |
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ feature, not an optional smoke check.
 Use the locked environment unless intentionally updating dependencies.
 
 ```bash
-uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py
+uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py
 uv run --locked pytest
 scripts/smoke-wheel.sh
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,7 +22,7 @@ requirements in `pyproject.toml`.
 Run the main validation suite before publishing changes:
 
 ```bash
-uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py
+uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py
 uv run --locked pytest
 scripts/smoke-wheel.sh
 ```
@@ -195,6 +195,8 @@ uv run --locked python scripts/corpus.py smoke \
 Use `--limit` for a quick sample and `--path` to focus on known regressions. The
 smoke command compiles source and target outputs, applies the same artifact
 comparisons as the CLI, and records rule, diagnostic, compile, and diff details.
+It writes an atomic checkpoint sidecar and resumes an ordered result prefix when
+the manifest, selected items, and target version still match the interrupted run.
 
 Corpus source directories and generated outputs live under `corpus/`, which is
 ignored by Git.
@@ -202,8 +204,9 @@ ignored by Git.
 ## Release process
 
 Publishing uses GitHub Actions and PyPI Trusted Publishing. The publish workflow
-runs on `v*` tags, builds the package, publishes to PyPI, and creates or updates
-the GitHub release using notes extracted from `CHANGELOG.md`.
+runs on `v*` tags, builds the package, verifies the tag, project and lockfile
+versions, changelog notes, and distribution metadata before publishing to PyPI,
+then creates or updates the GitHub release with the preflighted notes.
 
 Before tagging:
 
@@ -213,9 +216,10 @@ Before tagging:
 3. Run:
 
    ```bash
-   uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py
+   uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py
    uv run --locked pytest
    scripts/smoke-wheel.sh
+   uv run --locked python scripts/release_preflight.py v0.4.2 --dist dist
    ```
 
 4. Tag and push:

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ allow-storage-layout-change = false
 - `3` — source compilation or source artifact availability failed validation.
 - `4` — usage error (no paths, or conflicting flags).
 - `5` — an error-severity diagnostic was raised.
-- `6` — the requested formatter failed.
+- `6` — the requested formatter failed or could not be run.
 - `7` — an unwaived ABI, method-identifier, or storage-layout mismatch blocked the write.
 
 ## Coverage

--- a/scripts/corpus.py
+++ b/scripts/corpus.py
@@ -6,11 +6,14 @@ import concurrent.futures as cf
 import csv
 import hashlib
 import json
+import os
 import re
+import stat
 import time
 import traceback
 import urllib.parse
 import urllib.request
+import uuid
 from collections import Counter
 from dataclasses import replace
 from pathlib import Path
@@ -38,6 +41,15 @@ from vyupgrade.versions import (
 
 DEFAULT_ROOTS = (Path("~/dev").expanduser(), Path("~/yearn").expanduser())
 DEFAULT_OUTPUT = Path("corpus/vyper")
+CORPUS_MANIFESTS = {
+    "build": "manifest.json",
+    "codeslaw": "codeslaw-manifest.json",
+    "codeslaw-buckets": "codeslaw-buckets-manifest.json",
+    "old-vyper-bug": "old-vyper-bug-manifest.json",
+    "smart-contract-fiesta": "smart-contract-fiesta-manifest.json",
+    "vyper-2026": "vyper-2026-manifest.json",
+    "chainsecurity": "chainsecurity-manifest.json",
+}
 CODESLAW_CHAINS = (
     "ethereum",
     "arbitrum",
@@ -261,7 +273,7 @@ def build_corpus(roots: tuple[Path, ...], output: Path, max_per_repo: int = 0) -
             if compiler is not None:
                 by_compiler[compiler] += 1
 
-    manifest_path = output / "manifest.json"
+    manifest_path = _corpus_manifest_path(output, "build")
     manifest = {
         "manifest": str(manifest_path),
         "roots": [str(root.expanduser()) for root in roots],
@@ -347,7 +359,7 @@ def import_old_vyper_bug(source: Path, output: Path) -> dict[str, Any]:
             if source_path not in seen_sources:
                 counts["unreferenced_source"] += 1
 
-    manifest_path = output / "old-vyper-bug-manifest.json"
+    manifest_path = _corpus_manifest_path(output, "old-vyper-bug")
     manifest = {
         "manifest": str(manifest_path),
         "roots": [str(root)],
@@ -422,7 +434,7 @@ def import_smart_contract_fiesta(source: Path, output: Path) -> dict[str, Any]:
             by_repo[corpus_repo] += 1
             by_compiler[compiler] += 1
 
-    manifest_path = output / "smart-contract-fiesta-manifest.json"
+    manifest_path = _corpus_manifest_path(output, "smart-contract-fiesta")
     manifest = {
         "manifest": str(manifest_path),
         "roots": [str(root)],
@@ -547,7 +559,7 @@ def import_vyper_2026(source: Path, output: Path) -> dict[str, Any]:
             by_repo[corpus_repo] += 1
             by_compiler[compiler] += 1
 
-    manifest_path = output / "vyper-2026-manifest.json"
+    manifest_path = _corpus_manifest_path(output, "vyper-2026")
     manifest = {
         "manifest": str(manifest_path),
         "roots": [str(root)],
@@ -648,7 +660,7 @@ def _import_vyper_2026_inventory(source: Path, inventory_dir: Path, output: Path
 
         counts[f"source_catalog.parquet:unsupported_source_format:{source_format}"] += 1
 
-    manifest_path = output / "vyper-2026-manifest.json"
+    manifest_path = _corpus_manifest_path(output, "vyper-2026")
     manifest = {
         "manifest": str(manifest_path),
         "roots": [str(source)],
@@ -1070,7 +1082,7 @@ def import_chainsecurity(source: Path, output: Path) -> dict[str, Any]:
         if compiler is not None:
             by_compiler[compiler] += 1
 
-    manifest_path = output / "chainsecurity-manifest.json"
+    manifest_path = _corpus_manifest_path(output, "chainsecurity")
     manifest = {
         "manifest": str(manifest_path),
         "roots": [str(root)],
@@ -1087,16 +1099,9 @@ def dedupe_manifests(manifest_paths: list[Path] | None, output_path: Path) -> di
     if manifest_paths is None:
         corpus_root = output_path.parent
         manifest_paths = [
-            corpus_root / name
-            for name in (
-                "manifest.json",
-                "codeslaw-manifest.json",
-                "codeslaw-buckets-manifest.json",
-                "old-vyper-bug-manifest.json",
-                "smart-contract-fiesta-manifest.json",
-                "vyper-2026-manifest.json",
-            )
-            if (corpus_root / name).exists()
+            path
+            for name in CORPUS_MANIFESTS
+            if (path := _corpus_manifest_path(corpus_root, name)).exists()
         ]
 
     counts: Counter[str] = Counter()
@@ -1171,7 +1176,7 @@ def fetch_codeslaw(chain: str, query: str, sort: str, limit: int, output: Path) 
         matches, contracts_dir, counts, by_repo, by_compiler, items, seen_addresses
     )
 
-    manifest_path = output / "codeslaw-manifest.json"
+    manifest_path = _corpus_manifest_path(output, "codeslaw")
     manifest = {
         "manifest": str(manifest_path),
         "roots": [search_url],
@@ -1227,7 +1232,7 @@ def fetch_codeslaw_buckets(chains: tuple[str, ...], output: Path) -> dict[str, A
                 matches, contracts_dir, counts, by_repo, by_compiler, items, seen_addresses
             )
 
-    manifest_path = output / "codeslaw-buckets-manifest.json"
+    manifest_path = _corpus_manifest_path(output, "codeslaw-buckets")
     manifest = {
         "manifest": str(manifest_path),
         "roots": roots,
@@ -1318,18 +1323,35 @@ def smoke_corpus(
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     items = _smoke_items(manifest["items"], paths, limit)
     started = time.time()
-    results: list[dict[str, Any]] = []
-    with cf.ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = [pool.submit(_smoke_one, item, target_version) for item in items]
-        for index, future in enumerate(cf.as_completed(futures), 1):
-            results.append(future.result())
-            if index % 50 == 0:
-                output_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
-                print(f"progress {index}/{len(items)}", flush=True)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
-    summary = _smoke_summary(results, manifest_path, output_path, time.time() - started)
-    _summary_path(output_path).write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    identity = _smoke_run_identity(manifest_path, target_version, items)
+    resumed_results = _load_smoke_checkpoint(output_path, identity, items)
+    results: list[dict[str, Any] | None] = [None] * len(items)
+    results[: len(resumed_results)] = resumed_results
+    completed_prefix = len(resumed_results)
+    next_checkpoint = (completed_prefix // 50 + 1) * 50
+    with cf.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_smoke_one, item, target_version): index
+            for index, item in enumerate(items[completed_prefix:], completed_prefix)
+        }
+        for future in cf.as_completed(futures):
+            results[futures[future]] = future.result()
+            while completed_prefix < len(results) and results[completed_prefix] is not None:
+                completed_prefix += 1
+            if completed_prefix >= next_checkpoint:
+                checkpoint = completed_prefix // 50 * 50
+                _write_smoke_checkpoint(
+                    output_path,
+                    [result for result in results[:checkpoint] if result is not None],
+                    identity,
+                )
+                print(f"progress {checkpoint}/{len(items)}", flush=True)
+                next_checkpoint = checkpoint + 50
+    ordered_results = [result for result in results if result is not None]
+    _write_smoke_checkpoint(output_path, ordered_results, identity)
+    summary = _smoke_summary(ordered_results, manifest_path, output_path, time.time() - started)
+    _atomic_write_json(_summary_path(output_path), summary)
     return summary
 
 
@@ -1496,6 +1518,116 @@ def _summary_path(results_path: Path) -> Path:
     if results_path.name.endswith("-results.json"):
         return results_path.with_name(f"{results_path.name[: -len('-results.json')]}-summary.json")
     return results_path.with_name(f"{results_path.stem}-summary.json")
+
+
+def _checkpoint_path(results_path: Path) -> Path:
+    if results_path.name.endswith("-results.json"):
+        return results_path.with_name(
+            f"{results_path.name[: -len('-results.json')]}-checkpoint.json"
+        )
+    return results_path.with_name(f"{results_path.stem}-checkpoint.json")
+
+
+def _smoke_run_identity(
+    manifest_path: Path, target_version: str, items: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "checkpoint_version": 1,
+        "manifest_path": str(manifest_path.resolve()),
+        "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        "target_version": target_version,
+        "selected_items": len(items),
+        "selected_items_sha256": _json_digest(items),
+    }
+
+
+def _load_smoke_checkpoint(
+    output_path: Path,
+    identity: dict[str, Any],
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    try:
+        checkpoint = json.loads(_checkpoint_path(output_path).read_text(encoding="utf-8"))
+        if (
+            not isinstance(checkpoint, dict)
+            or checkpoint.get("checkpoint_version") != 1
+            or checkpoint.get("identity") != identity
+        ):
+            return []
+        completed = checkpoint.get("completed")
+        if type(completed) is not int or completed < 0 or completed > len(items):
+            return []
+        results = json.loads(output_path.read_text(encoding="utf-8"))
+        if not isinstance(results, list) or len(results) != completed:
+            return []
+        if checkpoint.get("results_sha256") != _json_digest(results):
+            return []
+        if not all(
+            isinstance(result, dict) and _result_matches_item(result, item)
+            for result, item in zip(results, items[:completed], strict=True)
+        ):
+            return []
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        return []
+    return results
+
+
+def _result_matches_item(result: dict[str, Any], item: dict[str, Any]) -> bool:
+    return all(key in result and result[key] == value for key, value in item.items())
+
+
+def _write_smoke_checkpoint(
+    output_path: Path,
+    results: list[dict[str, Any]],
+    identity: dict[str, Any],
+) -> None:
+    _atomic_write_json(output_path, results)
+    _atomic_write_json(
+        _checkpoint_path(output_path),
+        {
+            "checkpoint_version": 1,
+            "identity": identity,
+            "completed": len(results),
+            "results_sha256": _json_digest(results),
+        },
+    )
+
+
+def _corpus_manifest_path(output: Path, importer: str) -> Path:
+    return output / CORPUS_MANIFESTS[importer]
+
+
+def _json_digest(value: Any) -> str:
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _atomic_write_json(path: Path, value: Any) -> None:
+    payload = json.dumps(value, indent=2)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        destination_mode = stat.S_IMODE(path.stat().st_mode)
+    except FileNotFoundError:
+        destination_mode = None
+    temporary_path = path.with_name(
+        f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    )
+    descriptor = os.open(
+        temporary_path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o666,
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+            if destination_mode is not None:
+                os.fchmod(file.fileno(), destination_mode)
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
 
 
 def _source_hash(source: str) -> str:

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import tarfile
+import tomllib
+import zipfile
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Any
+
+from packaging.utils import canonicalize_name, parse_sdist_filename, parse_wheel_filename
+from packaging.version import Version
+
+if __package__:
+    from .release_notes import changelog_release_notes
+else:
+    from release_notes import changelog_release_notes
+
+
+def release_preflight(
+    tag: str,
+    *,
+    pyproject_path: Path = Path("pyproject.toml"),
+    lock_path: Path = Path("uv.lock"),
+    changelog_path: Path = Path("CHANGELOG.md"),
+    dist_path: Path | None = None,
+) -> str:
+    pyproject = _read_toml(pyproject_path)
+    project = pyproject.get("project")
+    if not isinstance(project, dict):
+        raise ValueError(f"{pyproject_path} does not contain a [project] table")
+    name = _required_string(project, "name", pyproject_path)
+    version = _required_string(project, "version", pyproject_path)
+
+    expected_tag = f"v{version}"
+    if tag != expected_tag:
+        raise ValueError(f"tag {tag!r} does not match project version {version!r} ({expected_tag})")
+
+    changelog = changelog_path.read_text(encoding="utf-8")
+    notes = changelog_release_notes(changelog, tag)
+    _validate_lock_version(_read_toml(lock_path), lock_path, name, version)
+    if dist_path is not None:
+        _validate_distribution(dist_path, name, version)
+    return notes
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as file:
+        return tomllib.load(file)
+
+
+def _required_string(table: dict[str, Any], key: str, path: Path) -> str:
+    value = table.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{path} project {key} must be a nonempty string")
+    return value
+
+
+def _validate_lock_version(lock: dict[str, Any], path: Path, name: str, version: str) -> None:
+    packages = lock.get("package")
+    if not isinstance(packages, list):
+        raise ValueError(f"{path} does not contain package entries")
+    project_name = canonicalize_name(name)
+    projects = [
+        package
+        for package in packages
+        if isinstance(package, dict)
+        and canonicalize_name(str(package.get("name", ""))) == project_name
+        and isinstance(package.get("source"), dict)
+        and package["source"].get("editable") == "."
+    ]
+    if len(projects) != 1:
+        raise ValueError(f"{path} must contain one editable {name!r} project package")
+    lock_version = projects[0].get("version")
+    if lock_version != version:
+        raise ValueError(
+            f"{path} project version {lock_version!r} does not match {version!r}"
+        )
+
+
+def _validate_distribution(dist_path: Path, name: str, version: str) -> None:
+    if not dist_path.is_dir():
+        raise ValueError(f"distribution directory does not exist: {dist_path}")
+    files = sorted(path for path in dist_path.iterdir() if path.is_file())
+    wheels = [path for path in files if path.suffix == ".whl"]
+    sdists = [path for path in files if path.name.endswith(".tar.gz")]
+    if len(wheels) != 1 or len(sdists) != 1:
+        raise ValueError(
+            f"{dist_path} must contain exactly one wheel and one .tar.gz sdist "
+            f"(found {len(wheels)} wheel(s), {len(sdists)} sdist(s))"
+        )
+
+    wheel_name, wheel_version, _build, _tags = parse_wheel_filename(wheels[0].name)
+    _validate_artifact_identity(wheels[0], wheel_name, wheel_version, name, version)
+    _validate_metadata(wheels[0], _wheel_metadata(wheels[0]), name, version)
+
+    sdist_name, sdist_version = parse_sdist_filename(sdists[0].name)
+    _validate_artifact_identity(sdists[0], sdist_name, sdist_version, name, version)
+    _validate_metadata(sdists[0], _sdist_metadata(sdists[0]), name, version)
+
+
+def _validate_artifact_identity(
+    path: Path, artifact_name: str, artifact_version: Version, name: str, version: str
+) -> None:
+    if canonicalize_name(artifact_name) != canonicalize_name(name):
+        raise ValueError(f"artifact filename has the wrong project name: {path.name}")
+    if artifact_version != Version(version):
+        raise ValueError(f"artifact filename has the wrong project version: {path.name}")
+
+
+def _wheel_metadata(path: Path) -> bytes:
+    with zipfile.ZipFile(path) as archive:
+        members = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+        if len(members) != 1:
+            raise ValueError(f"{path} must contain exactly one .dist-info/METADATA file")
+        return archive.read(members[0])
+
+
+def _sdist_metadata(path: Path) -> bytes:
+    with tarfile.open(path, "r:gz") as archive:
+        members = [
+            member
+            for member in archive.getmembers()
+            if member.isfile() and Path(member.name).name == "PKG-INFO"
+        ]
+        if len(members) != 1:
+            raise ValueError(f"{path} must contain exactly one PKG-INFO file")
+        file = archive.extractfile(members[0])
+        if file is None:
+            raise ValueError(f"could not read metadata from {path}")
+        return file.read()
+
+
+def _validate_metadata(path: Path, payload: bytes, name: str, version: str) -> None:
+    metadata = BytesParser(policy=policy.default).parsebytes(payload)
+    metadata_name = metadata.get("Name")
+    metadata_version = metadata.get("Version")
+    if not metadata_name or canonicalize_name(metadata_name) != canonicalize_name(name):
+        raise ValueError(f"{path} metadata project name {metadata_name!r} does not match {name!r}")
+    if metadata_version != version:
+        raise ValueError(
+            f"{path} metadata version {metadata_version!r} does not match {version!r}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate release metadata and optionally built distributions"
+    )
+    parser.add_argument("tag")
+    parser.add_argument("--pyproject", type=Path, default=Path("pyproject.toml"))
+    parser.add_argument("--lock", type=Path, default=Path("uv.lock"))
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    parser.add_argument("--dist", type=Path)
+    parser.add_argument("--notes-output", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        notes = release_preflight(
+            args.tag,
+            pyproject_path=args.pyproject,
+            lock_path=args.lock,
+            changelog_path=args.changelog,
+            dist_path=args.dist,
+        )
+        if args.notes_output is None:
+            print(notes, end="")
+        else:
+            args.notes_output.parent.mkdir(parents=True, exist_ok=True)
+            args.notes_output.write_text(notes, encoding="utf-8")
+            print(f"release preflight passed for {args.tag}")
+    except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+        print(f"release preflight failed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import stat
+import time
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 
 def _load_corpus_module():
@@ -115,6 +119,28 @@ def test_dedupe_manifests_keeps_one_item_per_source_hash(tmp_path: Path) -> None
     assert len(manifest["items"]) == 1
     assert manifest["items"][0]["duplicate_count"] == 1
     assert manifest["items"][0]["duplicate_sources"][0]["repo"] == "second"
+
+
+def test_default_dedupe_uses_every_registered_manifest(tmp_path: Path) -> None:
+    corpus = _load_corpus_module()
+    expected = {
+        "build": "manifest.json",
+        "codeslaw": "codeslaw-manifest.json",
+        "codeslaw-buckets": "codeslaw-buckets-manifest.json",
+        "old-vyper-bug": "old-vyper-bug-manifest.json",
+        "smart-contract-fiesta": "smart-contract-fiesta-manifest.json",
+        "vyper-2026": "vyper-2026-manifest.json",
+        "chainsecurity": "chainsecurity-manifest.json",
+    }
+    assert expected == corpus.CORPUS_MANIFESTS
+
+    for filename in corpus.CORPUS_MANIFESTS.values():
+        (tmp_path / filename).write_text('{"items": []}', encoding="utf-8")
+
+    manifest = corpus.dedupe_manifests(None, tmp_path / "deduped-manifest.json")
+
+    assert manifest["roots"] == [str(tmp_path / filename) for filename in expected.values()]
+    assert str(tmp_path / "chainsecurity-manifest.json") in manifest["roots"]
 
 
 def test_build_corpus_uses_hash_suffixed_path_for_path_collisions(tmp_path: Path) -> None:
@@ -474,6 +500,250 @@ def test_smoke_items_keeps_limit_for_unfiltered_runs() -> None:
     ]
 
     assert corpus._smoke_items(items, None, 1) == [items[0]]
+
+
+def test_smoke_checkpoints_in_manifest_order_after_creating_parent(
+    monkeypatch, tmp_path: Path
+) -> None:
+    corpus = _load_corpus_module()
+    items = [{"index": index, "repo": "test"} for index in range(51)]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    output_path = tmp_path / "nested" / "smoke-results.json"
+
+    def fake_smoke_one(item, target_version):
+        time.sleep((len(items) - item["index"]) * 0.0005)
+        return {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": target_version,
+        }
+
+    monkeypatch.setattr(corpus, "_smoke_one", fake_smoke_one)
+
+    summary = corpus.smoke_corpus(manifest_path, output_path, "0.4.3", 8, 0)
+
+    results = json.loads(output_path.read_text(encoding="utf-8"))
+    assert [result["index"] for result in results] == list(range(51))
+    assert summary["total"] == 51
+
+
+def test_smoke_resumes_an_ordered_prefix_and_only_submits_remaining_items(
+    monkeypatch, tmp_path: Path
+) -> None:
+    corpus = _load_corpus_module()
+    items = [{"index": index, "repo": "test"} for index in range(3)]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    output_path = tmp_path / "smoke-results.json"
+    target_version = "0.4.3"
+    identity = corpus._smoke_run_identity(manifest_path, target_version, items)
+    completed = [
+        {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": target_version,
+        }
+        for item in items[:2]
+    ]
+    corpus._write_smoke_checkpoint(output_path, completed, identity)
+    submitted: list[int] = []
+
+    def fake_smoke_one(item, requested_target):
+        submitted.append(item["index"])
+        return {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": requested_target,
+        }
+
+    monkeypatch.setattr(corpus, "_smoke_one", fake_smoke_one)
+
+    summary = corpus.smoke_corpus(manifest_path, output_path, target_version, 2, 0)
+
+    assert submitted == [2]
+    results = json.loads(output_path.read_text(encoding="utf-8"))
+    assert [result["index"] for result in results] == [0, 1, 2]
+    assert summary["total"] == 3
+
+
+def test_smoke_does_not_resume_when_run_identity_changes(monkeypatch, tmp_path: Path) -> None:
+    corpus = _load_corpus_module()
+    items = [{"index": index, "repo": "test"} for index in range(2)]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    output_path = tmp_path / "smoke-results.json"
+    old_target = "0.4.2"
+    identity = corpus._smoke_run_identity(manifest_path, old_target, items)
+    corpus._write_smoke_checkpoint(
+        output_path,
+        [
+            {
+                **items[0],
+                "source_compile": "passed",
+                "target_compile": "passed",
+                "target_version": old_target,
+            }
+        ],
+        identity,
+    )
+    submitted: list[int] = []
+
+    def fake_smoke_one(item, requested_target):
+        submitted.append(item["index"])
+        return {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": requested_target,
+        }
+
+    monkeypatch.setattr(corpus, "_smoke_one", fake_smoke_one)
+
+    corpus.smoke_corpus(manifest_path, output_path, "0.4.3", 2, 0)
+
+    assert sorted(submitted) == [0, 1]
+    results = json.loads(output_path.read_text(encoding="utf-8"))
+    assert {result["target_version"] for result in results} == {"0.4.3"}
+
+
+def test_smoke_does_not_resume_results_that_are_not_an_ordered_prefix(
+    monkeypatch, tmp_path: Path
+) -> None:
+    corpus = _load_corpus_module()
+    items = [{"index": index, "repo": "test"} for index in range(2)]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    output_path = tmp_path / "smoke-results.json"
+    target_version = "0.4.3"
+    identity = corpus._smoke_run_identity(manifest_path, target_version, items)
+    corpus._write_smoke_checkpoint(
+        output_path,
+        [
+            {
+                **items[1],
+                "source_compile": "passed",
+                "target_compile": "passed",
+            }
+        ],
+        identity,
+    )
+    submitted: list[int] = []
+
+    def fake_smoke_one(item, requested_target):
+        submitted.append(item["index"])
+        return {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": requested_target,
+        }
+
+    monkeypatch.setattr(corpus, "_smoke_one", fake_smoke_one)
+
+    corpus.smoke_corpus(manifest_path, output_path, target_version, 2, 0)
+
+    assert sorted(submitted) == [0, 1]
+    results = json.loads(output_path.read_text(encoding="utf-8"))
+    assert [result["index"] for result in results] == [0, 1]
+
+
+@pytest.mark.parametrize("malformed", ["checkpoint", "output"])
+def test_smoke_malformed_resume_state_falls_back_safely(
+    malformed: str, monkeypatch, tmp_path: Path
+) -> None:
+    corpus = _load_corpus_module()
+    items = [{"index": 0, "repo": "test"}]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    output_path = tmp_path / "smoke-results.json"
+    target_version = "0.4.3"
+    identity = corpus._smoke_run_identity(manifest_path, target_version, items)
+    corpus._write_smoke_checkpoint(
+        output_path,
+        [
+            {
+                **items[0],
+                "source_compile": "passed",
+                "target_compile": "passed",
+                "target_version": target_version,
+            }
+        ],
+        identity,
+    )
+    malformed_path = (
+        corpus._checkpoint_path(output_path) if malformed == "checkpoint" else output_path
+    )
+    malformed_path.write_text("{", encoding="utf-8")
+    submitted: list[int] = []
+
+    def fake_smoke_one(item, requested_target):
+        submitted.append(item["index"])
+        return {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": requested_target,
+        }
+
+    monkeypatch.setattr(corpus, "_smoke_one", fake_smoke_one)
+
+    corpus.smoke_corpus(manifest_path, output_path, target_version, 1, 0)
+
+    assert submitted == [0]
+    assert json.loads(output_path.read_text(encoding="utf-8"))[0]["index"] == 0
+    assert json.loads(corpus._checkpoint_path(output_path).read_text(encoding="utf-8"))[
+        "completed"
+    ] == 1
+
+
+def test_atomic_json_write_keeps_existing_destination_valid_on_replace_failure(
+    monkeypatch, tmp_path: Path
+) -> None:
+    corpus = _load_corpus_module()
+    destination = tmp_path / "results.json"
+    destination.write_text('{"generation": "old"}', encoding="utf-8")
+
+    def fail_replace(source, target):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(corpus.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        corpus._atomic_write_json(destination, {"generation": "new"})
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"generation": "old"}
+    assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_atomic_json_write_preserves_existing_destination_mode(tmp_path: Path) -> None:
+    corpus = _load_corpus_module()
+    destination = tmp_path / "results.json"
+    destination.write_text('{"generation": "old"}', encoding="utf-8")
+    destination.chmod(0o640)
+
+    corpus._atomic_write_json(destination, {"generation": "new"})
+
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"generation": "new"}
+
+
+def test_atomic_json_write_new_file_uses_normal_umask_mode(tmp_path: Path) -> None:
+    corpus = _load_corpus_module()
+    destination = tmp_path / "results.json"
+    reference = tmp_path / "reference.json"
+    previous_umask = corpus.os.umask(0o027)
+    try:
+        reference.write_text("{}", encoding="utf-8")
+        corpus._atomic_write_json(destination, {"generation": "new"})
+    finally:
+        corpus.os.umask(previous_umask)
+
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+    assert stat.S_IMODE(destination.stat().st_mode) == stat.S_IMODE(reference.stat().st_mode)
 
 
 def test_smoke_uses_manifest_pragma_as_source_version(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -57,3 +57,22 @@ def test_changelog_release_notes_rejects_missing_tag() -> None:
         assert "v0.3.1" in str(exc)
     else:
         raise AssertionError("expected missing changelog section to fail")
+
+
+def test_changelog_release_notes_rejects_empty_section() -> None:
+    module = load_release_notes_module()
+    changelog = """# Changelog
+
+## 0.3.1
+
+## 0.3.0
+
+- Added the feature.
+"""
+
+    try:
+        module.changelog_release_notes(changelog, "v0.3.1")
+    except ValueError as exc:
+        assert "empty" in str(exc)
+    else:
+        raise AssertionError("expected empty changelog section to fail")

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import io
+import importlib.util
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def _load_release_preflight_module():
+    script = Path(__file__).parents[1] / "scripts" / "release_preflight.py"
+    spec = importlib.util.spec_from_file_location("vyupgrade_release_preflight_script", script)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.path.insert(0, str(script.parent))
+    try:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+release_preflight = _load_release_preflight_module()
+
+
+def _release_fixture(
+    root: Path,
+    *,
+    version: str = "1.2.3",
+    lock_version: str | None = None,
+    wheel_filename_version: str | None = None,
+    wheel_metadata_version: str | None = None,
+) -> tuple[Path, Path, Path, Path]:
+    pyproject = root / "pyproject.toml"
+    lock = root / "uv.lock"
+    changelog = root / "CHANGELOG.md"
+    dist = root / "dist"
+    pyproject.write_text(
+        f'[project]\nname = "vyupgrade"\nversion = "{version}"\n', encoding="utf-8"
+    )
+    lock.write_text(
+        "\n".join(
+            [
+                "version = 1",
+                "",
+                "[[package]]",
+                'name = "vyupgrade"',
+                f'version = "{lock_version or version}"',
+                'source = { editable = "." }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    changelog.write_text(
+        f"# Changelog\n\n## {version} - 2026-07-10\n\n- Shipped safely.\n",
+        encoding="utf-8",
+    )
+    dist.mkdir()
+
+    wheel_version = wheel_filename_version or version
+    wheel = dist / f"vyupgrade-{wheel_version}-py3-none-any.whl"
+    wheel_metadata = (
+        "Metadata-Version: 2.4\n"
+        "Name: vyupgrade\n"
+        f"Version: {wheel_metadata_version or version}\n\n"
+    )
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"vyupgrade-{wheel_version}.dist-info/METADATA", wheel_metadata.encode()
+        )
+
+    sdist = dist / f"vyupgrade-{version}.tar.gz"
+    sdist_metadata = (
+        f"Metadata-Version: 2.4\nName: vyupgrade\nVersion: {version}\n\n"
+    ).encode()
+    with tarfile.open(sdist, "w:gz") as archive:
+        member = tarfile.TarInfo(f"vyupgrade-{version}/PKG-INFO")
+        member.size = len(sdist_metadata)
+        archive.addfile(member, io.BytesIO(sdist_metadata))
+    return pyproject, lock, changelog, dist
+
+
+def test_release_preflight_validates_metadata_and_returns_notes(tmp_path: Path) -> None:
+    pyproject, lock, changelog, dist = _release_fixture(tmp_path)
+
+    notes = release_preflight.release_preflight(
+        "v1.2.3",
+        pyproject_path=pyproject,
+        lock_path=lock,
+        changelog_path=changelog,
+        dist_path=dist,
+    )
+
+    assert notes == "- Shipped safely.\n"
+
+
+def test_release_preflight_rejects_tag_and_lock_version_drift(tmp_path: Path) -> None:
+    pyproject, lock, changelog, dist = _release_fixture(tmp_path, lock_version="1.2.2")
+
+    with pytest.raises(ValueError, match=r"tag .* does not match project version"):
+        release_preflight.release_preflight(
+            "v1.2.2",
+            pyproject_path=pyproject,
+            lock_path=lock,
+            changelog_path=changelog,
+            dist_path=dist,
+        )
+
+    with pytest.raises(ValueError, match=r"project version '1.2.2' does not match '1.2.3'"):
+        release_preflight.release_preflight(
+            "v1.2.3",
+            pyproject_path=pyproject,
+            lock_path=lock,
+            changelog_path=changelog,
+            dist_path=dist,
+        )
+
+
+def test_release_preflight_rejects_artifact_filename_version_drift(tmp_path: Path) -> None:
+    pyproject, lock, changelog, dist = _release_fixture(
+        tmp_path, wheel_filename_version="1.2.2"
+    )
+
+    with pytest.raises(ValueError, match="filename has the wrong project version"):
+        release_preflight.release_preflight(
+            "v1.2.3",
+            pyproject_path=pyproject,
+            lock_path=lock,
+            changelog_path=changelog,
+            dist_path=dist,
+        )
+
+
+def test_release_preflight_rejects_artifact_metadata_version_drift(tmp_path: Path) -> None:
+    pyproject, lock, changelog, dist = _release_fixture(
+        tmp_path, wheel_metadata_version="1.2.2"
+    )
+
+    with pytest.raises(
+        ValueError, match=r"metadata version '1.2.2' does not match '1.2.3'"
+    ):
+        release_preflight.release_preflight(
+            "v1.2.3",
+            pyproject_path=pyproject,
+            lock_path=lock,
+            changelog_path=changelog,
+            dist_path=dist,
+        )
+
+
+def test_release_preflight_cli_writes_validated_notes(tmp_path: Path) -> None:
+    pyproject, lock, changelog, dist = _release_fixture(tmp_path)
+    notes_path = tmp_path / "artifacts" / "release-notes.md"
+
+    exit_code = release_preflight.main(
+        [
+            "v1.2.3",
+            "--pyproject",
+            str(pyproject),
+            "--lock",
+            str(lock),
+            "--changelog",
+            str(changelog),
+            "--dist",
+            str(dist),
+            "--notes-output",
+            str(notes_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert notes_path.read_text(encoding="utf-8") == "- Shipped safely.\n"


### PR DESCRIPTION
## What

- centralize corpus manifest names and include the ChainSecurity corpus in default deduplication
- keep concurrent smoke results in manifest order
- add crash-safe, resumable smoke checkpoints bound to the manifest hash, selected items, target version, and schema
- write results, checkpoints, and summaries atomically while preserving normal file modes
- add a release preflight that verifies tag/project/lock versions, nonempty changelog notes, wheel/sdist identities, and embedded package metadata
- pass preflighted notes through the publish workflow before PyPI and GitHub release creation
- align local and CI Ruff coverage

## Why

Corpus futures previously produced nondeterministic output and direct checkpoint writes could be truncated. Interrupted runs always restarted expensive compiler work. The publish workflow also trusted tag, changelog, lockfile, and distribution metadata to agree without one explicit gate.

## Impact

Interrupted corpus smoke runs resume only a cryptographically identified ordered prefix; stale, reordered, malformed, or mismatched state safely restarts. Release tags cannot publish unless source metadata and both built artifacts agree. The final smoke result remains a JSON list for compatibility.

## Checks

- `uv run --locked pytest` (547 passed)
- focused corpus suite (29 passed)
- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py`
- `scripts/smoke-wheel.sh` (real isolated wheel install and CLI compile smoke)
- `uv run --locked python scripts/release_preflight.py v0.4.3 --dist dist`
- `git diff --check`
