### PR TITLE
refactor: share migration engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,9 @@ feature, not an optional smoke check.
 ## Repository map
 
 - `src/vyupgrade/cli.py` — command-line orchestration, config loading, report
-  generation, write/diff/check behavior, and validation diagnostics.
+  generation, and write/diff/check behavior.
+- `src/vyupgrade/engine.py` — shared source compilation, AST-isolated rewrite,
+  target-overlay validation, artifact comparison, and typed validation policy.
 - `src/vyupgrade/rules.py` — ordered rule pipeline. New rule groups must be
   imported here and inserted at the correct stage.
 - `src/vyupgrade/rule_registry.py` — rule descriptors and version gating.
@@ -140,8 +142,8 @@ again before returning.
   structs, storage variables, function decorators, loop variables, and return
   types.
 - Use `config.source_ast` plus helpers in `ast_facts.py` when compiler spans or
-  parsed constants are needed. `cli._prepare_rewrites()` already populates the
-  AST from source compilation when available.
+  parsed constants are needed. `engine.prepare_migrations()` populates a
+  per-file AST-backed config from source compilation when available.
 - Prefer local helpers over hand-rolled parsing when splitting arguments,
   inserting imports, finding matching delimiters, or computing line numbers.
 - If a rewrite depends on mutability or return types of external calls, update

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,9 +45,9 @@ The CLI flow is:
 
 1. `cli.main()` loads command-line and `[tool.vyupgrade]` config.
 2. `project.discover_files()` finds `.vy` and `.vyi` inputs.
-3. `cli._prepare_rewrites()` compiles each source under the inferred or provided
-   source compiler, stores the source AST when available, and calls
-   `rules.apply_rules()`.
+3. `engine.prepare_migrations()` compiles each source under the inferred or
+   provided source compiler, gives each file its own source AST-backed config,
+   and calls `rules.apply_rules()`.
 4. `rules.apply_rules()` constructs a `MigrationContext`, then runs the ordered
    rule pipeline from `RULES`.
 5. Optional interface splitting generates sibling `.vyi` files when
@@ -55,16 +55,16 @@ The CLI flow is:
 6. `write_plan.MigrationPlan` resolves every destination, rejects duplicate
    generated outputs and pre-existing generated-file collisions, and records
    original and candidate SHA-256 hashes.
-7. `cli._verify_rewrites()` builds a temporary target overlay, compiles migrated
-   sources under the target compiler, and compares ABI, method identifiers, and
-   storage layout.
-8. `validation.decide_run_validation()` turns compiler and artifact outcomes
-   into a typed, fail-closed write decision. Rule selection and diagnostic
-   version gating do not participate in this safety decision.
-9. Optional formatting runs only on temporary candidate files. The exact
+7. `engine.validate_migrations()` builds a temporary target overlay, directly
+   validates generated interfaces, compiles migrated sources under the target
+   compiler, compares ABI, method identifiers, and storage layout, and returns
+   the typed fail-closed decision from `validation.decide_run_validation()`.
+   Rule selection and diagnostic version gating do not participate in this
+   safety decision.
+8. Optional formatting runs only on temporary candidate files. The exact
    formatted bytes replace the candidates and pass through target validation
    again before writes are allowed.
-10. The write plan stages every destination and commits it as one rollback-aware
+9. The write plan stages every destination and commits it as one rollback-aware
     transaction only when validation passes or every blocker has an explicit
     waiver. A post-write test failure is reported and exits nonzero, but does not
     roll back the write or any external side effects from the test command.
@@ -80,6 +80,9 @@ is reported explicitly with final on-disk hashes instead of being described as c
 
 Important files:
 
+- `src/vyupgrade/engine.py` owns compiler-attempt selection, per-file AST-backed
+  rewrites, coherent target-overlay validation, artifact comparisons, and typed
+  validation decisions shared by the CLI and corpus smoke tool.
 - `src/vyupgrade/rules.py` defines rule order and `RULE_CHANGES`.
 - `src/vyupgrade/rule_registry.py` defines `Rule`, `RuleContext`, and gating.
 - `src/vyupgrade/rule_groups/` contains the actual migration rules.
@@ -93,6 +96,11 @@ Important files:
 - `src/vyupgrade/ast_facts.py` extracts facts from compiler AST output.
 - `docs/vyper-syntax-history.md` records source-visible upstream syntax changes.
 - `docs/migration-coverage.md` records this project's behavior for each change.
+
+JSON reports use the existing top-level envelope with `schema_version: 1`.
+Within schema 1, fields may be added but existing fields are not renamed,
+removed, or type-changed. A missing version identifies the legacy unversioned
+format; incompatible changes require a new schema version.
 
 ## Rule model
 
@@ -214,7 +222,10 @@ Use `--limit` for a quick sample and `--path` to focus on known regressions. The
 smoke command compiles source and target outputs, applies the same artifact
 comparisons as the CLI, and records rule, diagnostic, compile, and diff details.
 It writes an atomic checkpoint sidecar and resumes an ordered result prefix when
-the manifest, selected items, and target version still match the interrupted run.
+the manifest, selected items, target version, and smoke-result schema still match
+the interrupted run. Each result and summary declares `smoke_schema_version: 2`;
+the legacy unversioned rows are treated as schema 1 and are never mixed into a
+resumed schema 2 run.
 
 Corpus source directories and generated outputs live under `corpus/`, which is
 ignored by Git.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Poetry caret requirements, are skipped; use `--compiler-search-paths`,
 - `--allow-storage-layout-change` — write despite a storage-layout comparison mismatch.
 - `--config PATH` — read configuration from a specific `pyproject.toml`.
 
+JSON reports include a top-level `schema_version`. Version `1` preserves the
+existing report envelope and field paths; new fields may be added compatibly.
+Consumers should treat a missing version as the legacy unversioned format and
+require a new schema version before relying on renamed, removed, or
+type-changed fields.
+
 ### Configuration
 
 Defaults can live in `pyproject.toml` under `[tool.vyupgrade]`. Command-line

--- a/scripts/corpus.py
+++ b/scripts/corpus.py
@@ -15,19 +15,12 @@ import urllib.parse
 import urllib.request
 import uuid
 from collections import Counter
