### PR TITLE
fix: close corpus validation gaps

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -222,10 +222,19 @@ Use `--limit` for a quick sample and `--path` to focus on known regressions. The
 smoke command compiles source and target outputs, applies the same artifact
 comparisons as the CLI, and records rule, diagnostic, compile, and diff details.
 It writes an atomic checkpoint sidecar and resumes an ordered result prefix when
-the manifest, selected items, target version, and smoke-result schema still match
-the interrupted run. Each result and summary declares `smoke_schema_version: 2`;
+the manifest, selected items, target version, smoke-result schema, and runner-source
+fingerprint still match the interrupted run. Each result and summary declares
+`smoke_schema_version: 2`;
 the legacy unversioned rows are treated as schema 1 and are never mixed into a
-resumed schema 2 run.
+resumed schema 2 run. Schema 2 summaries retain the raw compiler
+`status_pairs`, and also expose `normalized_status_pairs`, where a safe
+`degraded` source compile is grouped with `passed`. `validation_statuses`,
+`validation_blockers`, and `validation_waivers` count the typed safety outcomes
+and issue codes. Failed repository, compiler, and error rankings include only
+blocked validations and runner exceptions; a non-blocking degraded source
+compile is not classified as a failure. Error rankings additionally exclude
+stderr from compile sides that passed (or safely degraded for source), so
+warnings attached to an artifact-change blocker are not mislabeled as errors.
 
 Corpus source directories and generated outputs live under `corpus/`, which is
 ignored by Git.

--- a/scripts/corpus.py
+++ b/scripts/corpus.py
@@ -1420,6 +1420,9 @@ def _smoke_one(item: dict[str, Any], target_version: str) -> dict[str, Any]:
             "target_compile": "exception",
             "source_error": f"{type(exc).__name__}: {exc}",
             "target_error": traceback.format_exc()[-2000:],
+            "validation_status": "exception",
+            "validation_blockers": [],
+            "validation_waivers": [],
             "seconds": round(time.time() - started, 3),
         }
 
@@ -1444,25 +1447,45 @@ def _smoke_summary(
     results: list[dict[str, Any]], manifest_path: Path, output_path: Path, elapsed: float
 ) -> dict[str, Any]:
     status_pairs = Counter((item["source_compile"], item["target_compile"]) for item in results)
