### PR TITLE
feat: make migration writes transactional

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,15 +52,31 @@ The CLI flow is:
    rule pipeline from `RULES`.
 5. Optional interface splitting generates sibling `.vyi` files when
    `--split-interfaces` is enabled and `VY120` is active.
-6. `cli._verify_rewrites()` builds a temporary target overlay, compiles migrated
+6. `write_plan.MigrationPlan` resolves every destination, rejects duplicate
+   generated outputs and pre-existing generated-file collisions, and records
+   original and candidate SHA-256 hashes.
+7. `cli._verify_rewrites()` builds a temporary target overlay, compiles migrated
    sources under the target compiler, and compares ABI, method identifiers, and
    storage layout.
-7. `validation.decide_run_validation()` turns compiler and artifact outcomes
+8. `validation.decide_run_validation()` turns compiler and artifact outcomes
    into a typed, fail-closed write decision. Rule selection and diagnostic
    version gating do not participate in this safety decision.
-8. The CLI writes in-place changes only when the validation decision passes or
-   every blocker has a matching explicit waiver; reports record the decision
-   either way.
+9. Optional formatting runs only on temporary candidate files. The exact
+   formatted bytes replace the candidates and pass through target validation
+   again before writes are allowed.
+10. The write plan stages every destination and commits it as one rollback-aware
+    transaction only when validation passes or every blocker has an explicit
+    waiver. A post-write test failure is reported and exits nonzero, but does not
+    roll back the write or any external side effects from the test command.
+
+The write transaction rechecks every planned source and no-op dependency before
+commit and checks each changed destination again immediately before replacement.
+Portable POSIX filesystems do not expose a content compare-and-swap rename, so an
+external writer that ignores coordination can still race the final check. Existing
+files are copied to staging with `copy2`, permission modes are retained, and changed
+hard-linked or read-only files are rejected. Platform-specific ownership, ACL, flag,
+or extended-attribute behavior remains filesystem dependent. An incomplete rollback
+is reported explicitly with final on-disk hashes instead of being described as clean.
 
 Important files:
 
@@ -70,6 +86,8 @@ Important files:
 - `src/vyupgrade/versions.py` owns supported Vyper versions and spec resolution.
 - `src/vyupgrade/compiler.py` owns compiler subprocesses, temporary overlays,
   dependency inference, and artifact comparison canonicalization.
+- `src/vyupgrade/write_plan.py` owns destination collision checks, candidate
+  hashes, staged replacements, and rollback on partial write failure.
 - `src/vyupgrade/analysis.py` extracts lightweight source facts for type-aware
   rules.
 - `src/vyupgrade/ast_facts.py` extracts facts from compiler AST output.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,18 @@ Target compilers must produce every requested validation output.
 The target compiler receives the exact migrated source bytes. Historical
 normalization is limited to copied dependencies in the temporary validation
 overlay and is not applied to files that would be written.
-Optional `--format mamushi` output is still produced after this validation and
-is not recompiled; post-format validation remains separate follow-up work.
+Optional `--format mamushi` runs only against temporary staged candidates. The
+formatted bytes are read back into the migration plan, compiled again under the
+target compiler, and compared before any destination is changed. Formatter
+failure leaves every original untouched.
+
+Writes recheck all planned inputs, reject generated symlinks and unsafe hard-linked
+or read-only replacements, and roll back already replaced files when a later write
+fails. Multi-file replacement is rollback-aware rather than globally atomic; a
+non-cooperating external writer can still race the final portable filesystem check.
+Reports distinguish original, validated candidate, and final on-disk hashes. If a
+post-write test command changes a planned file, the run exits nonzero and records the
+drift.
 
 Dependency inference is intentionally conservative. Exact requirements,
 ordinary version ranges, and Git dependencies are supported. Project-specific
@@ -105,8 +115,8 @@ Poetry caret requirements, are skipped; use `--compiler-search-paths`,
 - `--split-interfaces` — move top-level `interface` blocks into sibling `.vyi` files and import them.
 - `--select` / `--ignore` — comma-separated rule codes to include or exclude.
 - `--report-json PATH` — write a JSON report of fixes, diagnostics, and validation results.
-- `--format mamushi` — run `mamushi` over written files to reformat them.
-- `--test-command CMD` — run a test command after a successful write and record its result.
+- `--format mamushi` — format staged candidates, then revalidate the exact output before writing.
+- `--test-command CMD` — run a test command after a successful write, record its result, and fail when it does not pass.
 - `--enable-decimals` — treat decimals as enabled when reasoning about `0.4.x` rules.
 - `--source-vyper` / `--target-vyper` — pin the exact compiler version for each side.
 - `--source-python` / `--target-python` — pin the Python interpreter for each compiler subprocess.
@@ -147,6 +157,8 @@ allow-storage-layout-change = false
 - `5` — an error-severity diagnostic was raised.
 - `6` — the requested formatter failed or could not be run.
 - `7` — an unwaived ABI, method-identifier, or storage-layout mismatch blocked the write.
+- `8` — the post-write test command failed, timed out, or could not start.
+- `9` — migration planning or the rollback-aware write transaction failed.
 
 ## Coverage
 

--- a/src/vyupgrade/cli.py
+++ b/src/vyupgrade/cli.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import argparse
-import difflib
 import os
 import shlex
 import subprocess
 import sys
+import tempfile
 import tomllib
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -21,7 +21,15 @@ from .compiler import (
     unavailable_validation_artifacts,
 )
 from .interfaces import split_interfaces_to_vyi
-from .models import Config, Diagnostic, FileReport, RewriteResult, RunReport
+from .models import (
+    Config,
+    Diagnostic,
+    FileReport,
+    GeneratedFile,
+    RewriteResult,
+    RunReport,
+    ValidationDecision,
+)
 from .project import discover_files
 from .reporting import HumanReporter, write_json_report
 from .rule_registry import is_enabled
@@ -34,6 +42,7 @@ from .versions import (
     default_evm_version_for_spec,
     infer_pragma,
 )
+from .write_plan import MigrationPlan, PlanConflictError, WriteTransactionError
 
 
 @dataclass
@@ -96,89 +105,106 @@ def main(argv: list[str] | None = None) -> int:
         return 4
 
     files = discover_files(config.paths)
-    reports: list[FileReport] = []
-    diff_chunks: list[str] = []
-    write_back: list[tuple[Path, str]] = []
     human_reporter = None if config.diff else HumanReporter(sys.stdout)
     if human_reporter:
         human_reporter.start(config.source_version, config.target_version)
 
     rewrites = _prepare_rewrites(files, config)
-    _verify_rewrites(rewrites, config)
-    validation_decision = decide_run_validation(
-        (work.report for work in rewrites), config
-    )
-
-    for work in rewrites:
-        if work.report.changed:
-            _record_change(work.path, work.original, work.rewrite.source, write_back, diff_chunks)
-        reports.append(work.report)
-        if human_reporter:
-            human_reporter.file(work.report)
-        for generated_file in work.rewrite.generated_files:
-            previous = (
-                generated_file.path.read_text(encoding="utf-8")
-                if generated_file.path.exists()
-                else ""
-            )
-            if not _record_change(
-                generated_file.path,
-                previous,
-                generated_file.source,
-                write_back,
-                diff_chunks,
-            ):
-                continue
-            generated_report = FileReport(
-                path=generated_file.path, changed=True, fixes=[generated_file.fix]
-            )
-            reports.append(generated_report)
-            if human_reporter:
-                human_reporter.file(generated_report)
+    reports, generated_reports, plan, plan_error = _build_migration_plan(rewrites)
+    if plan_error is None:
+        _verify_rewrites(rewrites, generated_reports, config, plan)
+        validation_decision = decide_run_validation(reports, config)
+    else:
+        validation_decision = decide_run_validation((), config)
 
     run_report = RunReport(
         source_version=config.source_version,
         target_version=config.target_version,
         files=reports,
         write_requested=config.write,
-        wrote_changes=config.write and validation_decision.write_allowed,
         validation_decision=validation_decision,
         test_command=config.test_command,
     )