-from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from vyupgrade.compiler import (
-    compare_artifact_details,
-    compare_artifacts,
-    compile_source_file,
-    compile_target_source,
-    target_overlay,
-)
-from vyupgrade.models import Config
-from vyupgrade.rules import apply_rules
+from vyupgrade import engine
+from vyupgrade.engine import MigrationRequest, SourceCompileAttempt
+from vyupgrade.models import Config, FileReport
 from vyupgrade.versions import (
     KNOWN_VERSIONS,
     compiler_version_for_source,
@@ -50,6 +43,7 @@ CORPUS_MANIFESTS = {
     "vyper-2026": "vyper-2026-manifest.json",
     "chainsecurity": "chainsecurity-manifest.json",
 }
+SMOKE_RESULT_SCHEMA_VERSION = 2
 CODESLAW_CHAINS = (
     "ethereum",
     "arbitrum",
@@ -1378,47 +1372,50 @@ def _smoke_one(item: dict[str, Any], target_version: str) -> dict[str, Any]:
             source_version=source_version,
             compiler_search_paths=compiler_search_paths,
         )
-        source_compile = compile_source_file(path, config, source_version)
-        source_version, config, source_compile = _retry_source_compile_with_newer_version(
-            item, path, config, source_version, source_compile
+        request = MigrationRequest(
+            path,
+            original,
+            source_version,
+            _source_compile_attempts(item, source_version),
+            # Preserve the corpus smoke's historical attempt to compile a
+            # target even when the source is newer than that target.
+            skip_target_on_vyd016=False,
         )
-        source_ast = source_compile.artifacts.get("ast") if source_compile.artifacts else None
-        file_config = replace(
-            config, source_ast=source_ast if isinstance(source_ast, dict) else None
-        )
-        rewrite = apply_rules(original, file_config, path)
-        with target_overlay(
-            {path: rewrite.source}, config.target_version, config.compiler_search_paths
-        ) as overlay:
-            target_compile = compile_target_source(path, rewrite.source, config, overlay)
-        abi_equal, method_ids_equal, storage_layout_equal = compare_artifacts(
-            source_compile, target_compile
-        )
-        artifact_details = _artifact_detail_fields(
-            source_compile,
-            target_compile,
-            abi_equal,
-            method_ids_equal,
-            storage_layout_equal,
-        )
+        batch = engine.prepare_migrations((request,), config)
+        validation = engine.validate_migrations(batch, config)
+        migration = batch.files[0]
+        report = migration.report
+        rewrite = migration.rewrite
+        artifact_details = _artifact_detail_fields(report)
         return {
             **item,
+            "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION,
             "changed": original != rewrite.source,
             "fixes": [fix.rule for fix in rewrite.fixes],
             "diagnostics": [diag.rule for diag in rewrite.diagnostics],
-            "source_compile": source_compile.status,
-            "target_compile": target_compile.status,
-            "source_error": _error_excerpt(source_compile.stderr),
-            "target_error": _error_excerpt(target_compile.stderr),
-            "abi_equal": abi_equal,
-            "method_ids_equal": method_ids_equal,
-            "storage_layout_equal": storage_layout_equal,
+            "source_compile": report.source_compile,
+            "target_compile": report.target_compile,
+            "source_error": _error_excerpt(migration.source_compile.stderr),
+            "target_error": _error_excerpt(
+                migration.target_compile.stderr if migration.target_compile else None
+            ),
+            "abi_equal": report.abi_equal,
+            "method_ids_equal": report.method_ids_equal,
+            "storage_layout_equal": report.storage_layout_equal,
+            "validation_status": validation.status,
+            "validation_blockers": [
+                issue.to_json_obj() for issue in validation.blockers
+            ],
+            "validation_waivers": [
+                issue.to_json_obj() for issue in validation.waivers
+            ],
             **artifact_details,
             "seconds": round(time.time() - started, 3),
         }
     except Exception as exc:
         return {
             **item,
+            "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION,
             "source_compile": "exception",
             "target_compile": "exception",
             "source_error": f"{type(exc).__name__}: {exc}",
@@ -1427,27 +1424,18 @@ def _smoke_one(item: dict[str, Any], target_version: str) -> dict[str, Any]:
         }
 
 
-def _artifact_detail_fields(
-    source_compile,
-    target_compile,
-    abi_equal: bool | None,
-    method_ids_equal: bool | None,
-    storage_layout_equal: bool | None,
-) -> dict[str, list[str]]:
+def _artifact_detail_fields(report: FileReport) -> dict[str, list[str]]:
     requested = {
-        "abi_diff": abi_equal is False,
-        "method_id_diff": method_ids_equal is False,
-        "storage_layout_diff": storage_layout_equal is False,
+        "abi_diff": report.abi_equal is False,
+        "method_id_diff": report.method_ids_equal is False,
+        "storage_layout_diff": report.storage_layout_equal is False,
     }
     if not any(requested.values()):
         return {}
-    abi_diff, method_id_diff, storage_layout_diff = compare_artifact_details(
-        source_compile, target_compile
-    )
     details = {
-        "abi_diff": abi_diff,
-        "method_id_diff": method_id_diff,
-        "storage_layout_diff": storage_layout_diff,
+        "abi_diff": report.abi_diff,
+        "method_id_diff": report.method_id_diff,
+        "storage_layout_diff": report.storage_layout_diff,
     }
     return {field: details[field] for field, include in requested.items() if include}
 
@@ -1479,6 +1467,7 @@ def _smoke_summary(
     fixes = Counter(fix for item in results for fix in item.get("fixes", []))
     diagnostics = Counter(diag for item in results for diag in item.get("diagnostics", []))
     return {
+        "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION,
         "manifest": str(manifest_path),
         "results": str(output_path),
         "total": len(results),
@@ -1532,7 +1521,8 @@ def _smoke_run_identity(
     manifest_path: Path, target_version: str, items: list[dict[str, Any]]
 ) -> dict[str, Any]:
     return {
-        "checkpoint_version": 1,
+        "checkpoint_version": 2,
+        "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION,
         "manifest_path": str(manifest_path.resolve()),
         "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
         "target_version": target_version,
@@ -1550,7 +1540,7 @@ def _load_smoke_checkpoint(
         checkpoint = json.loads(_checkpoint_path(output_path).read_text(encoding="utf-8"))
         if (
             not isinstance(checkpoint, dict)
-            or checkpoint.get("checkpoint_version") != 1
+            or checkpoint.get("checkpoint_version") != 2
             or checkpoint.get("identity") != identity
         ):
             return []
@@ -1563,7 +1553,9 @@ def _load_smoke_checkpoint(
         if checkpoint.get("results_sha256") != _json_digest(results):
             return []
         if not all(
-            isinstance(result, dict) and _result_matches_item(result, item)
+            isinstance(result, dict)
+            and result.get("smoke_schema_version") == SMOKE_RESULT_SCHEMA_VERSION
+            and _result_matches_item(result, item)
             for result, item in zip(results, items[:completed], strict=True)
         ):
             return []
@@ -1581,14 +1573,18 @@ def _write_smoke_checkpoint(
     results: list[dict[str, Any]],
     identity: dict[str, Any],
 ) -> None:
-    _atomic_write_json(output_path, results)
+    versioned_results = [
+        {**result, "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION}
+        for result in results
+    ]
+    _atomic_write_json(output_path, versioned_results)
     _atomic_write_json(
         _checkpoint_path(output_path),
         {
-            "checkpoint_version": 1,
+            "checkpoint_version": 2,
             "identity": identity,
-            "completed": len(results),
-            "results_sha256": _json_digest(results),
+            "completed": len(versioned_results),
+            "results_sha256": _json_digest(versioned_results),
         },
     )
 
@@ -1827,26 +1823,20 @@ def _item_source_version(item: dict[str, Any]) -> str:
     return compiler_version_for_source(pragma, source) or pragma
 
 
-def _retry_source_compile_with_newer_version(
-    item: dict[str, Any],
-    path: Path,
-    config: Config,
-    source_version: str,
-    source_compile: Any,
-) -> tuple[str, Config, Any]:
-    if source_compile.status == "passed" or _has_exact_source_compiler(item):
-        return source_version, config, source_compile
+def _source_compile_attempts(
+    item: dict[str, Any], source_version: str
+) -> tuple[SourceCompileAttempt, ...]:
+    attempts = [SourceCompileAttempt(source_version, source_version)]
+    if _has_exact_source_compiler(item):
+        return tuple(attempts)
     current = parse_version(source_version)
     candidates = known_versions_satisfying(item.get("pragma"))
     for candidate in candidates:
         if current is not None and candidate <= current:
             continue
         retry_version = str(candidate)
-        retry_config = replace(config, source_version=retry_version)
-        retry_compile = compile_source_file(path, retry_config, retry_version)
-        if retry_compile.status == "passed":
-            return retry_version, retry_config, retry_compile
-    return source_version, config, source_compile
+        attempts.append(SourceCompileAttempt(retry_version, retry_version))
+    return tuple(attempts)
 
 
 def _has_exact_source_compiler(item: dict[str, Any]) -> bool:

--- a/src/vyupgrade/cli.py
+++ b/src/vyupgrade/cli.py
@@ -7,53 +7,15 @@ import subprocess
 import sys
 import tempfile
 import tomllib
-from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TextIO
 
-from .compiler import (
-    CompileResult,
-    compare_artifact_details,
-    compare_artifacts,
-    compile_source_file,
-    compile_target_source,
-    target_overlay,
-    unavailable_validation_artifacts,
-)
-from .interfaces import split_interfaces_to_vyi
-from .models import (
-    Config,
-    Diagnostic,
-    FileReport,
-    GeneratedFile,
-    RewriteResult,
-    RunReport,
-    ValidationDecision,
-)
+from . import engine
+from .models import Config, FileReport, RunReport
 from .project import discover_files
 from .reporting import HumanReporter, write_json_report
-from .rule_registry import is_enabled
-from .rules import RULE_CHANGES, apply_rules
 from .validation import decide_run_validation, validation_exit_code
-from .versions import (
-    MigrationContext,
-    compiler_version_for_source_validation,
-    compiler_version_for_spec,
-    default_evm_version_for_spec,
-    infer_pragma,
-)
 from .write_plan import MigrationPlan, PlanConflictError, WriteTransactionError
-
-
-@dataclass
-class RewriteWork:
-    path: Path
-    original: str
-    rewrite: RewriteResult
-    report: FileReport
-    source_compile: CompileResult
-    source_version: str | None
-    source_compiler: str | None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -109,11 +71,18 @@ def main(argv: list[str] | None = None) -> int:
     if human_reporter:
         human_reporter.start(config.source_version, config.target_version)
 
-    rewrites = _prepare_rewrites(files, config)
-    reports, generated_reports, plan, plan_error = _build_migration_plan(rewrites)
+    requests = [
+        engine.bounded_migration_request(
+            path, path.read_bytes().decode("utf-8"), config
+        )
+        for path in files
+    ]
+    batch = engine.prepare_migrations(requests, config)
+    reports, plan, plan_error = _build_migration_plan(batch)
     if plan_error is None:
-        _verify_rewrites(rewrites, generated_reports, config, plan)
-        validation_decision = decide_run_validation(reports, config)
+        validation_decision = engine.validate_migrations(
+            batch, config, plan.candidate_source
+        )
     else:
         validation_decision = decide_run_validation((), config)
 
@@ -133,8 +102,9 @@ def main(argv: list[str] | None = None) -> int:
         if config.format == "mamushi" and plan.writes:
             _run_mamushi(plan, run_report)
             if run_report.formatter_status == "passed":
-                _verify_rewrites(rewrites, generated_reports, config, plan)
-                validation_decision = decide_run_validation(reports, config)
+                validation_decision = engine.validate_migrations(
+                    batch, config, plan.candidate_source
+                )
                 run_report.validation_decision = validation_decision
                 if not validation_decision.write_allowed:
                     run_report.write_status = "blocked"
@@ -212,171 +182,6 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _prepare_rewrites(files: list[Path], config: Config) -> list[RewriteWork]:
-    rewrites: list[RewriteWork] = []
-    for path in files:
-        original = path.read_bytes().decode("utf-8")
-        source_version = config.source_version or infer_pragma(original)
-        context = MigrationContext.from_specs(source_version, config.target_version)
-        if context.source_newer_than_target():
-            rewrite = apply_rules(original, config, path)
-            file_report = FileReport(
-                path=path,
-                changed=False,
-                fixes=rewrite.fixes,
-                diagnostics=rewrite.diagnostics,
-                source_version=source_version,
-            )
-            rewrites.append(
-                RewriteWork(
-                    path,
-                    original,
-                    rewrite,
-                    file_report,
-                    CompileResult("skipped"),
-                    source_version,
-                    None,
-                )
-            )
-            continue
-        inferred_source_compiler = compiler_version_for_source_validation(
-            source_version, config.target_version, original
-        )
-        source_compile_version = source_version if config.source_vyper else inferred_source_compiler
-        source_compiler = None if config.source_vyper else inferred_source_compiler
-        source_compile = compile_source_file(path, config, source_compile_version)
-        source_ast = source_compile.artifacts.get("ast") if source_compile.artifacts else None
-        file_config = replace(
-            config, source_ast=source_ast if isinstance(source_ast, dict) else None
-        )
-        rewrite = apply_rules(original, file_config, path)
-        if (
-            config.split_interfaces
-            and path.suffix == ".vy"
-            and _rule_enabled("VY120", source_version, config)
-        ):
-            split = split_interfaces_to_vyi(rewrite.source, path)
-            rewrite.source = split.source
-            rewrite.fixes.extend(split.fixes)
-            rewrite.generated_files.extend(split.generated)
-        changed = original != rewrite.source
-        file_report = FileReport(
-            path=path,
-            changed=changed,
-            fixes=rewrite.fixes,
-            diagnostics=rewrite.diagnostics,
-            source_version=source_version,
-            source_compiler=source_compiler,
-        )
-        file_report.source_compile = source_compile.status
-        if source_compile.status != "skipped":
-            file_report.source_unavailable_artifacts = unavailable_validation_artifacts(
-                source_compile
-            )
-        file_report.source_unavailable_formats = list(source_compile.unavailable_formats)
-        file_report.source_error = (
-            source_compile.stderr if source_compile.status == "failed" else None
-        )
-        rewrites.append(
-            RewriteWork(
-                path,
-                original,
-                rewrite,
-                file_report,
-                source_compile,
-                source_version,
-                source_compiler,
-            )
-        )
-    return rewrites
-
-
-def _verify_rewrites(
-    rewrites: list[RewriteWork],
-    generated_reports: list[tuple[GeneratedFile, FileReport]],
-    config: Config,
-    plan: MigrationPlan,
-) -> None:
-    target_sources = {
-        work.path: plan.candidate_source(work.path, work.rewrite.source)
-        for work in rewrites
-    }
-    for work in rewrites:
-        target_sources.update(
-            {
-                generated_file.path: plan.candidate_source(
-                    generated_file.path, generated_file.source
-                )
-                for generated_file in work.rewrite.generated_files
-            }
-        )
-    for generated_file, report in generated_reports:
-        target_sources[report.path] = plan.candidate_source(
-            report.path, generated_file.source
-        )
-    with target_overlay(target_sources, config.target_version, config.compiler_search_paths) as overlay:
-        for work in rewrites:
-            _reset_target_validation(work.report)
-            if any(diagnostic.rule == "VYD016" for diagnostic in work.report.diagnostics):
-                continue
-            target_source = target_sources[work.path]
-            target_compile = compile_target_source(work.path, target_source, config, overlay)
-            _record_target_compile(work.report, target_compile)
-            abi_equal, method_ids_equal, storage_layout_equal = compare_artifacts(
-                work.source_compile, target_compile
-            )
-            work.report.abi_equal = abi_equal
-            work.report.method_ids_equal = method_ids_equal
-            work.report.storage_layout_equal = storage_layout_equal
-            abi_diff, method_id_diff, storage_layout_diff = compare_artifact_details(
-                work.source_compile,
-                target_compile,
-            )
-            work.report.abi_diff = abi_diff
-            work.report.method_id_diff = method_id_diff
-            work.report.storage_layout_diff = storage_layout_diff
-            _add_validation_diagnostics(
-                work.report, work.source_version, config, work.source_compiler
-            )
-        for _generated_file, report in generated_reports:
-            _reset_target_validation(report)
-            target_compile = compile_target_source(
-                report.path,
-                target_sources[report.path],
-                config,
-                overlay,
-            )
-            _record_target_compile(report, target_compile)
-
-
-def _record_target_compile(report: FileReport, target_compile: CompileResult) -> None:
-    report.target_compile = target_compile.status
-    report.target_unavailable_artifacts = unavailable_validation_artifacts(target_compile)
-    report.target_unavailable_formats = list(target_compile.unavailable_formats)
-    report.target_error = (
-        target_compile.stderr if target_compile.status == "failed" else None
-    )
-
-
-def _reset_target_validation(report: FileReport) -> None:
-    report.target_compile = "skipped"
-    report.target_unavailable_artifacts.clear()
-    report.target_unavailable_formats.clear()
-    report.target_error = None
-    report.abi_equal = None
-    report.method_ids_equal = None
-    report.storage_layout_equal = None
-    report.abi_diff.clear()
-    report.method_id_diff.clear()
-    report.storage_layout_diff.clear()
-    report.validation_decision = ValidationDecision()
-    report.diagnostics = [
-        diagnostic
-        for diagnostic in report.diagnostics
-        if diagnostic.rule not in {"VYD006", "VYD007", "VYD008", "VYD009"}
-    ]
-
-
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="vyupgrade")
     parser.add_argument("paths", nargs="*")
@@ -407,39 +212,27 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def _build_migration_plan(
-    rewrites: list[RewriteWork],
-) -> tuple[
-    list[FileReport],
-    list[tuple[GeneratedFile, FileReport]],
-    MigrationPlan,
-    str | None,
-]:
-    reports = [work.report for work in rewrites]
-    generated_reports: list[tuple[GeneratedFile, FileReport]] = []
-    for work in rewrites:
-        for generated_file in work.rewrite.generated_files:
-            generated_report = FileReport(
-                path=generated_file.path,
-                changed=True,
-                fixes=[generated_file.fix],
-            )
-            reports.append(generated_report)
-            generated_reports.append((generated_file, generated_report))
-
+    batch: engine.MigrationBatch,
+) -> tuple[list[FileReport], MigrationPlan, str | None]:
+    reports = batch.reports
     plan = MigrationPlan()
     try:
-        for work in rewrites:
+        for migration in batch.files:
             plan.add_source(
-                work.path,
-                work.original,
-                work.rewrite.source,
-                work.report,
+                migration.path,
+                migration.original,
+                migration.rewrite.source,
+                migration.report,
             )
-        for generated_file, report in generated_reports:
-            plan.add_generated(generated_file.path, generated_file.source, report)
+        for migration in batch.generated:
+            plan.add_generated(
+                migration.file.path,
+                migration.file.source,
+                migration.report,
+            )
     except PlanConflictError as exc:
-        return reports, generated_reports, plan, str(exc)
-    return reports, generated_reports, plan, None
+        return reports, plan, str(exc)
+    return reports, plan, None
 
 
 def _write_diff(diff_chunks: list[str], stream: TextIO) -> None:
@@ -504,87 +297,6 @@ def _none_if_infer(value: object) -> str | None:
 
 def _string_or_none(value: object) -> str | None:
     return None if value is None else str(value)
-
-
-def _add_validation_diagnostics(
-    file_report: FileReport,
-    source_version: str | None,
-    config: Config,
-    source_compiler: str | None = None,
-) -> None:
-    if file_report.source_compile == "failed":
-        _add_diagnostic_if_enabled(
-            file_report,
-            Diagnostic(
-                "VYD006", 1, "source compile failed under declared or inferred source compiler"
-            ),
-            source_version,
-            config,
-        )
-    if file_report.abi_equal is False:
-        _add_diagnostic_if_enabled(
-            file_report,
-            Diagnostic("VYD007", 1, "ABI changed after migration"),
-            source_version,
-            config,
-        )
-    if file_report.method_ids_equal is False:
-        _add_diagnostic_if_enabled(
-            file_report,
-            Diagnostic("VYD007", 1, "method identifiers changed after migration"),
-            source_version,
-            config,
-        )
-    if file_report.storage_layout_equal is False:
-        _add_diagnostic_if_enabled(
-            file_report,
-            Diagnostic("VYD008", 1, "storage layout changed after migration"),
-            source_version,
-            config,
-        )
-    evm_diagnostic = _evm_default_diagnostic(
-        source_compiler or source_version, config.target_version
-    )
-    if evm_diagnostic is not None and _rule_enabled(evm_diagnostic.rule, source_version, config):
-        file_report.diagnostics.append(evm_diagnostic)
-
-
-def _add_diagnostic_if_enabled(
-    file_report: FileReport,
-    diagnostic: Diagnostic,
-    source_version: str | None,
-    config: Config,
-) -> None:
-    if _rule_enabled(diagnostic.rule, source_version, config):
-        file_report.diagnostics.append(diagnostic)
-
-
-def _rule_enabled(rule: str, source_version: str | None, config: Config) -> bool:
-    context = MigrationContext.from_specs(source_version, config.target_version)
-    return is_enabled(rule, config, context, RULE_CHANGES)
-
-
-def _evm_default_diagnostic(source_version: str | None, target_version: str) -> Diagnostic | None:
-    source_evm = default_evm_version_for_spec(source_version)
-    target_evm = default_evm_version_for_spec(target_version)
-    if source_evm is not None and target_evm is not None:
-        if source_evm == target_evm:
-            return None
-        source_compiler = compiler_version_for_spec(source_version) or "unknown"
-        target_compiler = compiler_version_for_spec(target_version) or target_version
-        return Diagnostic(
-            "VYD009",
-            1,
-            f"default EVM version changed from {source_evm} (source compiler {source_compiler}) to {target_evm} (target compiler {target_compiler}); review or pin explicitly",
-        )
-    context = MigrationContext.from_specs(source_version, target_version)
-    if not context.crosses("0.4.0"):
-        return None
-    if target_evm is not None:
-        message = f"target compiler defaults to EVM {target_evm}; source-era default is unknown; review or pin explicitly"
-    else:
-        message = "target compiler default EVM version differs from source-era default; review or pin explicitly"
-    return Diagnostic("VYD009", 1, message)
 
 
 def _run_mamushi(plan: MigrationPlan, report: RunReport) -> None:

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+from .compiler import (
+    CompileResult,
+    compare_artifact_details,
+    compare_artifacts,
+    compile_source_file,
+    compile_target_source,
+    target_overlay,
+    unavailable_validation_artifacts,
+)
+from .interfaces import split_interfaces_to_vyi
+from .models import (
+    Config,
+    Diagnostic,
+    FileReport,
+    GeneratedFile,
+    RewriteResult,
+    ValidationDecision,
+)
+from .rule_registry import is_enabled
+from .rules import RULE_CHANGES, apply_rules
+from .validation import decide_run_validation
+from .versions import (
+    MigrationContext,
+    compiler_version_for_source_validation,
+    compiler_version_for_spec,
+    default_evm_version_for_spec,
+    infer_pragma,
+)
+
+
+CandidateSource = Callable[[Path, str], str]
+
+
+class CandidatePathConflictError(ValueError):
+    """Raised when multiple migration candidates resolve to one destination."""
+
+
+@dataclass(frozen=True)
+class SourceCompileAttempt:
+    """One compiler attempt and the source version rules should use if it wins."""
+
+    compile_version: str | None
+    rule_version: str | None
+    compiler_label: str | None = None
+
+
+@dataclass(frozen=True)
+class MigrationRequest:
+    path: Path
+    original: str
+    source_version: str | None
+    source_attempts: tuple[SourceCompileAttempt, ...]
+    skip_target_on_vyd016: bool = True
+
+
+@dataclass
+class MigrationFile:
+    request: MigrationRequest
+    rewrite: RewriteResult
+    report: FileReport
+    source_compile: CompileResult
+    source_version: str | None
+    source_compiler: str | None
+    target_compile: CompileResult | None = None
+    validation_diagnostics: list[Diagnostic] = field(default_factory=list)
+
+    @property
+    def path(self) -> Path:
+        return self.request.path
+
+    @property
+    def original(self) -> str:
+        return self.request.original
+
+
+@dataclass
+class GeneratedMigration:
+    file: GeneratedFile
+    report: FileReport
+    target_compile: CompileResult | None = None
+    validation_diagnostics: list[Diagnostic] = field(default_factory=list)
+
+
+@dataclass
+class MigrationBatch:
+    files: list[MigrationFile]
+    generated: list[GeneratedMigration]
+
+    @property
+    def reports(self) -> list[FileReport]:
+        return [
+            *(migration.report for migration in self.files),
+            *(migration.report for migration in self.generated),
+        ]
+
+
+def bounded_migration_request(path: Path, original: str, config: Config) -> MigrationRequest:
+    """Build the target-bounded source compiler request used by the CLI."""
+    source_version = config.source_version or infer_pragma(original)
+    context = MigrationContext.from_specs(source_version, config.target_version)
+    if context.source_newer_than_target():
+        attempts: tuple[SourceCompileAttempt, ...] = ()
+    elif config.source_vyper:
+        attempts = (SourceCompileAttempt(source_version, source_version),)
+    else:
+        compiler = compiler_version_for_source_validation(
+            source_version, config.target_version, original
+        )
+        attempts = (SourceCompileAttempt(compiler, source_version, compiler),)
+    return MigrationRequest(path, original, source_version, attempts)
+
+
+def prepare_migrations(
+    requests: Iterable[MigrationRequest], config: Config
+) -> MigrationBatch:
+    """Compile and rewrite sources without mutating their destinations."""
+    files: list[MigrationFile] = []
+    for request in requests:
+        attempt, source_compile = _compile_source(request, config)
+        source_version = (
+            attempt.rule_version if attempt is not None else request.source_version
+        )
+        source_compiler = attempt.compiler_label if attempt is not None else None
+        source_ast = (
+            source_compile.artifacts.get("ast") if source_compile.artifacts else None
+        )
+        # Config.source_ast remains the compatibility bridge for rules, but this
+        # derived config belongs to this file and is never reused by another file.
+        file_config = replace(
+            config,
+            source_version=source_version,
+            source_ast=source_ast if isinstance(source_ast, dict) else None,
+        )
+        rewrite = apply_rules(request.original, file_config, request.path)
+        if (
+            config.split_interfaces
+            and request.path.suffix == ".vy"
+            and not MigrationContext.from_specs(
+                source_version, config.target_version
+            ).source_newer_than_target()
+            and _rule_enabled("VY120", source_version, config)
+        ):
+            split = split_interfaces_to_vyi(rewrite.source, request.path)
+            rewrite.source = split.source
+            rewrite.fixes.extend(split.fixes)
+            rewrite.generated_files.extend(split.generated)
+
+        report = FileReport(
+            path=request.path,
+            changed=request.original != rewrite.source,
+            fixes=rewrite.fixes,
+            # Validation diagnostics belong to the report, not the rule result.
+            # Keeping these lists independent preserves rule-only consumers such
+            # as the corpus result's `diagnostics` field.
+            diagnostics=list(rewrite.diagnostics),
+            source_version=source_version,
+            source_compiler=source_compiler,
+            source_compile=source_compile.status,
+            source_unavailable_formats=list(
+                getattr(source_compile, "unavailable_formats", ())
+            ),
+            source_error=(
+                source_compile.stderr if source_compile.status == "failed" else None
+            ),
+        )
+        if source_compile.status != "skipped":
+            report.source_unavailable_artifacts = unavailable_validation_artifacts(
+                source_compile
+            )
+        files.append(
+            MigrationFile(
+                request,
+                rewrite,
+                report,
+                source_compile,
+                source_version,
+                source_compiler,
+            )
+        )
+
+    generated = [
+        GeneratedMigration(
+            generated_file,
+            FileReport(
+                path=generated_file.path,
+                changed=True,
+                fixes=[generated_file.fix],
+            ),
+        )
+        for migration in files
+        for generated_file in getattr(migration.rewrite, "generated_files", ())
+    ]
+    return MigrationBatch(files, generated)
+
+
+def validate_migrations(
+    batch: MigrationBatch,
+    config: Config,
+    candidate_source: CandidateSource | None = None,
+) -> ValidationDecision:
+    """Validate one coherent candidate overlay and return its typed decision."""
+    resolve_candidate = candidate_source or _unchanged_candidate
+    target_sources = _candidate_sources(batch, resolve_candidate)
+
+    with target_overlay(
+        target_sources, config.target_version, config.compiler_search_paths
+    ) as overlay:
+        for migration in batch.files:
+            _reset_target_validation(
+                migration.report, migration.validation_diagnostics
+            )
+            migration.target_compile = None
+            if (
+                migration.request.skip_target_on_vyd016
+                and any(
+                    diagnostic.rule == "VYD016"
+                    for diagnostic in migration.report.diagnostics
+                )
+            ):
+                continue
+            target_compile = compile_target_source(
+                migration.path,
+                target_sources[migration.path],
+                config,
+                overlay,
+            )
+            migration.target_compile = target_compile
+            _record_target_compile(migration.report, target_compile)
+            (
+                migration.report.abi_equal,
+                migration.report.method_ids_equal,
+                migration.report.storage_layout_equal,
+            ) = compare_artifacts(migration.source_compile, target_compile)
+            (
+                migration.report.abi_diff,
+                migration.report.method_id_diff,
+                migration.report.storage_layout_diff,
+            ) = compare_artifact_details(migration.source_compile, target_compile)
+            migration.validation_diagnostics.extend(
+                _add_validation_diagnostics(
+                    migration.report,
+                    migration.source_version,
+                    config,
+                    migration.source_compiler,
+                )
+            )
+
+        for migration in batch.generated:
+            _reset_target_validation(
+                migration.report, migration.validation_diagnostics
+            )
+            migration.target_compile = None
+            target_compile = compile_target_source(
+                migration.file.path,
+                target_sources[migration.file.path],
+                config,
+                overlay,
+            )
+            migration.target_compile = target_compile
+            _record_target_compile(migration.report, target_compile)
+
+    return decide_run_validation(batch.reports, config)
+
+
+def _compile_source(
+    request: MigrationRequest, config: Config
+) -> tuple[SourceCompileAttempt | None, CompileResult]:
+    if not request.source_attempts:
+        return None, CompileResult("skipped")
+
+    first_attempt: SourceCompileAttempt | None = None
+    first_result: CompileResult | None = None
+    for attempt in request.source_attempts:
+        attempt_config = replace(
+            config, source_version=attempt.rule_version, source_ast=None
+        )
+        result = compile_source_file(
+            request.path, attempt_config, attempt.compile_version
+        )
+        if first_result is None:
+            first_attempt = attempt
+            first_result = result
+        if result.status == "passed":
+            return attempt, result
+    assert first_attempt is not None and first_result is not None
+    return first_attempt, first_result
+
+
+def _unchanged_candidate(_path: Path, source: str) -> str:
+    return source
+
+
+def _candidate_sources(
+    batch: MigrationBatch, resolve_candidate: CandidateSource
+) -> dict[Path, str]:
+    candidates = [
+        *(
+            (
+                migration.path,
+                migration.rewrite.source,
+                False,
+                migration.original,
+            )
+            for migration in batch.files
+        ),
+        *(
+            (migration.file.path, migration.file.source, True, None)
+            for migration in batch.generated
+        ),
+    ]
+    destinations: dict[Path, tuple[Path, str, bool, bool]] = {}
+    target_sources: dict[Path, str] = {}
+    for path, fallback, generated, original in candidates:
+        candidate = resolve_candidate(path, fallback)
+        destination = path.resolve()
+        previous = destinations.get(destination)
+        if previous is not None:
+            (
+                previous_path,
+                previous_candidate,
+                generated_seen,
+                source_aliasable,
+            ) = previous
+            # MigrationPlan permits an existing, unchanged discovered source to
+            # satisfy one identical generated output as a no-op. Preserve that
+            # alias while still rejecting duplicate sources, differing bytes,
+            # and more than one generator for a destination.
+            if (
+                generated
+                and source_aliasable
+                and not generated_seen
+                and candidate == previous_candidate
+            ):
+                destinations[destination] = (
+                    previous_path,
+                    previous_candidate,
+                    True,
+                    True,
+                )
+                target_sources[path] = candidate
+                continue
+            raise CandidatePathConflictError(
+                f"migration candidates {previous_path} and {path} resolve to the same "
+                f"destination {destination}"
+            )
+        destinations[destination] = (
+            path,
+            candidate,
+            generated,
+            not generated and candidate == original,
+        )
+        target_sources[path] = candidate
+    return target_sources
+
+
+def _record_target_compile(report: FileReport, target_compile: CompileResult) -> None:
+    report.target_compile = target_compile.status
+    report.target_unavailable_artifacts = unavailable_validation_artifacts(target_compile)
+    report.target_unavailable_formats = list(
+        getattr(target_compile, "unavailable_formats", ())
+    )
+    report.target_error = (
+        target_compile.stderr if target_compile.status == "failed" else None
+    )
+
+
+def _reset_target_validation(
+    report: FileReport, validation_diagnostics: list[Diagnostic]
+) -> None:
+    report.target_compile = "skipped"
+    report.target_unavailable_artifacts.clear()
+    report.target_unavailable_formats.clear()
+    report.target_error = None
+    report.abi_equal = None
+    report.method_ids_equal = None
+    report.storage_layout_equal = None
+    report.abi_diff.clear()
+    report.method_id_diff.clear()
+    report.storage_layout_diff.clear()
+    report.validation_decision = ValidationDecision()
+    validation_ids = {id(diagnostic) for diagnostic in validation_diagnostics}
+    if validation_ids:
+        report.diagnostics = [
+            diagnostic
+            for diagnostic in report.diagnostics
+            if id(diagnostic) not in validation_ids
+        ]
+    validation_diagnostics.clear()
+
+
+def _add_validation_diagnostics(
+    file_report: FileReport,
+    source_version: str | None,
+    config: Config,
+    source_compiler: str | None = None,
+) -> list[Diagnostic]:
+    added: list[Diagnostic] = []
+
+    def add(diagnostic: Diagnostic) -> None:
+        if _rule_enabled(diagnostic.rule, source_version, config):
+            file_report.diagnostics.append(diagnostic)
+            added.append(diagnostic)
+
+    if file_report.source_compile == "failed":
+        add(
+            Diagnostic(
+                "VYD006",
+                1,
+                "source compile failed under declared or inferred source compiler",
+            )
+        )
+    if file_report.abi_equal is False:
+        add(Diagnostic("VYD007", 1, "ABI changed after migration"))
+    if file_report.method_ids_equal is False:
+        add(Diagnostic("VYD007", 1, "method identifiers changed after migration"))
+    if file_report.storage_layout_equal is False:
+        add(Diagnostic("VYD008", 1, "storage layout changed after migration"))
+    evm_diagnostic = _evm_default_diagnostic(
+        source_compiler or source_version, config.target_version
+    )
+    if evm_diagnostic is not None:
+        add(evm_diagnostic)
+    return added
+
+
+def _rule_enabled(rule: str, source_version: str | None, config: Config) -> bool:
+    context = MigrationContext.from_specs(source_version, config.target_version)
+    return is_enabled(rule, config, context, RULE_CHANGES)
+
+
+def _evm_default_diagnostic(
+    source_version: str | None, target_version: str
+) -> Diagnostic | None:
+    source_evm = default_evm_version_for_spec(source_version)
+    target_evm = default_evm_version_for_spec(target_version)
+    if source_evm is not None and target_evm is not None:
+        if source_evm == target_evm:
+            return None
+        source_compiler = compiler_version_for_spec(source_version) or "unknown"
+        target_compiler = compiler_version_for_spec(target_version) or target_version
+        return Diagnostic(
+            "VYD009",
+            1,
+            f"default EVM version changed from {source_evm} (source compiler {source_compiler}) to {target_evm} (target compiler {target_compiler}); review or pin explicitly",
+        )
+    context = MigrationContext.from_specs(source_version, target_version)
+    if not context.crosses("0.4.0"):
+        return None
+    if target_evm is not None:
+        message = (
+            f"target compiler defaults to EVM {target_evm}; "
+            "source-era default is unknown; review or pin explicitly"
+        )
+    else:
+        message = (
+            "target compiler default EVM version differs from source-era default; "
+            "review or pin explicitly"
+        )
+    return Diagnostic("VYD009", 1, message)

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -17,6 +17,7 @@ ValidationIssueCode = Literal[
     "method_identifiers_changed",
     "storage_layout_changed",
 ]
+REPORT_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -171,6 +172,7 @@ class RunReport:
 
     def to_json_obj(self) -> dict[str, Any]:
         return {
+            "schema_version": REPORT_SCHEMA_VERSION,
             "source_version": self.source_version,
             "target_version": self.target_version,
             "write_requested": self.write_requested,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,9 +8,10 @@ from pathlib import Path
 
 import pytest
 
-from vyupgrade import cli
-from vyupgrade.cli import _add_validation_diagnostics, _evm_default_diagnostic, _write_diff, main
+from vyupgrade import cli, engine
+from vyupgrade.cli import _write_diff, main
 from vyupgrade.compiler import CompileResult
+from vyupgrade.engine import _add_validation_diagnostics, _evm_default_diagnostic
 from vyupgrade.models import Config, Diagnostic, FileReport
 
 
@@ -37,8 +38,8 @@ def passing_compiler(monkeypatch):
     ) -> CompileResult:
         return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
 
-    monkeypatch.setattr(cli, "compile_source_file", compile_source_file)
-    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(engine, "compile_source_file", compile_source_file)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target_source)
     return None
 
 
@@ -52,7 +53,7 @@ def failing_target_compiler(monkeypatch, passing_compiler):
     ) -> CompileResult:
         return CompileResult("failed", stderr="target failed")
 
-    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target_source)
     return None
 
 
@@ -136,8 +137,8 @@ def f() -> uint256:
     ) -> CompileResult:
         return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
 
-    monkeypatch.setattr(cli, "compile_source_file", compile_source_file)
-    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(engine, "compile_source_file", compile_source_file)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target_source)
 
     report = tmp_path / "report.json"
     code = main([str(contract), "--check", "--report-json", str(report)])
@@ -182,8 +183,8 @@ def f() -> uint256:
     ) -> CompileResult:
         return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
 