-    failed_repos = Counter(
-        item["repo"]
+    normalized_status_pairs = Counter(
+        (
+            _normalized_compile_status(item["source_compile"]),
+            _normalized_compile_status(item["target_compile"]),
+        )
         for item in results
-        if item["source_compile"] != "passed" or item["target_compile"] != "passed"
+    )
+    validation_statuses = Counter(_smoke_validation_status(item) for item in results)
+    validation_blockers = Counter(
+        code
+        for item in results
+        for code in _validation_issue_codes(item.get("validation_blockers"))
+    )
+    validation_waivers = Counter(
+        code
+        for item in results
+        for code in _validation_issue_codes(item.get("validation_waivers"))
+    )
+    failed_repos = Counter(
+        item["repo"] for item in results if _is_smoke_safety_failure(item)
     )
     source_errors = Counter(
         item.get("source_error")
         for item in results
-        if item.get("source_error") and item["source_compile"] != "passed"
+        if item.get("source_error")
+        and _is_smoke_safety_failure(item)
+        and item["source_compile"] not in {"passed", "degraded"}
     )
     target_errors = Counter(
         item.get("target_error")
         for item in results
-        if item.get("target_error") and item["target_compile"] != "passed"
+        if item.get("target_error")
+        and _is_smoke_safety_failure(item)
+        and item["target_compile"] != "passed"
     )
     failed_compilers = Counter(
         item.get("source_compiler") or item.get("pragma") or "unknown"
         for item in results
-        if item["source_compile"] != "passed" or item["target_compile"] != "passed"
+        if _is_smoke_safety_failure(item)
     )
     fixes = Counter(fix for item in results for fix in item.get("fixes", []))
     diagnostics = Counter(diag for item in results for diag in item.get("diagnostics", []))
@@ -1475,6 +1498,13 @@ def _smoke_summary(
         "status_pairs": {
             f"{source}->{target}": count for (source, target), count in status_pairs.most_common()
         },
+        "normalized_status_pairs": {
+            f"{source}->{target}": count
+            for (source, target), count in normalized_status_pairs.most_common()
+        },
+        "validation_statuses": dict(validation_statuses.most_common()),
+        "validation_blockers": dict(validation_blockers.most_common()),
+        "validation_waivers": dict(validation_waivers.most_common()),
         "failed_repos": failed_repos.most_common(20),
         "changed": sum(1 for item in results if item.get("changed")),
         "abi_changed": sum(1 for item in results if item.get("abi_equal") is False),
@@ -1488,6 +1518,33 @@ def _smoke_summary(
         "top_fixes": fixes.most_common(20),
         "top_diagnostics": diagnostics.most_common(20),
     }
+
+
+def _normalized_compile_status(status: str) -> str:
+    return "passed" if status == "degraded" else status
+
+
+def _smoke_validation_status(item: dict[str, Any]) -> str:
+    if "exception" in {item.get("source_compile"), item.get("target_compile")}:
+        return "exception"
+    status = item.get("validation_status")
+    return status if isinstance(status, str) and status else "unknown"
+
+
+def _is_smoke_safety_failure(item: dict[str, Any]) -> bool:
+    return _smoke_validation_status(item) in {"blocked", "exception"}
+
+
+def _validation_issue_codes(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [
+        code
+        for issue in value
+        if isinstance(issue, dict)
+        and isinstance((code := issue.get("code")), str)
+        and code
+    ]
 
 
 def _build_summary(manifest: dict[str, Any]) -> dict[str, Any]:
@@ -1523,12 +1580,31 @@ def _smoke_run_identity(
     return {
         "checkpoint_version": 2,
         "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION,
+        "runner_sha256": _smoke_runner_digest(),
         "manifest_path": str(manifest_path.resolve()),
         "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
         "target_version": target_version,
         "selected_items": len(items),
         "selected_items_sha256": _json_digest(items),
     }
+
+
+def _smoke_runner_digest() -> str:
+    package_root = Path(engine.__file__).resolve().parent
+    sources = [
+        ("scripts/corpus.py", Path(__file__).resolve()),
+        *(
+            (f"vyupgrade/{path.relative_to(package_root)}", path)
+            for path in sorted(package_root.rglob("*.py"))
+        ),
+    ]
+    digest = hashlib.sha256()
+    for label, path in sources:
+        digest.update(str(label).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
 def _load_smoke_checkpoint(

--- a/src/vyupgrade/rule_groups/interfaces.py
+++ b/src/vyupgrade/rule_groups/interfaces.py
@@ -953,7 +953,13 @@ def _public_getter_return_type(facts: SourceFacts, name: str) -> str | None:
         if match is None:
             break
         type_name = match.group(1).strip()
-    return type_name.strip() or None
+    type_name = type_name.strip()
+    if type_name in facts.interfaces:
+        # Interface values are encoded as addresses by public getters.  A
+        # legacy built-in interface stub must describe the getter's ABI, not
+        # the source-level storage type, or modern Vyper rejects `implements`.
+        return "address"
+    return type_name or None
 
 
 def _implementation_mutability(facts: SourceFacts, name: str, default: str) -> str:

--- a/src/vyupgrade/rule_groups/legacy.py
+++ b/src/vyupgrade/rule_groups/legacy.py
@@ -742,14 +742,16 @@ def _reserved_local_names(rule_context: RuleContext) -> tuple[str, list[Fix], li
 def _natspec_strictness(rule_context: RuleContext) -> tuple[str, list[Fix], list[Diagnostic]]:
     source = rule_context.source
     facts = rule_context.facts
+    lines = source.splitlines(keepends=True)
     edits: list[TextEdit] = []
     fixes: list[Fix] = []
     in_docstring = False
     quote = ""
     doc_function_start: int | None = None
     seen_singleton_natspec_fields: set[str] = set()
+    reserved_natspec_tags: set[str] = set()
     offset = 0
-    for line_no, raw_line in enumerate(source.splitlines(keepends=True), start=1):
+    for line_no, raw_line in enumerate(lines, start=1):
         line = raw_line.rstrip("\n")
         stripped = line.lstrip()
         if not in_docstring:
@@ -758,10 +760,12 @@ def _natspec_strictness(rule_context: RuleContext) -> tuple[str, list[Fix], list
                 in_docstring = True
                 doc_function_start = _function_start_at_line(facts, line_no)
                 seen_singleton_natspec_fields = set()
+                reserved_natspec_tags = _natspec_tags_until_close(lines, line_no, quote)
                 if stripped.count(quote) >= 2:
                     in_docstring = False
                     doc_function_start = None
                     seen_singleton_natspec_fields = set()
+                    reserved_natspec_tags = set()
             offset += len(raw_line)
             continue
 
@@ -769,12 +773,17 @@ def _natspec_strictness(rule_context: RuleContext) -> tuple[str, list[Fix], list
             in_docstring = False
             doc_function_start = None
             seen_singleton_natspec_fields = set()
+            reserved_natspec_tags = set()
             offset += len(raw_line)
             continue
 
         singleton_tag = _natspec_singleton_tag(line)
         if singleton_tag is not None and singleton_tag in seen_singleton_natspec_fields:
-            replacement = _duplicate_natspec_line_replacement(line, singleton_tag)
+            replacement = _duplicate_natspec_line_replacement(
+                line,
+                singleton_tag,
+                reserved_natspec_tags,
+            )
             if replacement is None:
                 edits.append(TextEdit(offset, offset + len(raw_line), ""))
                 fixes.append(
@@ -833,14 +842,39 @@ def _natspec_singleton_tag(line: str) -> str | None:
     return tag if tag in _SINGLETON_NATSPEC_FIELDS else None
 
 
-def _duplicate_natspec_line_replacement(line: str, tag: str) -> str | None:
+def _natspec_tags_until_close(lines: list[str], start: int, quote: str) -> set[str]:
+    tags: set[str] = set()
+    for raw_line in lines[start:]:
+        stripped = raw_line.lstrip()
+        if stripped.startswith(quote):
+            break
+        match = re.match(r"^\s*@(\S+)", raw_line)
+        if match is not None:
+            tags.add(match.group(1))
+    return tags
+
+
+def _next_custom_natspec_tag(tag: str, reserved: set[str]) -> str:
+    candidate = f"custom:{tag}"
+    suffix = 2
+    while candidate in reserved:
+        candidate = f"custom:{tag}-{suffix}"
+        suffix += 1
+    reserved.add(candidate)
+    return candidate
+
+
+def _duplicate_natspec_line_replacement(
+    line: str, tag: str, reserved: set[str]
+) -> str | None:
     match = re.match(r"^(\s*)@[A-Za-z_][A-Za-z0-9_-]*(\s+.*)?$", line)
     if match is None:
         return line
     body = match.group(2)
     if body is None or not body.strip():
         return None
-    return f"{match.group(1)}@custom:{tag}{body}"
+    custom_tag = _next_custom_natspec_tag(tag, reserved)
+    return f"{match.group(1)}@{custom_tag}{body}"
 
 
 def _function_param_names_at_start(facts: SourceFacts, start: int | None) -> set[str] | None:

--- a/src/vyupgrade/rule_groups/numeric_signedness.py
+++ b/src/vyupgrade/rule_groups/numeric_signedness.py
@@ -146,6 +146,13 @@ def _mixed_signed_unsigned_arithmetic(
                     or _inside_range_header(source, start)
                     or (name in constant_values and _inside_shift_amount(source, start))
                     or _inside_type_subscript(source, start)
+                    or (
+                        name in constant_values
+                        and comparison_target is not None
+                        and not _integer_value_fits_type(
+                            constant_values[name], comparison_target
+                        )
+                    )
                     or _signed_comparison_target_type_at(source, start, name, vars_for_line)
                     is not None
                     or _signed_internal_call_arg_target_type(source, start, name, facts) is not None
@@ -205,19 +212,42 @@ def _mixed_signed_unsigned_arithmetic(
                 loop_type = normalize_type(
                     _nearest_loop_var_type(source, start, name) or vars_for_line.get(name) or ""
                 )
+                local_expr = _local_expression(source, start)
+                comparison_expr = _comparison_expression_at(source, start)
+                comparison_peer = _comparison_peer(comparison_expr, name)
+                if (
+                    comparison_peer in constant_values
+                    and comparison_peer in facts.global_vars
+                    and _is_signed_integer_type(vars_for_line.get(comparison_peer))
+                    and _integer_value_fits_type(
+                        constant_values[comparison_peer], loop_type
+                    )
+                ):
+                    # The signed-name pass casts this constant to the loop
+                    # variable's unsigned type. Avoid casting both operands in
+                    # opposite directions.
+                    continue
                 unsigned_comparison_target = _unsigned_comparison_target_type_at(
                     source, start, name, vars_for_line, facts
                 )
                 if unsigned_comparison_target == loop_type:
                     unsigned_comparison_target = None
+                arithmetic_target = (
+                    None
+                    if comparison_peer is not None
+                    else _unsigned_name_signed_arithmetic_target_type(
+                        local_expr, name, lhs_type, vars_for_line, facts
+                    )
+                )
                 target_type = (
                     _signed_comparison_target_type(
-                        _comparison_expression_at(source, start), name, vars_for_line
+                        comparison_expr, name, vars_for_line
+                    )
+                    or _signed_comparison_target_type_at(
+                        source, start, name, vars_for_line
                     )
                     or unsigned_comparison_target
-                    or _unsigned_name_signed_arithmetic_target_type(
-                        _local_expression(source, start), name, lhs_type, vars_for_line, facts
-                    )
+                    or arithmetic_target
                     or _signed_internal_call_arg_target_type(source, start, name, facts)
                     or _signed_external_call_arg_target_type(
                         source, start, name, facts, vars_for_line

--- a/tests/fixtures/erc4626_interface_getter.vy
+++ b/tests/fixtures/erc4626_interface_getter.vy
@@ -1,0 +1,119 @@
+# @version 0.3.10
+from vyper.interfaces import ERC20
+from vyper.interfaces import ERC4626
+
+implements: ERC4626
+
+asset: public(ERC20)
+
+event Deposit:
+    depositor: indexed(address)
+    receiver: indexed(address)
+    assets: uint256
+    shares: uint256
+
+event Withdraw:
+    withdrawer: indexed(address)
+    receiver: indexed(address)
+    owner: indexed(address)
+    assets: uint256
+    shares: uint256
+
+
+@external
+def __init__(_asset: ERC20):
+    self.asset = _asset
+
+
+@view
+@external
+def totalAssets() -> uint256:
+    return 0
+
+
+@view
+@external
+def convertToAssets(shareAmount: uint256) -> uint256:
+    return shareAmount
+
+
+@view
+@external
+def convertToShares(assetAmount: uint256) -> uint256:
+    return assetAmount
+
+
+@view
+@external
+def maxDeposit(owner: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def previewDeposit(assets: uint256) -> uint256:
+    return assets
+
+
+@external
+def deposit(assets: uint256, receiver: address = msg.sender) -> uint256:
+    return assets
+
+
+@view
+@external
+def maxMint(owner: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def previewMint(shares: uint256) -> uint256:
+    return shares
+
+
+@external
+def mint(shares: uint256, receiver: address = msg.sender) -> uint256:
+    return shares
+
+
+@view
+@external
+def maxWithdraw(owner: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def previewWithdraw(assets: uint256) -> uint256:
+    return assets
+
+
+@external
+def withdraw(
+    assets: uint256,
+    receiver: address = msg.sender,
+    owner: address = msg.sender,
+) -> uint256:
+    return assets
+
+
+@view
+@external
+def maxRedeem(owner: address) -> uint256:
+    return 0
+
+
+@view
+@external
+def previewRedeem(shares: uint256) -> uint256:
+    return shares
+
+
+@external
+def redeem(
+    shares: uint256,
+    receiver: address = msg.sender,
+    owner: address = msg.sender,
+) -> uint256:
+    return shares

--- a/tests/rule_groups/test_interfaces.py
+++ b/tests/rule_groups/test_interfaces.py
@@ -441,6 +441,21 @@ def __init__(vault: address):
     assert "asset = staticcall ERC4626(vault).asset()" in result.source
 
 
+def test_legacy_implemented_erc4626_stub_uses_abi_type_for_interface_getter(config) -> None:
+    source = Path("tests/fixtures/erc4626_interface_getter.vy").read_text(encoding="utf-8")
+
+    first = apply_rules(source, config(source_version="0.3.10", target_version="0.4.3"))
+    second = apply_rules(
+        first.source,
+        config(source_version="0.3.10", target_version="0.4.3"),
+    )
+
+    assert "asset: public(IERC20)" in first.source
+    assert "def asset() -> address: view" in first.source
+    assert "def asset() -> IERC20: view" not in first.source
+    assert second.source == first.source
+
+
 def test_pure_local_interface_view_implementation_becomes_view(config) -> None:
     source = """# @version 0.3.3
 interface ERC165:

--- a/tests/rule_groups/test_legacy.py
+++ b/tests/rule_groups/test_legacy.py
@@ -195,6 +195,56 @@ def collect_fees() -> uint256:
     assert any(fix.rule == "VY058" for fix in result.fixes)
 
 
+def test_natspec_strictness_uniquely_numbers_repeated_singleton_fields(config) -> None:
+    source = '''# @version 0.3.10
+# @dev This ordinary comment is not NatSpec.
+NOTE: constant(String[32]) = "@dev neither is this string"
+
+@external
+def collect_fees() -> uint256:
+    """
+    @dev First detail
+    @dev Second detail
+    @dev Third detail
+    @dev Fourth detail
+    """
+    return 0
+'''
+
+    first = apply_rules(source, config())
+    second = apply_rules(first.source, config())
+
+    assert "@dev First detail" in first.source
+    assert "@custom:dev Second detail" in first.source
+    assert "@custom:dev-2 Third detail" in first.source
+    assert "@custom:dev-3 Fourth detail" in first.source
+    assert "# @dev This ordinary comment is not NatSpec." in first.source
+    assert '"@dev neither is this string"' in first.source
+    assert second.source == first.source
+
+
+def test_natspec_strictness_avoids_existing_custom_tag_names(config) -> None:
+    source = '''# @version 0.3.10
+@external
+def collect_fees() -> uint256:
+    """
+    @dev First detail
+    @custom:dev Existing custom detail
+    @dev Second detail
+    @custom:dev-3 Another existing custom detail
+    @dev Third detail
+    """
+    return 0
+'''
+
+    result = apply_rules(source, config())
+
+    assert "@custom:dev Existing custom detail" in result.source
+    assert "@custom:dev-2 Second detail" in result.source
+    assert "@custom:dev-3 Another existing custom detail" in result.source
+    assert "@custom:dev-4 Third detail" in result.source
+
+
 def test_pragma_rewrite_bumps_to_enabled_target_version(config) -> None:
     source = """# @version 0.3.8
 @external

--- a/tests/rule_groups/test_numeric_signedness.py
+++ b/tests/rule_groups/test_numeric_signedness.py
@@ -678,6 +678,50 @@ def f():
     assert "self.points_sum[convert(gauge_type, int128)]" in result.source
 
 
+def test_unsigned_loop_prefers_casting_nonnegative_signed_constant(config) -> None:
+    source = """# @version 0.3.7
+MAX_SKIP_TICKS: constant(int256) = 1024
+
+@external
+def f(flag: bool):
+    for i in range(MAX_SKIP_TICKS + 1):
+        assert i < MAX_SKIP_TICKS
+        assert flag and i < MAX_SKIP_TICKS
+"""
+
+    first = apply_rules(source, config())
+    second = apply_rules(first.source, config())
+
+    assert (
+        "for i: uint256 in range(convert(MAX_SKIP_TICKS, uint256) + 1"
+        in first.source
+    )
+    assert "assert i < convert(MAX_SKIP_TICKS, uint256)" in first.source
+    assert "assert flag and i < convert(MAX_SKIP_TICKS, uint256)" in first.source
+    assert "convert(i, int256)" not in first.source
+    assert second.source == first.source
+
+
+def test_unsigned_loop_casts_to_signed_when_constant_does_not_fit(config) -> None:
+    source = """# @version 0.3.7
+MIN_TICK: constant(int256) = -1
+
+@external
+def f(flag: bool):
+    for i in range(10):
+        assert i > MIN_TICK
+        assert flag and i > MIN_TICK
+"""
+
+    first = apply_rules(source, config())
+    second = apply_rules(first.source, config())
+
+    assert "assert convert(i, int256) > MIN_TICK" in first.source
+    assert "assert flag and convert(i, int256) > MIN_TICK" in first.source
+    assert "convert(MIN_TICK, uint256)" not in first.source
+    assert second.source == first.source
+
+
 def test_signed_parameter_not_converted_in_uint_arithmetic(config) -> None:
     source = """# @version 0.3.7
 @internal

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -63,6 +63,45 @@ def x() -> uint256:
     } == {"lib.vy": "passed", "main.vy": "passed"}
 
 
+def test_repeated_singleton_natspec_fields_compile_after_rewrite(tmp_path: Path) -> None:
+    contract = tmp_path / "documented.vy"
+    contract.write_text(
+        '''# @version 0.3.10
+@external
+def collect_fees() -> uint256:
+    """
+    @dev First detail
+    @dev Second detail
+    @dev Third detail
+    @dev Fourth detail
+    """
+    return 0
+''',
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    code = main([str(contract), "--check", "--report-json", str(report)])
+
+    assert code == 1
+    file = json.loads(report.read_text(encoding="utf-8"))["files"][0]
+    assert file["validation"]["target_compile"] == "passed"
+    assert file["validation"]["decision"]["status"] == "passed"
+
+
+def test_legacy_erc4626_interface_getter_stub_compiles(tmp_path: Path) -> None:
+    contract = tmp_path / "ERC4626Mock.vy"
+    shutil.copyfile(Path("tests/fixtures/erc4626_interface_getter.vy"), contract)
+    report = tmp_path / "report.json"
+
+    code = main([str(contract), "--check", "--report-json", str(report)])
+
+    assert code == 1
+    file = json.loads(report.read_text(encoding="utf-8"))["files"][0]
+    assert file["validation"]["target_compile"] == "passed"
+    assert file["validation"]["decision"]["status"] == "passed"
+
+
 def test_alpha_target_validation_uses_alpha_compiler(tmp_path: Path) -> None:
     contract = tmp_path / "sqrt.vy"
     contract.write_text(

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -449,6 +449,9 @@ def test_smoke_summary_groups_failures_and_rules(tmp_path: Path) -> None:
                 "source_compile": "passed",
                 "target_compile": "failed",
                 "target_error": "target failed",
+                "validation_status": "blocked",
+                "validation_blockers": [{"code": "target_compile_failed"}],
+                "validation_waivers": [],
                 "fixes": ["VY001"],
                 "diagnostics": ["VYD001"],
             },
@@ -459,6 +462,59 @@ def test_smoke_summary_groups_failures_and_rules(tmp_path: Path) -> None:
                 "target_compile": "failed",
                 "source_error": "source failed",
                 "target_error": "target failed",
+                "validation_status": "blocked",
+                "validation_blockers": [
+                    {"code": "source_compile_failed"},
+                    {"code": "target_compile_failed"},
+                ],
+                "validation_waivers": [],
+                "fixes": [],
+                "diagnostics": [],
+            },
+            {
+                "repo": "safe-degraded",
+                "source_compiler": "0.2.15",
+                "source_compile": "degraded",
+                "target_compile": "passed",
+                "source_error": "unsupported optional source artifact",
+                "validation_status": "passed",
+                "validation_blockers": [],
+                "validation_waivers": [],
+                "fixes": [],
+                "diagnostics": [],
+            },
+            {
+                "repo": "safe-waived",
+                "source_compiler": "0.2.15",
+                "source_compile": "degraded",
+                "target_compile": "passed",
+                "source_error": "waived source artifact gap",
+                "validation_status": "waived",
+                "validation_blockers": [],
+                "validation_waivers": [{"code": "source_artifacts_unavailable"}],
+                "fixes": [],
+                "diagnostics": [],
+            },
+            {
+                "repo": "crashed",
+                "source_compiler": "0.1.0",
+                "source_compile": "exception",
+                "target_compile": "exception",
+                "source_error": "runner exploded",
+                "target_error": "traceback",
+                "fixes": [],
+                "diagnostics": [],
+            },
+            {
+                "repo": "artifact-change",
+                "source_compiler": "0.4.0",
+                "source_compile": "passed",
+                "target_compile": "passed",
+                "source_error": "harmless source warning",
+                "target_error": "harmless target warning",
+                "validation_status": "blocked",
+                "validation_blockers": [{"code": "storage_layout_changed"}],
+                "validation_waivers": [],
                 "fixes": [],
                 "diagnostics": [],
             },
@@ -468,11 +524,46 @@ def test_smoke_summary_groups_failures_and_rules(tmp_path: Path) -> None:
         1.2,
     )
 
-    assert summary["failed_compilers"] == [("0.3.10", 1), ("0.2.16", 1)]
-    assert summary["top_target_errors"] == [("target failed", 2)]
-    assert summary["top_source_errors"] == [("source failed", 1)]
+    assert summary["failed_compilers"] == [
+        ("0.3.10", 1),
+        ("0.2.16", 1),
+        ("0.1.0", 1),
+        ("0.4.0", 1),
+    ]
+    assert summary["top_target_errors"] == [("target failed", 2), ("traceback", 1)]
+    assert summary["top_source_errors"] == [("source failed", 1), ("runner exploded", 1)]
     assert summary["top_fixes"] == [("VY001", 1)]
     assert summary["top_diagnostics"] == [("VYD001", 1)]
+    assert summary["status_pairs"] == {
+        "degraded->passed": 2,
+        "passed->failed": 1,
+        "failed->failed": 1,
+        "exception->exception": 1,
+        "passed->passed": 1,
+    }
+    assert summary["normalized_status_pairs"] == {
+        "passed->passed": 3,
+        "passed->failed": 1,
+        "failed->failed": 1,
+        "exception->exception": 1,
+    }
+    assert summary["validation_statuses"] == {
+        "blocked": 3,
+        "passed": 1,
+        "waived": 1,
+        "exception": 1,
+    }
+    assert summary["validation_blockers"] == {
+        "target_compile_failed": 2,
+        "source_compile_failed": 1,
+        "storage_layout_changed": 1,
+    }
+    assert summary["validation_waivers"] == {"source_artifacts_unavailable": 1}
+    assert summary["failed_repos"] == [
+        ("chainsecurity", 2),
+        ("crashed", 1),
+        ("artifact-change", 1),
+    ]
 
 
 def test_smoke_items_filters_by_corpus_path_when_paths_are_given(tmp_path: Path) -> None:
@@ -659,6 +750,52 @@ def test_smoke_does_not_resume_when_run_identity_changes(monkeypatch, tmp_path: 
     assert sorted(submitted) == [0, 1]
     results = json.loads(output_path.read_text(encoding="utf-8"))
     assert {result["target_version"] for result in results} == {"0.4.3"}
+
+
+def test_smoke_does_not_resume_when_runner_source_changes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    corpus = _load_corpus_module()
+    items = [{"index": index, "repo": "test"} for index in range(2)]
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
+    output_path = tmp_path / "smoke-results.json"
+    target_version = "0.4.3"
+    monkeypatch.setattr(corpus, "_smoke_runner_digest", lambda: "old-runner")
+    identity = corpus._smoke_run_identity(manifest_path, target_version, items)
+    corpus._write_smoke_checkpoint(
+        output_path,
+        [
+            {
+                **items[0],
+                "source_compile": "passed",
+                "target_compile": "passed",
+                "target_version": target_version,
+            }
+        ],
+        identity,
+    )
+    monkeypatch.setattr(corpus, "_smoke_runner_digest", lambda: "new-runner")
+    submitted: list[int] = []
+
+    def fake_smoke_one(item, requested_target):
+        submitted.append(item["index"])
+        return {
+            **item,
+            "source_compile": "passed",
+            "target_compile": "passed",
+            "target_version": requested_target,
+        }
+
+    monkeypatch.setattr(corpus, "_smoke_one", fake_smoke_one)
+
+    corpus.smoke_corpus(manifest_path, output_path, target_version, 2, 0)
+
+    assert sorted(submitted) == [0, 1]
+    checkpoint = json.loads(
+        corpus._checkpoint_path(output_path).read_text(encoding="utf-8")
+    )
+    assert checkpoint["identity"]["runner_sha256"] == "new-runner"
 
 
 def test_smoke_does_not_resume_results_that_are_not_an_ordered_prefix(


### PR DESCRIPTION
## What

- make repeated singleton NatSpec fields use collision-free custom tags that preserve every description and compile under Vyper 0.4.3
- describe interface-typed public getters with their address ABI type in local ERC-4626 stubs
- make signedness rewrites choose one range-checked cast direction instead of casting both comparison operands incompatibly
- make corpus summaries distinguish raw compiler statuses from typed validation outcomes
- bind resumable corpus checkpoints to a deterministic runner-source fingerprint

## Why

The post-architecture release corpus found seven old-target-pass/new-target-fail paths. Exact-candidate validation correctly exposed three previously masked migration gaps: duplicate NatSpec custom keys, a wrong ERC-4626 getter stub type, and competing signedness casts. The summary also classified safe degraded compiles as failures, and schema identity alone could not prevent resumes across code changes.

## Validation

- 591 tests passed, including real Vyper compiler integration coverage
- Ruff and git diff checks passed
- built-wheel smoke passed
- all seven exact corpus regressions now compile passed to passed
- targeted set has zero ABI or method-ID changes; three retain only expected storage-layout blockers
- exact AMM, Robo, and ERC4626Mock candidates compile under target Vyper 0.4.3
- adversarial review completed with no remaining findings