### PR TITLE
fix: reject unsupported source version specs

### DIFF
--- a/docs/migration-coverage.md
+++ b/docs/migration-coverage.md
@@ -577,5 +577,7 @@ modern Python interpreter.
 - `VYD007`: ABI or method identifiers changed after migration.
 - `VYD008`: storage layout changed after migration.
 - `VYD009`: target compiler default EVM version differs from source-era default.
-- `VYD016`: source version matches no compiler supported by this `vyupgrade`
-  release, or resolves to a compiler newer than the requested target.
+- `VYD016`: source version resolves to a compiler newer than the requested
+  target.
+- `VYD018`: source version matches no compiler supported by this `vyupgrade`
+  release.

--- a/docs/migration-coverage.md
+++ b/docs/migration-coverage.md
@@ -577,5 +577,5 @@ modern Python interpreter.
 - `VYD007`: ABI or method identifiers changed after migration.
 - `VYD008`: storage layout changed after migration.
 - `VYD009`: target compiler default EVM version differs from source-era default.
-- `VYD016`: source version resolves to a compiler newer than the requested
-  target.
+- `VYD016`: source version matches no compiler supported by this `vyupgrade`
+  release, or resolves to a compiler newer than the requested target.

--- a/scripts/corpus.py
+++ b/scripts/corpus.py
@@ -1380,9 +1380,9 @@ def _smoke_one(item: dict[str, Any], target_version: str) -> dict[str, Any]:
             original,
             source_version,
             _source_compile_attempts(item, source_version),
-            # Preserve the corpus smoke's historical attempt to compile a
-            # target even when the source is newer than that target.
-            skip_target_on_vyd016=False,
+            # Preserve the corpus smoke's historical target compile attempt
+            # even when the source-version boundary blocks normal migration.
+            skip_target_on_blocked_source=False,
         )
         batch = engine.prepare_migrations((request,), config)
         migration = batch.files[0]

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -56,7 +56,7 @@ class MigrationRequest:
     original: str
     source_version: str | None
     source_attempts: tuple[SourceCompileAttempt, ...]
-    skip_target_on_vyd016: bool = True
+    skip_target_on_blocked_source: bool = True
 
 
 @dataclass
@@ -216,12 +216,12 @@ def validate_migrations(
                 migration.report, migration.validation_diagnostics
             )
             migration.target_compile = None
+            source_context = MigrationContext.from_specs(
+                migration.request.source_version, config.target_version
+            )
             if (
-                migration.request.skip_target_on_vyd016
-                and any(
-                    diagnostic.rule == "VYD016"
-                    for diagnostic in migration.report.diagnostics
-                )
+                migration.request.skip_target_on_blocked_source
+                and not source_context.source_can_migrate_to_target()
             ):
                 continue
             target_compile = compile_target_source(

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -104,7 +104,7 @@ def bounded_migration_request(path: Path, original: str, config: Config) -> Migr
     """Build the target-bounded source compiler request used by the CLI."""
     source_version = config.source_version or infer_pragma(original)
     context = MigrationContext.from_specs(source_version, config.target_version)
-    if context.source_newer_than_target():
+    if not context.source_can_migrate_to_target():
         attempts: tuple[SourceCompileAttempt, ...] = ()
     elif config.source_vyper:
         attempts = (SourceCompileAttempt(source_version, source_version),)
@@ -141,9 +141,9 @@ def prepare_migrations(
         if (
             config.split_interfaces
             and request.path.suffix == ".vy"
-            and not MigrationContext.from_specs(
+            and MigrationContext.from_specs(
                 source_version, config.target_version
-            ).source_newer_than_target()
+            ).source_can_migrate_to_target()
             and _rule_enabled("VY120", source_version, config)
         ):
             split = split_interfaces_to_vyi(rewrite.source, request.path)

--- a/src/vyupgrade/rules.py
+++ b/src/vyupgrade/rules.py
@@ -97,6 +97,7 @@ METADATA_RULES = (
             crossing("VYD008", (0, 4, 0)),
             crossing("VYD009", (0, 4, 0)),
             target_floor("VYD016", (0, 1, 0)),
+            target_floor("VYD018", (0, 1, 0)),
         ),
     ),
 )