-    monkeypatch.setattr(cli, "compile_source_file", compile_source_file)
-    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(engine, "compile_source_file", compile_source_file)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target_source)
 
     report = tmp_path / "report.json"
     code = main(
@@ -319,7 +320,7 @@ def test_formatter_runs_on_staged_candidates_and_final_bytes_are_revalidated(
     )
     report = tmp_path / "report.json"
     compiled: list[str] = []
-    original_apply_rules = cli.apply_rules
+    original_apply_rules = engine.apply_rules
 
     def apply_rules_with_diagnostic(source, config, path):
         result = original_apply_rules(source, config, path)
@@ -338,8 +339,8 @@ def test_formatter_runs_on_staged_candidates_and_final_bytes_are_revalidated(
         staged.write_text(staged.read_text(encoding="utf-8") + "# formatted\n", encoding="utf-8")
         return cli.subprocess.CompletedProcess(command, 0, "", "")
 
-    monkeypatch.setattr(cli, "apply_rules", apply_rules_with_diagnostic)
-    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(engine, "apply_rules", apply_rules_with_diagnostic)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target_source)
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
     code = main(
@@ -391,7 +392,7 @@ def test_formatter_output_that_fails_final_validation_is_not_committed(
         )
         return cli.subprocess.CompletedProcess(command, 0, "", "")
 
-    monkeypatch.setattr(cli, "compile_target_source", compile_target_source)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target_source)
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
     code = main(
@@ -435,7 +436,7 @@ interface Token:
         )
         return cli.subprocess.CompletedProcess(command, 0, "", "")
 
-    monkeypatch.setattr(cli, "compile_target_source", compile_target)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target)
     monkeypatch.setattr(cli.subprocess, "run", break_staged_interface)
 
     code = main(
@@ -611,7 +612,7 @@ def test_write_mode_does_not_write_when_source_compile_fails(
     contract.write_text(original, encoding="utf-8")
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult("failed", stderr="source failed"),
     )
@@ -635,7 +636,7 @@ def test_allow_unvalidated_source_waives_source_failure(
     )
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult("failed", stderr="source failed"),
     )