+    if plan_error is not None:
+        run_report.write_status = "failed"
+        run_report.write_output = plan_error
 
+    if config.write and plan_error is None and validation_decision.write_allowed:
+        if config.format == "mamushi" and plan.writes:
+            _run_mamushi(plan, run_report)
+            if run_report.formatter_status == "passed":
+                _verify_rewrites(rewrites, generated_reports, config, plan)
+                validation_decision = decide_run_validation(reports, config)
+                run_report.validation_decision = validation_decision
+                if not validation_decision.write_allowed:
+                    run_report.write_status = "blocked"
+                    run_report.write_output = (
+                        "formatted candidates did not pass final validation"
+                    )
+            else:
+                run_report.write_status = "failed"
+                run_report.write_output = "formatter failed before the write transaction"
+        if (
+            run_report.formatter_status != "failed"
+            and validation_decision.write_allowed
+        ):
+            try:
+                run_report.wrote_changes = plan.commit()
+                run_report.write_status = (
+                    "committed" if run_report.wrote_changes else "no-op"
+                )
+                run_report.wrote_changes, _mismatches = plan.refresh_final_state()
+            except WriteTransactionError as exc:
+                changed, mismatches = plan.refresh_final_state()
+                run_report.wrote_changes = changed
+                run_report.write_status = (
+                    "rollback-incomplete" if exc.rollback_incomplete else "failed"
+                )
+                run_report.write_output = str(exc)
+                if mismatches:
+                    run_report.write_output += "; on-disk bytes differ from candidates: " + ", ".join(
+                        str(path) for path in mismatches
+                    )
+
+    diff_chunks = plan.diff_chunks()
     if config.diff and diff_chunks:
         _write_diff(diff_chunks, sys.stdout)
-
-    if config.write and validation_decision.write_allowed:
-        for path, content in write_back:
-            path.write_text(content, encoding="utf-8")
-        if config.format == "mamushi" and write_back:
-            _run_mamushi([path for path, _ in write_back], run_report)
-
-    formatter_failed = run_report.formatter_status == "failed"
 
     if (
         config.test_command
         and config.write
         and validation_decision.write_allowed
-        and not formatter_failed
+        and run_report.write_status in {"committed", "no-op"}
     ):
-        proc = subprocess.run(
-            config.test_command, shell=True, capture_output=True, text=True, timeout=600
-        )
-        run_report.test_status = "passed" if proc.returncode == 0 else "failed"
-        run_report.test_output = (proc.stdout + proc.stderr).strip()
+        _run_test_command(config.test_command, run_report)
+        run_report.wrote_changes, mismatches = plan.refresh_final_state()
+        if mismatches:
+            drift = "test command changed planned destinations: " + ", ".join(
+                str(path) for path in mismatches
+            )
+            run_report.test_status = "failed"
+            run_report.test_output = "\n".join(
+                part for part in (run_report.test_output, drift) if part
+            )
 
     if config.report_json:
         write_json_report(config.report_json, run_report)
 
     if human_reporter:
+        for report in reports:
+            human_reporter.file(report)
         human_reporter.summary(run_report)
 
+    if run_report.write_status in {"failed", "rollback-incomplete"}:
+        if run_report.formatter_status == "failed":
+            return 6
+        return 9
     if (exit_code := validation_exit_code(validation_decision)) is not None:
         return exit_code
-    if formatter_failed:
+    if run_report.formatter_status == "failed":
         return 6
+    if run_report.test_status == "failed":
+        return 8
     if config.check and any(file.changed for file in reports):
         return 1
     if any(diag.severity == "error" for file in reports for diag in file.diagnostics):
@@ -189,7 +215,7 @@ def main(argv: list[str] | None = None) -> int:
 def _prepare_rewrites(files: list[Path], config: Config) -> list[RewriteWork]:
     rewrites: list[RewriteWork] = []
     for path in files:
-        original = path.read_text(encoding="utf-8")
+        original = path.read_bytes().decode("utf-8")
         source_version = config.source_version or infer_pragma(original)
         context = MigrationContext.from_specs(source_version, config.target_version)
         if context.source_newer_than_target():
@@ -265,28 +291,37 @@ def _prepare_rewrites(files: list[Path], config: Config) -> list[RewriteWork]:
     return rewrites
 
 
-def _verify_rewrites(rewrites: list[RewriteWork], config: Config) -> None:
-    target_sources = {work.path: work.rewrite.source for work in rewrites}
+def _verify_rewrites(
+    rewrites: list[RewriteWork],
+    generated_reports: list[tuple[GeneratedFile, FileReport]],
+    config: Config,
+    plan: MigrationPlan,
+) -> None:
+    target_sources = {
+        work.path: plan.candidate_source(work.path, work.rewrite.source)
+        for work in rewrites
+    }
     for work in rewrites:
         target_sources.update(
             {
-                generated_file.path: generated_file.source
+                generated_file.path: plan.candidate_source(
+                    generated_file.path, generated_file.source
+                )
                 for generated_file in work.rewrite.generated_files
             }
         )
+    for generated_file, report in generated_reports:
+        target_sources[report.path] = plan.candidate_source(
+            report.path, generated_file.source
+        )
     with target_overlay(target_sources, config.target_version, config.compiler_search_paths) as overlay:
         for work in rewrites:
+            _reset_target_validation(work.report)
             if any(diagnostic.rule == "VYD016" for diagnostic in work.report.diagnostics):
                 continue
-            target_compile = compile_target_source(work.path, work.rewrite.source, config, overlay)
-            work.report.target_compile = target_compile.status
-            work.report.target_unavailable_artifacts = unavailable_validation_artifacts(
-                target_compile
-            )
-            work.report.target_unavailable_formats = list(target_compile.unavailable_formats)
-            work.report.target_error = (
-                target_compile.stderr if target_compile.status == "failed" else None
-            )
+            target_source = target_sources[work.path]
+            target_compile = compile_target_source(work.path, target_source, config, overlay)
+            _record_target_compile(work.report, target_compile)
             abi_equal, method_ids_equal, storage_layout_equal = compare_artifacts(
                 work.source_compile, target_compile
             )
@@ -303,6 +338,43 @@ def _verify_rewrites(rewrites: list[RewriteWork], config: Config) -> None:
             _add_validation_diagnostics(
                 work.report, work.source_version, config, work.source_compiler
             )
