### PR TITLE
chore: prepare 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.1 - 2026-07-10
+
+- Extracted fail-closed storage-layout parsing, canonicalization, AST evidence,
+  and comparison into a dedicated typed module without changing validation
+  behavior or compiler-facing APIs.
+
 ## 0.5.0 - 2026-07-10
 
 - Made compiler-backed validation fail closed with typed blockers for missing,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "vyupgrade"
-version = "0.5.0"
+version = "0.5.1"
 description = "Compiler-backed tool for upgrading Vyper contracts."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "vyupgrade"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary

- bump the package and lockfile version to `0.5.1`
- add patch-release notes for the typed storage-layout module extraction

## Validation

- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py` — passed
- `uv run --locked pytest` — 739 passed
- exact 178-contract storage corpus — semantic parity with the `0.5.0` baseline on all 178 rows
- `scripts/smoke-wheel.sh` — built, installed, and exercised `vyupgrade 0.5.1`
- `uv run --locked python scripts/release_notes.py v0.5.1` — passed
- `uv run --locked python scripts/release_preflight.py v0.5.1 --dist dist` — passed

After merge, the release flow will tag `v0.5.1`, wait for Trusted Publishing, and verify both the GitHub release and PyPI artifact.