@@ -669,14 +670,14 @@ def test_patch_level_abi_mismatch_blocks_even_when_diagnostic_is_ignored(
     contract.write_text(original, encoding="utf-8")
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult(
             "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
         ),
     )
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_target_source",
         lambda *_args: CompileResult(
             "passed",
@@ -744,14 +745,14 @@ def test_artifact_change_waivers_are_narrow_and_reported(
     )
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult(
             "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
         ),
     )
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_target_source",
         lambda *_args: CompileResult("passed", artifacts=target_artifacts),
     )
@@ -782,14 +783,14 @@ def test_artifact_waiver_does_not_cover_other_diff_classes(
     contract.write_text(original, encoding="utf-8")
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult(
             "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
         ),
     )
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_target_source",
         lambda *_args: CompileResult(
             "passed",
@@ -831,7 +832,7 @@ def test_missing_source_artifact_blocks_without_source_waiver(
     contract.write_text(original, encoding="utf-8")
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult(
             "degraded",
@@ -857,7 +858,7 @@ def test_optional_source_ast_unavailability_is_degraded_but_safe(
     )
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult(
             "degraded",
@@ -883,7 +884,7 @@ def test_missing_target_artifact_is_not_waived_by_source_or_diff_flags(
     contract.write_text(original, encoding="utf-8")
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_target_source",
         lambda *_args: CompileResult(
             "passed", artifacts={"abi": [], "method_identifiers": {}}
@@ -915,7 +916,7 @@ def test_malformed_target_artifacts_block_write(
     contract.write_text(original, encoding="utf-8")
     report = tmp_path / "report.json"
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_target_source",
         lambda *_args: CompileResult(
             "passed",
@@ -1011,7 +1012,7 @@ interface Token:
             return CompileResult("failed", stderr="generated interface failed")
         return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
 
-    monkeypatch.setattr(cli, "compile_target_source", fail_generated)
+    monkeypatch.setattr(engine, "compile_target_source", fail_generated)
 
     code = main(
         [
@@ -1116,9 +1117,11 @@ def balanceOf(owner: address) -> uint256: ...
 
     code = main(
         [
-            str(contract),
+            str(tmp_path),
             "--write",
             "--split-interfaces",
+            "--ignore",
+            "VY001,VYD005",
             "--report-json",
             str(report),
         ]
@@ -1127,11 +1130,15 @@ def balanceOf(owner: address) -> uint256: ...
     assert code == 0
     assert "import Token" in contract.read_text(encoding="utf-8")
     assert token.read_text(encoding="utf-8") == token_source
-    token_report = next(
+    token_reports = [
         item for item in json.loads(report.read_text())["files"] if item["path"] == str(token)
+    ]
+    assert len(token_reports) == 2
+    assert all(item["changed"] is False for item in token_reports)
+    assert all(
+        item["original_sha256"] == item["candidate_sha256"]
+        for item in token_reports
     )
-    assert token_report["changed"] is False
-    assert token_report["original_sha256"] == token_report["candidate_sha256"]
 
 
 def test_split_interfaces_respects_rule_ignore(tmp_path: Path, passing_compiler) -> None:
@@ -1211,7 +1218,7 @@ allow-unvalidated-source = true
         encoding="utf-8",
     )
     monkeypatch.setattr(
-        cli,
+        engine,
         "compile_source_file",
         lambda *_args: CompileResult("failed", stderr="source failed"),
     )

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -570,6 +570,57 @@ def test_smoke_resumes_an_ordered_prefix_and_only_submits_remaining_items(
     assert summary["total"] == 3
 
 
+def test_smoke_does_not_resume_unversioned_result_rows(
+    monkeypatch, tmp_path: Path
+) -> None:
+    corpus = _load_corpus_module()
+    items = [{"index": index, "repo": "test"} for index in range(2)]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    output_path = tmp_path / "smoke-results.json"
+    target_version = "0.4.3"
+    identity = corpus._smoke_run_identity(manifest_path, target_version, items)
+    legacy_results = [
+        {
+            **items[0],
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": target_version,
+        }
+    ]
+    corpus._atomic_write_json(output_path, legacy_results)
+    corpus._atomic_write_json(
+        corpus._checkpoint_path(output_path),
+        {
+            "checkpoint_version": 2,
+            "identity": identity,
+            "completed": 1,
+            "results_sha256": corpus._json_digest(legacy_results),
+        },
+    )
+    submitted: list[int] = []
+
+    def fake_smoke_one(item, requested_target):
+        submitted.append(item["index"])
+        return {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": requested_target,
+        }
+
+    monkeypatch.setattr(corpus, "_smoke_one", fake_smoke_one)
+
+    corpus.smoke_corpus(manifest_path, output_path, target_version, 2, 0)
+
+    assert sorted(submitted) == [0, 1]
+    results = json.loads(output_path.read_text(encoding="utf-8"))
+    assert all(
+        result["smoke_schema_version"] == corpus.SMOKE_RESULT_SCHEMA_VERSION
+        for result in results
+    )
+
+
 def test_smoke_does_not_resume_when_run_identity_changes(monkeypatch, tmp_path: Path) -> None:
     corpus = _load_corpus_module()
     items = [{"index": index, "repo": "test"} for index in range(2)]
@@ -766,10 +817,10 @@ def test_smoke_uses_manifest_pragma_as_source_version(monkeypatch, tmp_path: Pat
     def fake_compile_source_file(path, config, source_version):
         return SimpleNamespace(status="passed", artifacts={}, stderr=None)
 
-    monkeypatch.setattr(corpus, "apply_rules", fake_apply_rules)
-    monkeypatch.setattr(corpus, "compile_source_file", fake_compile_source_file)
+    monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
+    monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "compile_target_source",
         lambda path, source, config, overlay: SimpleNamespace(
             status="passed", artifacts={}, stderr=None
@@ -781,6 +832,11 @@ def test_smoke_uses_manifest_pragma_as_source_version(monkeypatch, tmp_path: Pat
     assert seen["source_version"] == "0.3.0"
     assert result["source_compile"] == "passed"
     assert result["target_compile"] == "passed"
+    assert result["validation_status"] == "blocked"
+    assert result["validation_blockers"][0]["code"] == (
+        "target_artifacts_unavailable"
+    )
+    assert result["validation_waivers"] == []
 
 
 def test_smoke_records_artifact_diff_details_for_mismatches(monkeypatch, tmp_path: Path) -> None:
@@ -796,27 +852,31 @@ def test_smoke_records_artifact_diff_details_for_mismatches(monkeypatch, tmp_pat
     }
 
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "compile_source_file",
         lambda path, config, source_version: SimpleNamespace(
             status="passed", artifacts={}, stderr=None
         ),
     )
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "compile_target_source",
         lambda path, source, config, overlay: SimpleNamespace(
             status="passed", artifacts={}, stderr=None
         ),
     )
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "apply_rules",
         lambda source, config, path: SimpleNamespace(source=source, fixes=[], diagnostics=[]),
     )
-    monkeypatch.setattr(corpus, "compare_artifacts", lambda source, target: (False, True, False))
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
+        "compare_artifacts",
+        lambda source, target: (False, True, False),
+    )
+    monkeypatch.setattr(
+        corpus.engine,
         "compare_artifact_details",
         lambda source, target: (
             ["changed ABI entry: f(): stateMutability 'view' -> 'nonpayable'"],
@@ -860,10 +920,10 @@ def test_smoke_raises_broad_pragma_source_version_from_syntax(monkeypatch, tmp_p
         seen["compile_version"] = source_version
         return SimpleNamespace(status="passed", artifacts={}, stderr=None)
 
-    monkeypatch.setattr(corpus, "apply_rules", fake_apply_rules)
-    monkeypatch.setattr(corpus, "compile_source_file", fake_compile_source_file)
+    monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
+    monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "compile_target_source",
         lambda path, source, config, overlay: SimpleNamespace(
             status="passed", artifacts={}, stderr=None
@@ -902,10 +962,10 @@ def test_smoke_retries_broad_pragma_with_newer_source_compiler(
         seen["rewrite_version"] = config.source_version
         return SimpleNamespace(source=source, fixes=[], diagnostics=[])
 
-    monkeypatch.setattr(corpus, "compile_source_file", fake_compile_source_file)
-    monkeypatch.setattr(corpus, "apply_rules", fake_apply_rules)
+    monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
+    monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "compile_target_source",
         lambda path, source, config, overlay: SimpleNamespace(
             status="passed", artifacts={}, stderr=None
@@ -942,10 +1002,10 @@ def test_smoke_uses_standard_json_compiler_version_for_source(monkeypatch, tmp_p
         seen["compile_version"] = source_version
         return SimpleNamespace(status="passed", artifacts={}, stderr=None)
 
-    monkeypatch.setattr(corpus, "apply_rules", fake_apply_rules)
-    monkeypatch.setattr(corpus, "compile_source_file", fake_compile_source_file)
+    monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
+    monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "compile_target_source",
         lambda path, source, config, overlay: SimpleNamespace(
             status="passed", artifacts={}, stderr=None
@@ -995,10 +1055,10 @@ def test_smoke_uses_standard_json_search_paths(monkeypatch, tmp_path: Path) -> N
         seen["source_paths"] = config.compiler_search_paths
         return SimpleNamespace(status="passed", artifacts={}, stderr=None)
 
-    monkeypatch.setattr(corpus, "apply_rules", fake_apply_rules)
-    monkeypatch.setattr(corpus, "compile_source_file", fake_compile_source_file)
+    monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
+    monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
-        corpus,
+        corpus.engine,
         "compile_target_source",
         lambda path, source, config, overlay: SimpleNamespace(
             status="passed", artifacts={}, stderr=None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from vyupgrade import engine
+from vyupgrade.compiler import CompileResult
+from vyupgrade.engine import MigrationRequest, SourceCompileAttempt
+from vyupgrade.models import Config, Diagnostic, Fix, GeneratedFile, RewriteResult
+
+
+VALIDATION_ARTIFACTS = {"abi": [], "method_identifiers": {}, "layout": {}}
+SOURCE_ARTIFACTS = {**VALIDATION_ARTIFACTS, "ast": {}}
+
+
+def _config(tmp_path: Path, **kwargs) -> Config:
+    values = {"paths": (tmp_path,), "target_version": "0.4.3"}
+    values.update(kwargs)
+    return Config(**values)
+
+
+def _request(
+    path: Path,
+    source_version: str = "0.3.10",
+    attempts: tuple[SourceCompileAttempt, ...] | None = None,
+) -> MigrationRequest:
+    return MigrationRequest(
+        path,
+        "#pragma version 0.3.10\nx: uint256\n",
+        source_version,
+        attempts or (SourceCompileAttempt(source_version, source_version),),
+    )
+
+
+def _unchanged_rewrite(source, config, path) -> RewriteResult:
+    return RewriteResult(source, [], [])
+
+
+def test_bounded_request_preserves_cli_compiler_selection(tmp_path: Path) -> None:
+    path = tmp_path / "Contract.vy"
+    source = "#pragma version >0.3.10\nx: uint256\n"
+
+    inferred = engine.bounded_migration_request(path, source, _config(tmp_path))
+    explicit = engine.bounded_migration_request(
+        path, source, _config(tmp_path, source_vyper="/tmp/vyper")
+    )
+
+    assert inferred.source_attempts == (
+        SourceCompileAttempt("0.4.3", ">0.3.10", "0.4.3"),
+    )
+    assert explicit.source_attempts == (
+        SourceCompileAttempt(">0.3.10", ">0.3.10"),
+    )
+
+
+def test_prepare_uses_first_passing_retry_and_its_rule_version(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "Contract.vy"
+    attempts = tuple(
+        SourceCompileAttempt(version, version)
+        for version in ("0.3.0", "0.3.1", "0.3.2")
+    )
+    seen: dict[str, object] = {"compile": []}
+
+    def compile_source(path, config, source_version):
+        seen["compile"].append(source_version)
+        if source_version == "0.3.0":
+            return CompileResult("failed", stderr="first failed")
+        return CompileResult("passed", artifacts=SOURCE_ARTIFACTS)
+
+    def apply(source, config, path):
+        seen["rule_version"] = config.source_version
+        return RewriteResult(source, [], [])
+
+    monkeypatch.setattr(engine, "compile_source_file", compile_source)
+    monkeypatch.setattr(engine, "apply_rules", apply)
+
+    batch = engine.prepare_migrations(
+        (_request(path, "0.3.0", attempts),), _config(tmp_path)
+    )
+
+    assert seen == {"compile": ["0.3.0", "0.3.1"], "rule_version": "0.3.1"}
+    assert batch.files[0].source_version == "0.3.1"
+    assert batch.files[0].source_compile.status == "passed"
+
+
+def test_prepare_retains_first_failure_when_all_retries_fail(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "Contract.vy"
+    attempts = tuple(
+        SourceCompileAttempt(version, version)
+        for version in ("0.3.0", "0.3.1", "0.3.2")
+    )
+    seen: dict[str, object] = {"compile": []}
+
+    def compile_source(path, config, source_version):
+        seen["compile"].append(source_version)
+        return CompileResult("failed", stderr=f"failed {source_version}")
+
+    def apply(source, config, path):
+        seen["rule_version"] = config.source_version
+        return RewriteResult(source, [], [])
+
+    monkeypatch.setattr(engine, "compile_source_file", compile_source)
+    monkeypatch.setattr(engine, "apply_rules", apply)
+
+    batch = engine.prepare_migrations(
+        (_request(path, "0.3.0", attempts),), _config(tmp_path)
+    )
+
+    assert seen == {
+        "compile": ["0.3.0", "0.3.1", "0.3.2"],
+        "rule_version": "0.3.0",
+    }
+    assert batch.files[0].source_compile.stderr == "failed 0.3.0"
+
+
+def test_source_ast_is_owned_by_each_file(monkeypatch, tmp_path: Path) -> None:
+    first = tmp_path / "First.vy"
+    second = tmp_path / "Second.vy"
+    asts: dict[str, object] = {}
+
+    def compile_source(path, config, source_version):
+        artifacts = dict(VALIDATION_ARTIFACTS)
+        if path == first:
+            artifacts["ast"] = {"owner": "first"}
+        return CompileResult("passed", artifacts=artifacts)
+
+    def apply(source, config, path):
+        asts[path.name] = config.source_ast
+        return RewriteResult(source, [], [])
+
+    monkeypatch.setattr(engine, "compile_source_file", compile_source)
+    monkeypatch.setattr(engine, "apply_rules", apply)
+    config = _config(tmp_path, source_ast={"stale": True})
+
+    engine.prepare_migrations((_request(first), _request(second)), config)
+
+    assert asts == {"First.vy": {"owner": "first"}, "Second.vy": None}
+    assert config.source_ast == {"stale": True}
+
+
+def test_newer_source_cannot_split_interfaces_when_diagnostic_is_ignored(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "Main.vy"
+    original = """#pragma version >=0.5.0a1,<0.6.0
+
+interface Token:
+    def balanceOf(owner: address) -> uint256: view
+"""
+    request = MigrationRequest(
+        path,
+        original,
+        ">=0.5.0a1,<0.6.0",
+        (),
+    )
+    config = _config(
+        tmp_path,
+        split_interfaces=True,
+        ignore=frozenset({"VYD016"}),
+    )
+
+    batch = engine.prepare_migrations((request,), config)
+
+    assert batch.files[0].rewrite.source == original
+    assert batch.files[0].report.diagnostics == []
+    assert batch.files[0].report.changed is False
+    assert batch.generated == []
+
+
+def test_candidate_override_and_revalidation_reset_only_engine_diagnostics(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "Contract.vy"
+    rule_diagnostic = Diagnostic("VYD007", 9, "rule-owned diagnostic")
+    compiled: list[str] = []
+
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+    monkeypatch.setattr(
+        engine,
+        "apply_rules",
+        lambda source, config, path: RewriteResult(
+            source + "# rewritten\n", [], [rule_diagnostic]
+        ),
+    )
+
+    def compile_target(path, source, config, overlay):
+        compiled.append(source)
+        artifacts = (
+            {
+                **VALIDATION_ARTIFACTS,
+                "abi": [{"type": "function", "name": "changed", "inputs": []}],
+            }
+            if len(compiled) == 1
+            else VALIDATION_ARTIFACTS
+        )
+        return CompileResult("passed", artifacts=artifacts)
+
+    monkeypatch.setattr(engine, "compile_target_source", compile_target)
+    batch = engine.prepare_migrations((_request(path),), _config(tmp_path))
+
+    first = engine.validate_migrations(
+        batch, _config(tmp_path), lambda _path, _fallback: "# formatted one\n"
+    )
+    second = engine.validate_migrations(
+        batch, _config(tmp_path), lambda _path, _fallback: "# formatted two\n"
+    )
+
+    assert compiled == ["# formatted one\n", "# formatted two\n"]
+    assert first.status == "blocked"
+    assert second.status == "passed"
+    assert batch.files[0].report.abi_diff == []
+    assert [
+        diagnostic
+        for diagnostic in batch.files[0].report.diagnostics
+        if diagnostic.rule == "VYD007"
+    ] == [rule_diagnostic]
+
+
+def test_generated_interface_and_cross_file_sources_share_one_overlay(
+    monkeypatch, tmp_path: Path
+) -> None:
+    first = tmp_path / "First.vy"
+    second = tmp_path / "Second.vy"
+    interface = tmp_path / "Shared.vyi"
+    overlay_sources: dict[Path, str] = {}
+    compiled: list[tuple[Path, object]] = []
+    overlay_token = object()
+
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+
+    def apply(source, config, path):
+        generated = []
+        if path == first:
+            generated.append(
+                GeneratedFile(
+                    interface,
+                    "@external\ndef ping(): ...\n",
+                    Fix("VY120", 1, "split interface", "", ""),
+                )
+            )
+        return RewriteResult(source, [], [], generated)
+
+    @contextmanager
+    def overlay(sources, target_version, search_paths):
+        overlay_sources.update(sources)
+        yield overlay_token
+
+    def compile_target(path, source, config, overlay):
+        compiled.append((path, overlay))
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    monkeypatch.setattr(engine, "apply_rules", apply)
+    monkeypatch.setattr(engine, "target_overlay", overlay)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target)
+    batch = engine.prepare_migrations((_request(first), _request(second)), _config(tmp_path))
+
+    decision = engine.validate_migrations(batch, _config(tmp_path))
+
+    assert set(overlay_sources) == {first, second, interface}
+    assert {path for path, _overlay in compiled} == {first, second, interface}
+    assert all(used_overlay is overlay_token for _path, used_overlay in compiled)
+    assert batch.generated[0].report.target_compile == "passed"
+    assert decision.status == "passed"
+
+
+def test_validation_rejects_duplicate_resolved_destinations(
+    monkeypatch, tmp_path: Path
+) -> None:
+    first = tmp_path / "First.vy"
+    second = tmp_path / "Second.vy"
+    interface = tmp_path / "Shared.vyi"
+
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+
+    def apply(source, config, path):
+        declaration = "one" if path == first else "two"
+        generated = GeneratedFile(
+            interface,
+            f"@external\ndef {declaration}(): ...\n",
+            Fix("VY120", 1, "split interface", "", ""),
+        )
+        return RewriteResult(source, [], [], [generated])
+
+    monkeypatch.setattr(engine, "apply_rules", apply)
+    batch = engine.prepare_migrations(
+        (_request(first), _request(second)), _config(tmp_path)
+    )
+
+    with pytest.raises(engine.CandidatePathConflictError, match=r"Shared\.vyi"):
+        engine.validate_migrations(batch, _config(tmp_path))
+
+
+def test_malformed_target_artifacts_remain_unwaivable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "Contract.vy"
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+    monkeypatch.setattr(
+        engine,
+        "compile_target_source",
+        lambda *_args: CompileResult(
+            "passed",
+            artifacts={
+                "abi": [None],
+                "method_identifiers": {},
+                "layout": {"storage_layout": []},
+            },
+        ),
+    )
+    config = _config(
+        tmp_path,
+        allow_unvalidated_source=True,
+        allow_abi_change=True,
+        allow_method_id_change=True,
+        allow_storage_layout_change=True,
+    )
+    batch = engine.prepare_migrations((_request(path),), config)
+
+    decision = engine.validate_migrations(batch, config)
+
+    assert decision.status == "blocked"
+    assert decision.blockers[0].code == "target_artifacts_unavailable"
+
+
+def test_source_failure_uses_typed_waiver(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "Contract.vy"
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("failed", stderr="source failed"),
+    )
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+    monkeypatch.setattr(
+        engine,
+        "compile_target_source",
+        lambda *_args: CompileResult("passed", artifacts=VALIDATION_ARTIFACTS),
+    )
+    config = _config(tmp_path, allow_unvalidated_source=True)
+    batch = engine.prepare_migrations((_request(path),), config)
+
+    decision = engine.validate_migrations(batch, config)
+
+    assert decision.status == "waived"
+    assert [issue.code for issue in decision.waivers] == ["source_compile_failed"]
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        (CompileResult("passed", artifacts=VALIDATION_ARTIFACTS), "passed"),
+        (CompileResult("failed", stderr="interface failed"), "blocked"),
+    ],
+)
+def test_interface_validation_is_target_only(
+    target: CompileResult, expected: str, monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "Interface.vyi"
+    request = MigrationRequest(
+        path,
+        "@external\ndef ping(): ...\n",
+        "0.3.10",
+        (SourceCompileAttempt("0.3.10", "0.3.10"),),
+    )
+    monkeypatch.setattr(
+        engine, "compile_source_file", lambda *_args: CompileResult("skipped")
+    )
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+    monkeypatch.setattr(engine, "compile_target_source", lambda *_args: target)
+    config = _config(tmp_path)
+    batch = engine.prepare_migrations((request,), config)
+
+    decision = engine.validate_migrations(batch, config)
+
+    assert batch.files[0].report.source_compile == "skipped"
+    assert decision.status == expected

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -49,6 +49,16 @@ def test_render_text_includes_compile_errors() -> None:
     assert 'Version specification "0.2.11" is not compatible' in text
 
 
+def test_json_report_declares_additive_schema_version() -> None:
+    report = RunReport(source_version=None, target_version="0.4.3", files=[])
+
+    data = report.to_json_obj()
+
+    assert data["schema_version"] == 1
+    assert data["files"] == []
+    assert data["target_version"] == "0.4.3"
+
+
 def test_render_text_hides_stderr_for_successful_compiles() -> None:
     file_report = FileReport(
         path=Path("ok.vy"),


### PR DESCRIPTION
## What

- add one shared engine for source compiler selection, per-file AST-backed rewrites, coherent target overlays, artifact comparisons, and typed validation decisions
- route both the CLI and corpus smoke runner through the same migration pipeline
- add explicit CLI report schema version 1 and corpus smoke schema version 2 with safe checkpoint invalidation
- reject conflicting resolved candidates while preserving the transactional plan's one identical source/generated no-op alias

## Why

Compiler-backed safety behavior had been duplicated between the CLI and corpus tool. That made retry, diagnostics, artifact comparison, and overlay behavior liable to drift. This centralizes the safety boundary while keeping CLI writes transactional and corpus retries compatible.

## Safety impact

- source-newer-than-target remains an unconditional rewrite boundary even when VYD016 is ignored
- generated interfaces and all migrated sources compile in one coherent overlay
- repeated validation removes only engine-owned diagnostics
- malformed artifacts and destination conflicts remain fail-closed
- legacy corpus checkpoint rows cannot be mixed with the new validation result schema

## Validation

- 583 tests passed, including real compiler integration tests
- Ruff passed across src, tests, and release/corpus scripts
- git diff --check passed
- built sdist and wheel; installed-wheel migration passed source compile, target compile, ABI, method ID, storage layout, and typed validation checks
- independent adversarial review completed with no remaining findings