+        for _generated_file, report in generated_reports:
+            _reset_target_validation(report)
+            target_compile = compile_target_source(
+                report.path,
+                target_sources[report.path],
+                config,
+                overlay,
+            )
+            _record_target_compile(report, target_compile)
+
+
+def _record_target_compile(report: FileReport, target_compile: CompileResult) -> None:
+    report.target_compile = target_compile.status
+    report.target_unavailable_artifacts = unavailable_validation_artifacts(target_compile)
+    report.target_unavailable_formats = list(target_compile.unavailable_formats)
+    report.target_error = (
+        target_compile.stderr if target_compile.status == "failed" else None
+    )
+
+
+def _reset_target_validation(report: FileReport) -> None:
+    report.target_compile = "skipped"
+    report.target_unavailable_artifacts.clear()
+    report.target_unavailable_formats.clear()
+    report.target_error = None
+    report.abi_equal = None
+    report.method_ids_equal = None
+    report.storage_layout_equal = None
+    report.abi_diff.clear()
+    report.method_id_diff.clear()
+    report.storage_layout_diff.clear()
+    report.validation_decision = ValidationDecision()
+    report.diagnostics = [
+        diagnostic
+        for diagnostic in report.diagnostics
+        if diagnostic.rule not in {"VYD006", "VYD007", "VYD008", "VYD009"}
+    ]
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -334,25 +406,40 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _record_change(
-    path: Path,
-    previous: str,
-    current: str,
-    write_back: list[tuple[Path, str]],
-    diff_chunks: list[str],
-) -> bool:
-    if previous == current:
-        return False
-    write_back.append((path, current))
-    diff_chunks.extend(
-        difflib.unified_diff(
-            previous.splitlines(keepends=True),
-            current.splitlines(keepends=True),
-            fromfile=str(path),
-            tofile=str(path),
-        )
-    )
-    return True
+def _build_migration_plan(
+    rewrites: list[RewriteWork],
+) -> tuple[
+    list[FileReport],
+    list[tuple[GeneratedFile, FileReport]],
+    MigrationPlan,
+    str | None,
+]:
+    reports = [work.report for work in rewrites]
+    generated_reports: list[tuple[GeneratedFile, FileReport]] = []
+    for work in rewrites:
+        for generated_file in work.rewrite.generated_files:
+            generated_report = FileReport(
+                path=generated_file.path,
+                changed=True,
+                fixes=[generated_file.fix],
+            )
+            reports.append(generated_report)
+            generated_reports.append((generated_file, generated_report))
+
+    plan = MigrationPlan()
+    try:
+        for work in rewrites:
+            plan.add_source(
+                work.path,
+                work.original,
+                work.rewrite.source,
+                work.report,
+            )
+        for generated_file, report in generated_reports:
+            plan.add_generated(generated_file.path, generated_file.source, report)
+    except PlanConflictError as exc:
+        return reports, generated_reports, plan, str(exc)
+    return reports, generated_reports, plan, None
 
 
 def _write_diff(diff_chunks: list[str], stream: TextIO) -> None:
@@ -500,35 +587,110 @@ def _evm_default_diagnostic(source_version: str | None, target_version: str) -> 
     return Diagnostic("VYD009", 1, message)
 
 