@@ -145,7 +146,7 @@ def _blocked_source_version_result(
 def _unsupported_source_version_diagnostic(context: MigrationContext) -> Diagnostic:
     assert context.source_spec is not None
     return Diagnostic(
-        "VYD016",
+        "VYD018",
         1,
         f"source version {context.source_spec} matches no Vyper compiler supported by this vyupgrade release",
         "error",

--- a/src/vyupgrade/rules.py
+++ b/src/vyupgrade/rules.py
@@ -55,12 +55,17 @@ def apply_rules(source: str, config: Config, path: Path | None = None) -> Rewrit
         config.source_version or infer_pragma(source), config.target_version
     )
     rule_context = RuleContext(source, config, context, path, RULE_CHANGES)
-    if context.source_newer_than_target():
-        diagnostic = _source_newer_than_target_diagnostic(context)
-        return RewriteResult(
+    if context.source_spec_unsupported():
+        return _blocked_source_version_result(
             source,
-            [],
-            [diagnostic] if rule_context.is_enabled(diagnostic.rule) else [],
+            rule_context,
+            _unsupported_source_version_diagnostic(context),
+        )
+    if context.source_newer_than_target():
+        return _blocked_source_version_result(
+            source,
+            rule_context,
+            _source_newer_than_target_diagnostic(context),
         )
 
     current = source
@@ -125,6 +130,26 @@ RULES = (
     *METADATA_RULES,
 )
 RULE_CHANGES = rule_changes(RULES)
+
+
+def _blocked_source_version_result(
+    source: str, rule_context: RuleContext, diagnostic: Diagnostic
+) -> RewriteResult:
+    return RewriteResult(
+        source,
+        [],
+        [diagnostic] if rule_context.is_enabled(diagnostic.rule) else [],
+    )
+
+
+def _unsupported_source_version_diagnostic(context: MigrationContext) -> Diagnostic:
+    assert context.source_spec is not None
+    return Diagnostic(
+        "VYD016",
+        1,
+        f"source version {context.source_spec} matches no Vyper compiler supported by this vyupgrade release",
+        "error",
+    )
 
 
 def _source_newer_than_target_diagnostic(context: MigrationContext) -> Diagnostic:

--- a/src/vyupgrade/versions.py
+++ b/src/vyupgrade/versions.py
@@ -70,8 +70,14 @@ class MigrationContext:
             return True
         return self.source_floor < introduced
 
+    def source_spec_unsupported(self) -> bool:
+        return self.source_spec is not None and not known_versions_satisfying(self.source_spec)
+
     def source_newer_than_target(self) -> bool:
         return self.source_floor is not None and self.source_floor > self.target_version
+
+    def source_can_migrate_to_target(self) -> bool:
+        return not self.source_spec_unsupported() and not self.source_newer_than_target()
 
 
 def infer_pragma(source: str) -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1371,7 +1371,7 @@ def f() -> uint256:
     assert file_report["changed"] is False
     assert file_report["diagnostics"] == [
         {
-            "rule": "VYD016",
+            "rule": "VYD018",
             "line": 1,
             "message": "source version 0.5.0 matches no Vyper compiler supported by this vyupgrade release",
             "severity": "error",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1342,6 +1342,45 @@ def test_validation_diagnostics_use_resolved_source_compiler_for_evm_default(
     assert not [diagnostic for diagnostic in report.diagnostics if diagnostic.rule == "VYD009"]
 
 
+def test_unsupported_source_version_skips_compile_and_reports_error(tmp_path: Path) -> None:
+    contract = tmp_path / "unsupported.vy"
+    contract.write_text(
+        """# pragma version 0.5.0
+
+@external
+def f() -> uint256:
+    return 1
+""",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(contract),
+            "--check",
+            "--target-version",
+            "0.5.0a3",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 5
+    file_report = json.loads(report.read_text())["files"][0]
+    assert file_report["changed"] is False
+    assert file_report["diagnostics"] == [
+        {
+            "rule": "VYD016",
+            "line": 1,
+            "message": "source version 0.5.0 matches no Vyper compiler supported by this vyupgrade release",
+            "severity": "error",
+        }
+    ]
+    assert file_report["validation"]["source_compile"] == "skipped"
+    assert file_report["validation"]["target_compile"] == "skipped"
+
+
 def test_source_newer_than_target_skips_compile_and_reports_error(tmp_path: Path) -> None:
     contract = tmp_path / "newer.vy"
     contract.write_text(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -145,11 +145,18 @@ def test_source_ast_is_owned_by_each_file(monkeypatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("source_version", "target_version"),
-    [(">=0.5.0a1,<0.6.0", "0.4.3"), ("0.4.4", "0.5.0a3")],
+    ("source_version", "target_version", "diagnostic_code"),
+    [
+        (">=0.5.0a1,<0.6.0", "0.4.3", "VYD016"),
+        ("0.4.4", "0.5.0a3", "VYD018"),
+    ],
 )
-def test_blocked_source_cannot_split_interfaces_when_diagnostic_is_ignored(
-    source_version: str, target_version: str, tmp_path: Path
+def test_blocked_source_cannot_validate_or_split_when_diagnostic_is_ignored(
+    source_version: str,
+    target_version: str,
+    diagnostic_code: str,
+    monkeypatch,
+    tmp_path: Path,
 ) -> None:
     path = tmp_path / "Main.vy"
     original = f"""#pragma version {source_version}
@@ -162,14 +169,23 @@ interface Token:
         tmp_path,
         target_version=target_version,
         split_interfaces=True,
-        ignore=frozenset({"VYD016"}),
+        ignore=frozenset({diagnostic_code}),
     )
 
     batch = engine.prepare_migrations((request,), config)
+    monkeypatch.setattr(
+        engine,
+        "compile_target_source",
+        lambda *_args, **_kwargs: pytest.fail("blocked source reached target compiler"),
+    )
+    decision = engine.validate_migrations(batch, config)
 
     assert batch.files[0].rewrite.source == original
     assert batch.files[0].report.diagnostics == []
     assert batch.files[0].report.changed is False
+    assert batch.files[0].report.source_compile == "skipped"
+    assert batch.files[0].report.target_compile == "skipped"
+    assert decision.status == "not-required"
     assert batch.generated == []
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -144,23 +144,23 @@ def test_source_ast_is_owned_by_each_file(monkeypatch, tmp_path: Path) -> None:
     assert config.source_ast == {"stale": True}
 
 
-def test_newer_source_cannot_split_interfaces_when_diagnostic_is_ignored(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    ("source_version", "target_version"),
+    [(">=0.5.0a1,<0.6.0", "0.4.3"), ("0.4.4", "0.5.0a3")],
+)
+def test_blocked_source_cannot_split_interfaces_when_diagnostic_is_ignored(
+    source_version: str, target_version: str, tmp_path: Path
 ) -> None:
     path = tmp_path / "Main.vy"
-    original = """#pragma version >=0.5.0a1,<0.6.0
+    original = f"""#pragma version {source_version}
 
 interface Token:
     def balanceOf(owner: address) -> uint256: view
 """
-    request = MigrationRequest(
-        path,
-        original,
-        ">=0.5.0a1,<0.6.0",
-        (),
-    )
+    request = MigrationRequest(path, original, source_version, ())
     config = _config(
         tmp_path,
+        target_version=target_version,
         split_interfaces=True,
         ignore=frozenset({"VYD016"}),
     )

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -247,3 +247,24 @@ def f() -> uint256:
     assert result.fixes == []
     assert [(diag.rule, diag.severity) for diag in result.diagnostics] == [("VYD016", "error")]
     assert "newer than target 0.4.3" in result.diagnostics[0].message
+
+
+def test_unsupported_source_version_is_distinct_error_diagnostic(config) -> None:
+    source = """# pragma version 0.4.4
+
+@external
+def f() -> uint256:
+    return 1
+"""
+
+    result = apply_rules(
+        source,
+        config(target_version="0.5.0a3", ignore=frozenset({"VYD016"})),
+    )
+
+    assert result.source == source
+    assert result.fixes == []
+    assert [(diag.rule, diag.severity) for diag in result.diagnostics] == [
+        ("VYD018", "error")
+    ]
+    assert "matches no Vyper compiler" in result.diagnostics[0].message


### PR DESCRIPTION
_co-authored by gpt-5.6 sol_

## Summary

- Detect source version specs that match no compiler supported by the current `vyupgrade` release before comparing their parsed floor with the target.
- Report unsupported source specs as `VYD018`, distinct from `VYD016` for valid source versions newer than the requested target.
- Fail closed independently of diagnostic filtering: blocked sources are not compiled, rewritten, interface-split, or target-validated even when their diagnostic is ignored.
- Preserve the corpus smoke's explicit opt-out for historical target compile attempts across blocked source-version boundaries.

## Safety

The migration boundary is derived from the source and target version specs during validation rather than inferred from emitted diagnostics. Unsupported specs leave source bytes unchanged, and ignoring or excluding `VYD016` or `VYD018` cannot re-enable compilation or migration.

Closes #20.