-def _run_mamushi(paths: list[Path], report: RunReport) -> None:
-    command = ["mamushi", *map(str, paths)]
-    report.formatter_command = shlex.join(command)
+def _run_mamushi(plan: MigrationPlan, report: RunReport) -> None:
+    with tempfile.TemporaryDirectory(prefix="vyupgrade-format-") as raw_directory:
+        directory = Path(raw_directory)
+        staged: dict[Path, Path] = {}
+        try:
+            common_parent = Path(
+                os.path.commonpath([str(entry.path.parent) for entry in plan.writes])
+            )
+            for entry in plan.writes:
+                staged_path = directory / entry.path.relative_to(common_parent)
+                staged_path.parent.mkdir(parents=True, exist_ok=True)
+                staged_path.write_bytes(entry.candidate)
+                staged[entry.path] = staged_path
+        except OSError as exc:
+            report.formatter_status = "failed"
+            report.formatter_output = f"could not stage formatter inputs: {exc}"
+            return
+
+        command = ["mamushi", *map(str, staged.values())]
+        report.formatter_command = shlex.join(command)
+        try:
+            proc = subprocess.run(command, capture_output=True, text=True, timeout=120)
+        except FileNotFoundError:
+            report.formatter_status = "failed"
+            report.formatter_output = "mamushi executable not found"
+            return
+        except subprocess.TimeoutExpired as exc:
+            report.formatter_status = "failed"
+            output = _command_output(exc.stdout, exc.stderr)
+            report.formatter_output = "\n".join(
+                part
+                for part in (
+                    f"mamushi timed out after {exc.timeout:g} seconds",
+                    output,
+                )
+                if part
+            )
+            return
+        except OSError as exc:
+            report.formatter_status = "failed"
+            report.formatter_output = f"mamushi failed to start: {exc}"
+            return
+
+        report.formatter_status = "passed" if proc.returncode == 0 else "failed"
+        output = _command_output(proc.stdout, proc.stderr)
+        if proc.returncode != 0:
+            report.formatter_output = "\n".join(
+                part
+                for part in (
+                    f"mamushi exited with status {proc.returncode}",
+                    output,
+                )
+                if part
+            )
+            return
+
+        try:
+            formatted = {
+                destination: staged_path.read_bytes()
+                for destination, staged_path in staged.items()
+            }
+            for candidate in formatted.values():
+                candidate.decode("utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            report.formatter_status = "failed"
+            report.formatter_output = f"could not read formatted candidates: {exc}"
+            return
+        plan.update_candidates(formatted)
+        report.formatter_output = output or None
+
+
+def _run_test_command(command: str, report: RunReport) -> None:
     try:
-        proc = subprocess.run(command, capture_output=True, text=True, timeout=120)
-    except FileNotFoundError:
-        report.formatter_status = "failed"
-        report.formatter_output = "mamushi executable not found"
-        return
+        proc = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
     except subprocess.TimeoutExpired as exc:
-        report.formatter_status = "failed"
+        report.test_status = "failed"
         output = _command_output(exc.stdout, exc.stderr)
-        report.formatter_output = "\n".join(
-            part for part in (f"mamushi timed out after {exc.timeout:g} seconds", output) if part
+        report.test_output = "\n".join(
+            part
+            for part in (f"test command timed out after {exc.timeout:g} seconds", output)
+            if part
         )
         return
     except OSError as exc:
-        report.formatter_status = "failed"
-        report.formatter_output = f"mamushi failed to start: {exc}"
+        report.test_status = "failed"
+        report.test_output = f"test command failed to start: {exc}"
         return
 
-    report.formatter_status = "passed" if proc.returncode == 0 else "failed"
+    report.test_status = "passed" if proc.returncode == 0 else "failed"
     output = _command_output(proc.stdout, proc.stderr)
-    if proc.returncode != 0:
-        report.formatter_output = "\n".join(
-            part for part in (f"mamushi exited with status {proc.returncode}", output) if part
-        )
+    if proc.returncode == 0:
+        report.test_output = output or None
     else:
-        report.formatter_output = output or None
+        report.test_output = "\n".join(
+            part
+            for part in (f"test command exited with status {proc.returncode}", output)
+            if part
+        )
 
 
 def _command_output(stdout: str | bytes | None, stderr: str | bytes | None) -> str:

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -106,6 +106,10 @@ class FileReport:
     source_unavailable_formats: list[str] = field(default_factory=list)
     target_unavailable_formats: list[str] = field(default_factory=list)
     validation_decision: ValidationDecision = field(default_factory=ValidationDecision)
+    original_sha256: str | None = None
+    candidate_sha256: str | None = None
+    final_sha256: str | None = None
+    final_matches_candidate: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -143,6 +147,8 @@ class RunReport:
     files: list[FileReport]
     write_requested: bool = False
     wrote_changes: bool = False
+    write_status: str = "skipped"
+    write_output: str | None = None
     validation_decision: ValidationDecision = field(default_factory=ValidationDecision)
     formatter_command: str | None = None
     formatter_status: str = "skipped"
@@ -169,11 +175,17 @@ class RunReport:
             "target_version": self.target_version,
             "write_requested": self.write_requested,
             "wrote_changes": self.wrote_changes,
+            "write_status": self.write_status,
+            "write_output": self.write_output,
             "validation_decision": self.validation_decision.to_json_obj(),
             "files": [
                 {
                     "path": str(file.path),
                     "changed": file.changed,
+                    "original_sha256": file.original_sha256,
+                    "candidate_sha256": file.candidate_sha256,
+                    "final_sha256": file.final_sha256,
+                    "final_matches_candidate": file.final_matches_candidate,
                     "fixes": [fix.__dict__ for fix in file.fixes],
                     "diagnostics": [diag.__dict__ for diag in file.diagnostics],
                     "validation": {

--- a/src/vyupgrade/reporting.py
+++ b/src/vyupgrade/reporting.py
@@ -143,6 +143,14 @@ def _render_text_file(file: FileReport) -> str:
         if equal is not None:
             lines.append(f"  {label}: {equal}")
             lines.extend(f"    {line}" for line in diff)
+    if file.original_sha256 is not None:
+        lines.append(f"  original SHA-256: {file.original_sha256}")
+    if file.candidate_sha256 is not None:
+        lines.append(f"  candidate SHA-256: {file.candidate_sha256}")
+    if file.final_sha256 is not None:
+        lines.append(f"  final SHA-256: {file.final_sha256}")
+    if file.final_matches_candidate is not None:
+        lines.append(f"  final bytes match candidate: {file.final_matches_candidate}")
     lines.append(f"  validation decision: {file.validation_decision.status}")
     lines.extend(
         f"  validation blocker: {issue.message}" for issue in file.validation_decision.blockers
@@ -168,6 +176,10 @@ def _render_text_summary(report: RunReport) -> str:
         lines.append(f"validation waivers: {', '.join(waiver_flags)}")
     if not report.write_requested and report.changed_count:
         lines.append("run with --write to apply these changes")
+    if report.write_status != "skipped":
+        lines.append(f"write transaction: {report.write_status}")
+        if report.write_output:
+            lines.append(report.write_output.rstrip())
     if report.formatter_command:
         lines.append(f"formatter: {report.formatter_status}")
         if report.formatter_output:
@@ -205,6 +217,16 @@ def _render_summary(console: Console, report: RunReport) -> None:
         console.print(_label_value("validation waivers", ", ".join(waiver_flags), "vy.warning"))
     if not report.write_requested and report.changed_count:
         console.print(Text("run with --write to apply these changes", style="vy.muted"))
+    if report.write_status != "skipped":
+        console.print(
+            _label_value(
+                "write transaction",
+                report.write_status,
+                _status_style(report.write_status),
+            )
+        )
+        if report.write_output:
+            console.print(report.write_output.rstrip())
     if report.formatter_command:
         console.print(
             _label_value(
@@ -252,6 +274,16 @@ def _render_file(console: Console, file: FileReport) -> None:
         if equal is not None:
             console.print(_bool_line(label, equal))
             _render_detail_lines(console, diff)
+    if file.original_sha256 is not None:
+        console.print(_indented(f"original SHA-256: {file.original_sha256}", "vy.muted"))
+    if file.candidate_sha256 is not None:
+        console.print(_indented(f"candidate SHA-256: {file.candidate_sha256}", "vy.muted"))
+    if file.final_sha256 is not None:
+        console.print(_indented(f"final SHA-256: {file.final_sha256}", "vy.muted"))
+    if file.final_matches_candidate is not None:
+        console.print(
+            _bool_line("final bytes match candidate", file.final_matches_candidate)
+        )
     console.print(
         _label_value(
             "  validation decision",
@@ -376,6 +408,9 @@ def _status_style(status: str) -> str:
         "passed": "vy.success",
         "waived": "vy.warning",
         "blocked": "vy.error",
+        "rollback-incomplete": "vy.error",
+        "committed": "vy.success",
+        "no-op": "vy.muted",
         "not-required": "vy.muted",
         "degraded": "vy.warning",
         "failed": "vy.error",

--- a/src/vyupgrade/write_plan.py
+++ b/src/vyupgrade/write_plan.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import difflib
+import hashlib
+import os
+import shutil
+import stat
+import uuid
+from collections.abc import Iterable
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .models import FileReport
+
+
+class PlanConflictError(ValueError):
+    """Raised when two migration outputs cannot safely share a destination."""
+
+
+class WriteTransactionError(OSError):
+    """Raised when a planned write cannot be committed or fully rolled back."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        rollback_incomplete: bool = False,
+        affected_paths: tuple[Path, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.rollback_incomplete = rollback_incomplete
+        self.affected_paths = affected_paths
+
+
+@dataclass
+class PlannedWrite:
+    path: Path
+    original: bytes | None
+    candidate: bytes
+    mode: int | None
+    generated: bool
+    reports: list[FileReport] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        return self.original != self.candidate
+
+
+class MigrationPlan:
+    """A collision-checked, content-addressed set of migration destinations."""
+
+    def __init__(self) -> None:
+        self._entries: dict[Path, PlannedWrite] = {}
+        self._generated_destinations: set[Path] = set()
+
+    @property
+    def entries(self) -> tuple[PlannedWrite, ...]:
+        return tuple(self._entries.values())
+
+    @property
+    def writes(self) -> tuple[PlannedWrite, ...]:
+        return tuple(entry for entry in self._entries.values() if entry.changed)
+
+    def add_source(
+        self,
+        path: Path,
+        original: str,
+        candidate: str,
+        report: FileReport,
+    ) -> None:
+        destination = path.resolve()
+        if destination in self._entries:
+            raise PlanConflictError(f"duplicate migration destination: {destination}")
+        try:
+            original_bytes, source_stat = _snapshot_existing(destination)
+        except OSError as exc:
+            raise PlanConflictError(
+                f"could not snapshot migration source {destination}: {exc}"
+            ) from exc
+        expected = original.encode("utf-8")
+        if original_bytes != expected:
+            raise PlanConflictError(
+                f"migration source changed while planning: {destination}"
+            )
+        candidate_bytes = candidate.encode("utf-8")
+        if original_bytes != candidate_bytes:
+            _require_replaceable_regular_file(destination, source_stat)
+        entry = PlannedWrite(
+            destination,
+            original_bytes,
+            candidate_bytes,
+            stat.S_IMODE(source_stat.st_mode),
+            False,
+            [report],
+        )
+        self._entries[destination] = entry
+        self._refresh_entry_reports(entry)
+
+    def add_generated(self, path: Path, candidate: str, report: FileReport) -> None:
+        try:
+            lexical_stat = path.lstat()
+        except FileNotFoundError:
+            lexical_stat = None
+        except OSError as exc:
+            raise PlanConflictError(
+                f"could not inspect generated destination {path}: {exc}"
+            ) from exc
+        if lexical_stat is not None and stat.S_ISLNK(lexical_stat.st_mode):
+            raise PlanConflictError(
+                f"generated destination may not be a symbolic link: {path}"
+            )
+
+        destination = path.resolve()
+        candidate_bytes = candidate.encode("utf-8")
+        if destination in self._generated_destinations:
+            raise PlanConflictError(f"duplicate generated destination: {destination}")
+        self._generated_destinations.add(destination)
+
+        existing_entry = self._entries.get(destination)
+        if existing_entry is not None:
+            if existing_entry.changed or existing_entry.original != candidate_bytes:
+                raise PlanConflictError(
+                    f"generated destination collides with a migration source: {destination}"
+                )
+            existing_entry.reports.append(report)
+            self._refresh_entry_reports(existing_entry)
+            return
+
+        try:
+            original, destination_stat = _snapshot_existing(destination)
+        except FileNotFoundError:
+            original = None
+            destination_stat = None
+        except OSError as exc:
+            raise PlanConflictError(
+                f"could not inspect generated destination {destination}: {exc}"
+            ) from exc
+        if original is not None:
+            assert destination_stat is not None
+            if original != candidate_bytes:
+                raise PlanConflictError(
+                    "generated destination already exists with different content: "
+                    f"{destination}"
+                )
+            mode = stat.S_IMODE(destination_stat.st_mode)
+        else:
+            mode = None
+
+        entry = PlannedWrite(
+            destination,
+            original,
+            candidate_bytes,
+            mode,
+            True,
+            [report],
+        )
+        self._entries[destination] = entry
+        self._refresh_entry_reports(entry)
+
+    def candidate_source(self, path: Path, fallback: str) -> str:
+        entry = self._entries.get(path.resolve())
+        if entry is None:
+            return fallback
+        return entry.candidate.decode("utf-8")
+
+    def update_candidates(self, candidates: dict[Path, bytes]) -> None:
+        for path, candidate in candidates.items():
+            entry = self._entries[path.resolve()]
+            candidate.decode("utf-8")
+            entry.candidate = candidate
+            self._refresh_entry_reports(entry)
+
+    def diff_chunks(self) -> list[str]:
+        chunks: list[str] = []
+        for entry in self.writes:
+            previous = b"" if entry.original is None else entry.original
+            chunks.extend(
+                difflib.unified_diff(
+                    previous.decode("utf-8").splitlines(keepends=True),
+                    entry.candidate.decode("utf-8").splitlines(keepends=True),
+                    fromfile=str(entry.path),
+                    tofile=str(entry.path),
+                )
+            )
+        return chunks
+
+    def commit(self) -> bool:
+        entries = self.entries
+        self._assert_destinations_unchanged(entries)
+        writes = self.writes
+        if not writes:
+            return False
+
+        staged: dict[Path, Path] = {}
+        try:
+            for entry in writes:
+                staged[entry.path] = _stage_replacement(entry)
+        except OSError as exc:
+            _cleanup_staged(staged.values())
+            raise WriteTransactionError(f"could not stage migration writes: {exc}") from exc
+
+        committed: list[PlannedWrite] = []
+        try:
+            self._assert_destinations_unchanged(entries)
+            for entry in writes:
+                self._assert_destinations_unchanged((entry,))
+                os.replace(staged[entry.path], entry.path)
+                committed.append(entry)
+        except OSError as exc:
+            rollback_errors = _rollback(committed)
+            _cleanup_staged(staged.values())
+            if rollback_errors:
+                self.refresh_final_state()
+                affected = self.paths_differing_from_original()
+                detail = (
+                    f"migration write failed and rollback was incomplete: {exc}; "
+                    "rollback errors: " + "; ".join(rollback_errors)
+                )
+                raise WriteTransactionError(
+                    detail,
+                    rollback_incomplete=True,
+                    affected_paths=tuple(affected),
+                ) from exc
+            raise WriteTransactionError(
+                f"migration write failed; all committed destinations were restored: {exc}"
+            ) from exc
+
+        _cleanup_staged(staged.values())
+        return True
+
+    def _assert_destinations_unchanged(
+        self, writes: tuple[PlannedWrite, ...]
+    ) -> None:
+        for entry in writes:
+            try:
+                current = _read_regular_file_or_missing(entry.path)
+            except OSError as exc:
+                raise WriteTransactionError(
+                    f"could not recheck migration destination {entry.path}: {exc}"
+                ) from exc
+            if current != entry.original:
+                raise WriteTransactionError(
+                    f"migration destination changed before commit: {entry.path}"
+                )
+
+    def refresh_final_state(self) -> tuple[bool, list[Path]]:
+        """Refresh on-disk hashes and return whether anything differs from the plan."""
+        differs_from_original = False
+        differs_from_candidate: list[Path] = []
+        for entry in self.entries:
+            try:
+                current = _read_regular_file_or_missing(entry.path)
+                readable = True
+            except OSError:
+                current = None
+                readable = False
+            final_sha256 = _sha256(current) if current is not None else None
+            final_matches_candidate = readable and current == entry.candidate
+            differs_from_original = (
+                differs_from_original or not readable or current != entry.original
+            )
+            if not final_matches_candidate:
+                differs_from_candidate.append(entry.path)
+            for report in entry.reports:
+                report.final_sha256 = final_sha256
+                report.final_matches_candidate = final_matches_candidate
+        return differs_from_original, differs_from_candidate
+
+    def paths_differing_from_original(self) -> list[Path]:
+        affected: list[Path] = []
+        for entry in self.entries:
+            try:
+                current = _read_regular_file_or_missing(entry.path)
+            except OSError:
+                affected.append(entry.path)
+                continue
+            if current != entry.original:
+                affected.append(entry.path)
+        return affected
+
+    @staticmethod
+    def _refresh_entry_reports(entry: PlannedWrite) -> None:
+        original_sha256 = (
+            _sha256(entry.original) if entry.original is not None else None
+        )
+        candidate_sha256 = _sha256(entry.candidate)
+        for report in entry.reports:
+            report.changed = entry.changed
+            report.original_sha256 = original_sha256
+            report.candidate_sha256 = candidate_sha256
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _stage_replacement(entry: PlannedWrite) -> Path:
+    staged = entry.path.with_name(
+        f".{entry.path.name}.vyupgrade-{os.getpid()}-{uuid.uuid4().hex}"
+    )
+    try:
+        if entry.mode is None:
+            descriptor = os.open(
+                staged,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o666,
+            )
+        else:
+            shutil.copy2(entry.path, staged)
+            descriptor = os.open(staged, os.O_WRONLY | os.O_TRUNC)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(entry.candidate)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except BaseException:
+        staged.unlink(missing_ok=True)
+        raise
+    return staged
+
+
+def _rollback(committed: list[PlannedWrite]) -> list[str]:
+    errors: list[str] = []
+    for entry in reversed(committed):
+        try:
+            if entry.original is None:
+                entry.path.unlink(missing_ok=True)
+                continue
+            rollback_entry = PlannedWrite(
+                entry.path,
+                entry.candidate,
+                entry.original,
+                entry.mode,
+                entry.generated,
+            )
+            staged = _stage_replacement(rollback_entry)
+            try:
+                os.replace(staged, entry.path)
+            finally:
+                staged.unlink(missing_ok=True)
+        except OSError as exc:
+            errors.append(f"{entry.path}: {exc}")
+    return errors
+
+
+def _cleanup_staged(paths: Iterable[Path]) -> None:
+    for path in paths:
+        with suppress(OSError):
+            Path(path).unlink(missing_ok=True)
+
+
+def _snapshot_existing(path: Path) -> tuple[bytes, os.stat_result]:
+    before = path.lstat()
+    if stat.S_ISLNK(before.st_mode):
+        raise OSError("destination is a symbolic link")
+    if not stat.S_ISREG(before.st_mode):
+        raise OSError("destination is not a regular file")
+    content = path.read_bytes()
+    after = path.lstat()
+    if _stat_identity(before) != _stat_identity(after):
+        raise OSError("destination changed while it was being read")
+    return content, after
+
+
+def _stat_identity(value: os.stat_result) -> tuple[int, ...]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _require_replaceable_regular_file(path: Path, value: os.stat_result) -> None:
+    if not stat.S_ISREG(value.st_mode):
+        raise PlanConflictError(f"migration destination is not a regular file: {path}")
+    if value.st_nlink != 1:
+        raise PlanConflictError(
+            f"migration destination has {value.st_nlink} hard links and cannot be replaced safely: {path}"
+        )
+    if stat.S_IMODE(value.st_mode) & 0o222 == 0:
+        raise PlanConflictError(f"migration destination is read-only: {path}")
+
+
+def _read_regular_file_or_missing(path: Path) -> bytes | None:
+    try:
+        content, _value = _snapshot_existing(path)
+    except FileNotFoundError:
+        return None
+    return content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import hashlib
+import subprocess
 from io import StringIO
 from pathlib import Path
 
@@ -9,7 +11,7 @@ import pytest
 from vyupgrade import cli
 from vyupgrade.cli import _add_validation_diagnostics, _evm_default_diagnostic, _write_diff, main
 from vyupgrade.compiler import CompileResult
-from vyupgrade.models import Config, FileReport
+from vyupgrade.models import Config, Diagnostic, FileReport
 
 
 VALIDATION_ARTIFACTS = {"abi": [], "method_identifiers": {}, "layout": {}}
@@ -222,12 +224,14 @@ def __init__():
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
+    original = contract.read_text(encoding="utf-8")
     code = main([str(contract), "--write", "--format", "mamushi", "--report-json", str(report)])
 
     assert code == 6
-    assert "#pragma version 0.4.3" in contract.read_text(encoding="utf-8")
+    assert contract.read_text(encoding="utf-8") == original
     data = json.loads(report.read_text())
-    assert data["wrote_changes"] is True
+    assert data["wrote_changes"] is False
+    assert data["write_status"] == "failed"
     assert data["formatter_status"] == "failed"
     assert data["formatter_output"] == "mamushi executable not found"
     assert data["test_status"] == "skipped"
@@ -247,6 +251,7 @@ def __init__():
         encoding="utf-8",
     )
     report = tmp_path / "report.json"
+    original = contract.read_text(encoding="utf-8")
 
     def fake_run(command, **kwargs):
         assert command[0] == "mamushi"
@@ -268,13 +273,317 @@ def __init__():
     )
 
     assert code == 6
+    assert contract.read_text(encoding="utf-8") == original
     data = json.loads(report.read_text())
+    assert data["wrote_changes"] is False
     assert data["formatter_command"].startswith("mamushi ")
     assert data["formatter_status"] == "failed"
     assert data["formatter_output"] == (
         "mamushi exited with status 2\nformatted stdout\nformatted stderr"
     )
     assert data["test_status"] == "skipped"
+
+
+def test_write_mode_reports_timed_out_mamushi_without_mutation(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, 120, output="partial output")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    code = main(
+        [str(contract), "--write", "--format", "mamushi", "--report-json", str(report)]
+    )
+
+    assert code == 6
+    assert contract.read_text(encoding="utf-8") == original
+    data = json.loads(report.read_text())
+    assert data["wrote_changes"] is False
+    assert data["formatter_status"] == "failed"
+    assert "mamushi timed out after 120 seconds" in data["formatter_output"]
+
+
+def test_formatter_runs_on_staged_candidates_and_final_bytes_are_revalidated(
+    tmp_path: Path, monkeypatch, capsys, passing_compiler
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+    compiled: list[str] = []
+    original_apply_rules = cli.apply_rules
+
+    def apply_rules_with_diagnostic(source, config, path):
+        result = original_apply_rules(source, config, path)
+        result.diagnostics.append(Diagnostic("TEST001", 1, "preserve this diagnostic"))
+        return result
+
+    def compile_target_source(path, source, config, overlay=None):
+        compiled.append(source)
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    def fake_run(command, **kwargs):
+        assert command[0] == "mamushi"
+        assert all(Path(path).resolve() != contract.resolve() for path in command[1:])
+        staged = Path(command[1])
+        assert staged.name == contract.name
+        staged.write_text(staged.read_text(encoding="utf-8") + "# formatted\n", encoding="utf-8")
+        return cli.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(cli, "apply_rules", apply_rules_with_diagnostic)
+    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--diff",
+            "--format",
+            "mamushi",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 0
+    assert len(compiled) == 2
+    assert "# formatted" not in compiled[0]
+    assert compiled[1].endswith("# formatted\n")
+    final = contract.read_bytes()
+    assert final.endswith(b"# formatted\n")
+    assert "+# formatted" in capsys.readouterr().out
+    data = json.loads(report.read_text())
+    assert data["files"][0]["candidate_sha256"] == hashlib.sha256(final).hexdigest()
+    assert data["files"][0]["final_sha256"] == hashlib.sha256(final).hexdigest()
+    assert data["files"][0]["final_matches_candidate"] is True
+    diagnostics = data["files"][0]["diagnostics"]
+    assert [item["rule"] for item in diagnostics].count("TEST001") == 1
+    assert [item["rule"] for item in diagnostics].count("VYD009") == 1
+
+
+def test_formatter_output_that_fails_final_validation_is_not_committed(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    def compile_target_source(path, source, config, overlay=None):
+        if "# formatter-broke-source" in source:
+            return CompileResult("failed", stderr="formatted candidate failed")
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    def fake_run(command, **kwargs):
+        staged = Path(command[1])
+        staged.write_text(
+            staged.read_text(encoding="utf-8") + "# formatter-broke-source\n",
+            encoding="utf-8",
+        )
+        return cli.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    code = main(
+        [str(contract), "--write", "--format", "mamushi", "--report-json", str(report)]
+    )
+
+    assert code == 2
+    assert contract.read_text(encoding="utf-8") == original
+    data = json.loads(report.read_text())
+    assert data["wrote_changes"] is False
+    assert data["write_status"] == "blocked"
+    assert data["formatter_status"] == "passed"
+    assert data["validation_decision"]["blockers"][0]["code"] == "target_compile_failed"
+
+
+def test_formatted_generated_interface_bytes_are_revalidated(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "Main.vy"
+    original = """#pragma version 0.4.3
+
+interface Token:
+    def balanceOf(owner: address) -> uint256: view
+"""
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+    compiled_interfaces: list[str] = []
+
+    def compile_target(path, source, config, overlay=None):
+        if path.suffix == ".vyi":
+            compiled_interfaces.append(source)
+            if "# broken generated interface" in source:
+                return CompileResult("failed", stderr="formatted interface failed")
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    def break_staged_interface(command, **kwargs):
+        interface = next(Path(path) for path in command[1:] if str(path).endswith(".vyi"))
+        interface.write_text(
+            interface.read_text(encoding="utf-8") + "# broken generated interface\n",
+            encoding="utf-8",
+        )
+        return cli.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(cli, "compile_target_source", compile_target)
+    monkeypatch.setattr(cli.subprocess, "run", break_staged_interface)
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--split-interfaces",
+            "--format",
+            "mamushi",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 2
+    assert contract.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "Token.vyi").exists()
+    assert len(compiled_interfaces) == 2
+    assert "# broken generated interface" not in compiled_interfaces[0]
+    assert "# broken generated interface" in compiled_interfaces[1]
+    data = json.loads(report.read_text())
+    assert data["write_status"] == "blocked"
+
+
+def test_post_write_test_failure_returns_nonzero_and_persists_report(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda command, **kwargs: cli.subprocess.CompletedProcess(
+            command, 2, "test stdout", "test stderr"
+        ),
+    )
+
+    code = main(
+        [str(contract), "--write", "--test-command", "false", "--report-json", str(report)]
+    )
+
+    assert code == 8
+    assert "#pragma version 0.4.3" in contract.read_text(encoding="utf-8")
+    data = json.loads(report.read_text())
+    assert data["wrote_changes"] is True
+    assert data["test_status"] == "failed"
+    assert data["test_output"] == "test command exited with status 2\ntest stdout\ntest stderr"
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        (
+            subprocess.TimeoutExpired("tests", 600, output="partial"),
+            "test command timed out after 600 seconds",
+        ),
+        (OSError("shell unavailable"), "test command failed to start: shell unavailable"),
+    ],
+)
+def test_post_write_test_runtime_errors_return_nonzero_and_persist_report(
+    tmp_path: Path, monkeypatch, passing_compiler, failure: BaseException, message: str
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    def fake_run(command, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    code = main(
+        [str(contract), "--write", "--test-command", "tests", "--report-json", str(report)]
+    )
+
+    assert code == 8
+    assert "#pragma version 0.4.3" in contract.read_text(encoding="utf-8")
+    data = json.loads(report.read_text())
+    assert data["wrote_changes"] is True
+    assert data["test_status"] == "failed"
+    assert message in data["test_output"]
+
+
+def test_post_write_test_mutation_is_detected_in_final_hashes(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    def mutate_planned_file(command, **kwargs):
+        contract.write_text("# changed by tests\n", encoding="utf-8")
+        return cli.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(cli.subprocess, "run", mutate_planned_file)
+
+    code = main(
+        [str(contract), "--write", "--test-command", "tests", "--report-json", str(report)]
+    )
+
+    assert code == 8
+    data = json.loads(report.read_text())
+    file_report = data["files"][0]
+    assert data["test_status"] == "failed"
+    assert "test command changed planned destinations" in data["test_output"]
+    assert file_report["final_matches_candidate"] is False
+    assert file_report["final_sha256"] == hashlib.sha256(contract.read_bytes()).hexdigest()
+
+
+def test_incomplete_rollback_is_reported_as_partial_on_disk_change(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "migration_03.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    def leave_candidate_behind(plan):
+        entry = plan.writes[0]
+        entry.path.write_bytes(entry.candidate)
+        raise cli.WriteTransactionError(
+            "injected incomplete rollback",
+            rollback_incomplete=True,
+            affected_paths=(entry.path,),
+        )
+
+    monkeypatch.setattr(cli.MigrationPlan, "commit", leave_candidate_behind)
+
+    code = main([str(contract), "--write", "--report-json", str(report)])
+
+    assert code == 9
+    data = json.loads(report.read_text())
+    assert data["write_status"] == "rollback-incomplete"
+    assert data["wrote_changes"] is True
+    assert "injected incomplete rollback" in data["write_output"]
+    assert data["files"][0]["final_matches_candidate"] is True
 
 
 def test_write_mode_does_not_write_when_target_compile_fails(
@@ -643,7 +952,16 @@ def f(token: Token, owner: address) -> uint256:
         encoding="utf-8",
     )
 
-    code = main([str(contract), "--write", "--split-interfaces"])
+    report = tmp_path / "report.json"
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--split-interfaces",
+            "--report-json",
+            str(report),
+        ]
+    )
 
     assert code == 0
     assert (
@@ -665,6 +983,155 @@ def balanceOf(owner: address) -> uint256: ...
 def transfer(to: address, amount: uint256) -> bool: ...
 """
     )
+    generated_report = next(
+        item
+        for item in json.loads(report.read_text())["files"]
+        if item["path"] == str(tmp_path / "Token.vyi")
+    )
+    assert generated_report["validation"]["source_compile"] == "skipped"
+    assert generated_report["validation"]["target_compile"] == "passed"
+    assert generated_report["validation"]["abi_equal"] is None
+    assert generated_report["validation"]["decision"]["status"] == "passed"
+
+
+def test_generated_interface_target_failure_blocks_every_write(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "Main.vy"
+    original = """#pragma version 0.4.3
+
+interface Token:
+    def balanceOf(owner: address) -> uint256: view
+"""
+    contract.write_text(original, encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    def fail_generated(path, source, config, overlay=None):
+        if path.suffix == ".vyi":
+            return CompileResult("failed", stderr="generated interface failed")
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    monkeypatch.setattr(cli, "compile_target_source", fail_generated)
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--split-interfaces",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 2
+    assert contract.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "Token.vyi").exists()
+    data = json.loads(report.read_text())
+    generated_report = next(
+        item for item in data["files"] if item["path"] == str(tmp_path / "Token.vyi")
+    )
+    assert generated_report["validation"]["target_compile"] == "failed"
+    assert generated_report["validation"]["decision"]["status"] == "blocked"
+    assert any(
+        blocker["path"] == str(tmp_path / "Token.vyi")
+        for blocker in data["validation_decision"]["blockers"]
+    )
+def test_split_interfaces_rejects_existing_generated_file_collision(
+    tmp_path: Path, passing_compiler
+) -> None:
+    contract = tmp_path / "Main.vy"
+    original = """#pragma version 0.4.3
+
+interface Token:
+    def balanceOf(owner: address) -> uint256: view
+"""
+    contract.write_text(original, encoding="utf-8")
+    token = tmp_path / "Token.vyi"
+    token.write_text("# user-owned interface\n", encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--split-interfaces",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 9
+    assert contract.read_text(encoding="utf-8") == original
+    assert token.read_text(encoding="utf-8") == "# user-owned interface\n"
+    data = json.loads(report.read_text())
+    assert data["wrote_changes"] is False
+    assert data["write_status"] == "failed"
+    assert "already exists with different content" in data["write_output"]
+
+
+def test_split_interfaces_rejects_duplicate_generated_destinations(
+    tmp_path: Path, passing_compiler
+) -> None:
+    originals: dict[Path, str] = {}
+    for name in ("First.vy", "Second.vy"):
+        source = """#pragma version 0.4.3
+
+interface Token:
+    def balanceOf(owner: address) -> uint256: view
+"""
+        path = tmp_path / name
+        path.write_text(source, encoding="utf-8")
+        originals[path] = source
+    report = tmp_path / "report.json"
+
+    code = main(
+        [str(tmp_path), "--write", "--split-interfaces", "--report-json", str(report)]
+    )
+
+    assert code == 9
+    assert not (tmp_path / "Token.vyi").exists()
+    assert all(path.read_text(encoding="utf-8") == source for path, source in originals.items())
+    assert "duplicate generated destination" in json.loads(report.read_text())["write_output"]
+
+
+def test_split_interfaces_accepts_identical_generated_file_as_noop(
+    tmp_path: Path, passing_compiler
+) -> None:
+    contract = tmp_path / "Main.vy"
+    contract.write_text(
+        """#pragma version 0.4.3
+
+interface Token:
+    def balanceOf(owner: address) -> uint256: view
+""",
+        encoding="utf-8",
+    )
+    token = tmp_path / "Token.vyi"
+    token_source = """@view
+@external
+def balanceOf(owner: address) -> uint256: ...
+"""
+    token.write_text(token_source, encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--split-interfaces",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 0
+    assert "import Token" in contract.read_text(encoding="utf-8")
+    assert token.read_text(encoding="utf-8") == token_source
+    token_report = next(
+        item for item in json.loads(report.read_text())["files"] if item["path"] == str(token)
+    )
+    assert token_report["changed"] is False
+    assert token_report["original_sha256"] == token_report["candidate_sha256"]
 
 
 def test_split_interfaces_respects_rule_ignore(tmp_path: Path, passing_compiler) -> None:

--- a/tests/test_write_plan.py
+++ b/tests/test_write_plan.py
@@ -1,0 +1,228 @@
+import stat
+from pathlib import Path
+
+import pytest
+
+from vyupgrade import cli, write_plan
+from vyupgrade.models import FileReport, RunReport
+from vyupgrade.write_plan import MigrationPlan, PlanConflictError, WriteTransactionError
+
+
+def test_partial_write_failure_rolls_back_every_destination(
+    tmp_path: Path, monkeypatch
+) -> None:
+    first = tmp_path / "First.vy"
+    second = tmp_path / "Second.vy"
+    first.write_text("first original\n", encoding="utf-8")
+    second.write_text("second original\n", encoding="utf-8")
+    plan = MigrationPlan()
+    plan.add_source(
+        first,
+        "first original\n",
+        "first candidate\n",
+        FileReport(first),
+    )
+    plan.add_source(
+        second,
+        "second original\n",
+        "second candidate\n",
+        FileReport(second),
+    )
+    real_replace = write_plan.os.replace
+    failed = False
+
+    def fail_second_once(source, destination):
+        nonlocal failed
+        if Path(destination) == second and not failed:
+            failed = True
+            raise OSError("injected second-write failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(write_plan.os, "replace", fail_second_once)
+
+    with pytest.raises(WriteTransactionError, match="destinations were restored"):
+        plan.commit()
+
+    assert first.read_text(encoding="utf-8") == "first original\n"
+    assert second.read_text(encoding="utf-8") == "second original\n"
+    assert not list(tmp_path.glob(".*.vyupgrade-*"))
+
+
+def test_commit_refuses_to_overwrite_a_destination_changed_after_planning(
+    tmp_path: Path,
+) -> None:
+    contract = tmp_path / "Contract.vy"
+    contract.write_text("original\n", encoding="utf-8")
+    plan = MigrationPlan()
+    plan.add_source(contract, "original\n", "candidate\n", FileReport(contract))
+    contract.write_text("concurrent edit\n", encoding="utf-8")
+
+    with pytest.raises(WriteTransactionError, match="changed before commit"):
+        plan.commit()
+
+    assert contract.read_text(encoding="utf-8") == "concurrent edit\n"
+
+
+def test_source_snapshot_stat_failure_becomes_a_reportable_plan_conflict(
+    tmp_path: Path, monkeypatch
+) -> None:
+    contract = tmp_path / "Contract.vy"
+    contract.write_text("original\n", encoding="utf-8")
+    destination = contract.resolve()
+    real_lstat = Path.lstat
+
+    def fail_destination_stat(path: Path, *args, **kwargs):
+        if path == destination:
+            raise OSError("injected stat failure")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "lstat", fail_destination_stat)
+
+    with pytest.raises(PlanConflictError, match="could not snapshot migration source"):
+        MigrationPlan().add_source(
+            contract,
+            "original\n",
+            "candidate\n",
+            FileReport(contract),
+        )
+
+
+def test_new_generated_file_uses_the_normal_creation_mode(tmp_path: Path) -> None:
+    control = tmp_path / "control.vyi"
+    control.write_text("control\n", encoding="utf-8")
+    generated = tmp_path / "Generated.vyi"
+    plan = MigrationPlan()
+    plan.add_generated(
+        generated,
+        "generated\n",
+        FileReport(generated),
+    )
+
+    assert plan.commit() is True
+
+    assert stat.S_IMODE(generated.stat().st_mode) == stat.S_IMODE(control.stat().st_mode)
+
+
+def test_generated_broken_symlink_is_rejected_without_creating_its_target(
+    tmp_path: Path,
+) -> None:
+    escaped = tmp_path / "escaped.vyi"
+    generated = tmp_path / "Generated.vyi"
+    generated.symlink_to(escaped)
+
+    with pytest.raises(PlanConflictError, match="may not be a symbolic link"):
+        MigrationPlan().add_generated(
+            generated,
+            "generated\n",
+            FileReport(generated),
+        )
+
+    assert generated.is_symlink()
+    assert not escaped.exists()
+
+
+def test_commit_rechecks_unchanged_planned_dependencies(tmp_path: Path) -> None:
+    contract = tmp_path / "Contract.vy"
+    dependency = tmp_path / "Dependency.vyi"
+    contract.write_text("original\n", encoding="utf-8")
+    dependency.write_text("dependency\n", encoding="utf-8")
+    plan = MigrationPlan()
+    plan.add_source(contract, "original\n", "candidate\n", FileReport(contract))
+    plan.add_source(
+        dependency,
+        "dependency\n",
+        "dependency\n",
+        FileReport(dependency),
+    )
+    dependency.write_text("concurrent dependency edit\n", encoding="utf-8")
+
+    with pytest.raises(WriteTransactionError, match="changed before commit"):
+        plan.commit()
+
+    assert contract.read_text(encoding="utf-8") == "original\n"
+    assert dependency.read_text(encoding="utf-8") == "concurrent dependency edit\n"
+
+
+def test_changed_hardlinked_source_is_rejected(tmp_path: Path) -> None:
+    contract = tmp_path / "Contract.vy"
+    alias = tmp_path / "Alias.vy"
+    contract.write_text("original\n", encoding="utf-8")
+    alias.hardlink_to(contract)
+
+    with pytest.raises(PlanConflictError, match="hard links"):
+        MigrationPlan().add_source(
+            contract,
+            "original\n",
+            "candidate\n",
+            FileReport(contract),
+        )
+
+
+def test_incomplete_rollback_is_explicit_and_refreshes_final_state(
+    tmp_path: Path, monkeypatch
+) -> None:
+    first = tmp_path / "First.vy"
+    second = tmp_path / "Second.vy"
+    first.write_text("first original\n", encoding="utf-8")
+    second.write_text("second original\n", encoding="utf-8")
+    first_report = FileReport(first)
+    plan = MigrationPlan()
+    plan.add_source(first, "first original\n", "first candidate\n", first_report)
+    plan.add_source(
+        second,
+        "second original\n",
+        "second candidate\n",
+        FileReport(second),
+    )
+    real_replace = write_plan.os.replace
+    first_replaced = False
+
+    def fail_commit_and_rollback(source, destination):
+        nonlocal first_replaced
+        destination = Path(destination)
+        if destination == first and not first_replaced:
+            first_replaced = True
+            return real_replace(source, destination)
+        if destination in {first, second}:
+            raise OSError("injected replace failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(write_plan.os, "replace", fail_commit_and_rollback)
+
+    with pytest.raises(WriteTransactionError, match="rollback was incomplete") as caught:
+        plan.commit()
+
+    assert caught.value.rollback_incomplete is True
+    assert caught.value.affected_paths == (first,)
+    assert first.read_text(encoding="utf-8") == "first candidate\n"
+    assert first_report.final_matches_candidate is True
+
+
+def test_formatter_staging_preserves_hierarchy_for_duplicate_basenames(
+    tmp_path: Path, monkeypatch
+) -> None:
+    first = tmp_path / "one" / "Contract.vy"
+    second = tmp_path / "two" / "Contract.vy"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_text("first\n", encoding="utf-8")
+    second.write_text("second\n", encoding="utf-8")
+    plan = MigrationPlan()
+    plan.add_source(first, "first\n", "first candidate\n", FileReport(first))
+    plan.add_source(second, "second\n", "second candidate\n", FileReport(second))
+    report = RunReport(None, "0.4.3", [])
+
+    def fake_run(command, **kwargs):
+        staged = [Path(path) for path in command[1:]]
+        assert [path.name for path in staged] == ["Contract.vy", "Contract.vy"]
+        assert staged[0].parent != staged[1].parent
+        assert all(path.parent.name in {"one", "two"} for path in staged)
+        return cli.subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    cli._run_mamushi(plan, report)
+
+    assert report.formatter_status == "passed"
+    assert first.read_text(encoding="utf-8") == "first\n"
+    assert second.read_text(encoding="utf-8") == "second\n"


### PR DESCRIPTION
## What

- replace loose write-back tuples with a resolved-path, content-addressed `MigrationPlan`
- reject duplicate/generated collisions, generated symlinks, unsafe hard-linked/read-only replacements, and stale planned inputs
- format only staged candidates, then recompile and compare the exact formatted bytes before any write
- directly target-validate generated `.vyi` files and include them in the run decision
- stage every replacement and roll back prior replacements when a later write fails
- report incomplete rollback separately, with original/candidate/final SHA-256 state
- make post-write test failures, timeouts, start errors, and planned-file mutations exit 8
- use exit 9 for planning or write-transaction failures

## Why

The previous flow validated one set of bytes, wrote files directly, and then let Mamushi mutate them without recompilation. Generated files could collide or overwrite user files, multi-file writes could stop halfway, and failing test commands still returned success.

## Impact

Only final validated candidates are committed. Formatter failure and final validation failure leave originals untouched. Existing generated files are accepted only as identical no-ops. Reports distinguish validated candidates from final on-disk state, including changes made by a test command.

The transaction is rollback-aware rather than globally atomic. All planned inputs are rechecked and each changed destination is checked immediately before replacement, but portable POSIX filesystems do not provide a content compare-and-swap rename against non-cooperating external writers. Platform-specific ACL/ownership/xattr preservation remains filesystem dependent and is documented.

## Checks

- `uv run --locked pytest` (569 passed)
- focused CLI/interface/report/write-plan suite (71 passed)
- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py`
- `scripts/smoke-wheel.sh` (real isolated wheel install and compiler-backed CLI smoke)
- `git diff --check`
