### PR TITLE
refactor(compiler): single-source the import-closure traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added a public import-closure primitive (resolve_import_closure) and a reusable overlay materializer, single-sourcing the validation dependency traversal.
+
 ## 0.5.1 - 2026-07-10
 
 - Extracted fail-closed storage-layout parsing, canonicalization, AST evidence,

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -71,6 +71,17 @@ class TargetOverlay:
     source_roots: tuple[Path, ...]
     search_paths: tuple[Path, ...]
 
+@dataclass(frozen=True)
+class ImportClosure:
+    roots: tuple[Path, ...]
+    dependencies: tuple[Path, ...]
+    source_roots: tuple[Path, ...]
+    common_root: Path
+
+    @property
+    def files(self) -> tuple[Path, ...]:
+        return self.roots + self.dependencies
+
 
 def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
     artifacts = result.artifacts or {}
@@ -335,6 +346,36 @@ def _compile_target_interface(
             harness_path.unlink(missing_ok=True)
 
 
+def resolve_import_closure(
+    sources: Mapping[Path, str],
+    search_paths: tuple[Path, ...] = (),
+) -> ImportClosure:
+    """Resolve the full transitive closure, including external search-path files.
+
+    Overlay materialization copies only closure members under ``common_root``;
+    external configured-search-path dependencies remain available in place.
+    """
+    resolved_sources = {path.resolve(): source for path, source in sources.items()}
+    if not resolved_sources:
+        raise ValueError("resolve_import_closure requires at least one source")
+    source_roots, import_roots, common_root = _overlay_roots(
+        resolved_sources, search_paths
+    )
+    dependencies = [
+        path
+        for source_root in source_roots
+        for path, _source in _walk_validation_sources(
+            source_root, import_roots, common_root, resolved_sources
+        )
+    ]
+    return ImportClosure(
+        roots=tuple(sorted(resolved_sources)),
+        dependencies=tuple(sorted(dict.fromkeys(dependencies))),
+        source_roots=source_roots,
+        common_root=common_root,
+    )
+
+
 @contextmanager
 def target_overlay(
     sources: Mapping[Path, str],
@@ -345,6 +386,66 @@ def target_overlay(
     if not resolved_sources:
         yield None
         return
+    with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
+        overlay = materialize_target_overlay(
+            resolved_sources, target_version, Path(tmp), search_paths
+        )
+        assert overlay is not None
+        yield overlay
+
+
+def materialize_target_overlay(
+    sources: Mapping[Path, str],
+    target_version: str,
+    root: Path,
+    search_paths: tuple[Path, ...] = (),
+) -> TargetOverlay | None:
+    resolved_sources = {path.resolve(): source for path, source in sources.items()}
+    if not resolved_sources:
+        return None
+    roots, import_roots, common = _overlay_roots(resolved_sources, search_paths)
+    paths: dict[Path, Path] = {}
+    overlay_search_paths: set[Path] = set()
+    for source_root in roots:
+        overlay_search_paths.update(
+            _copy_validation_sources(
+                source_root,
+                import_roots,
+                common,
+                root,
+                target_version,
+                resolved_sources,
+            )
+        )
+    overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
+    for path, source in resolved_sources.items():
+        try:
+            relative = path.relative_to(common)
+        except ValueError:
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+        paths[path] = target
+        overlay_search_paths.add(target.parent)
+    _copy_project_configs(common, root)
+    return TargetOverlay(
+        root=root,
+        paths=paths,
+        source_roots=roots,
+        search_paths=tuple(
+            sorted(
+                (path for path in overlay_search_paths if path != root),
+                key=lambda path: str(path),
+            )
+        ),
+    )
+
+
+def _overlay_roots(
+    resolved_sources: Mapping[Path, str],
+    search_paths: tuple[Path, ...],
+) -> tuple[tuple[Path, ...], tuple[Path, ...], Path]:
     roots = tuple(
         dict.fromkeys(
             root
@@ -356,45 +457,7 @@ def target_overlay(
         dict.fromkeys((*roots, *(search_path.resolve() for search_path in search_paths)))
     )
     common = Path(os.path.commonpath([str(root) for root in roots]))
-    with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
-        root = Path(tmp)
-        paths: dict[Path, Path] = {}
-        overlay_search_paths: set[Path] = set()
-        for source_root in roots:
-            overlay_search_paths.update(
-                _copy_validation_sources(
-                    source_root,
-                    import_roots,
-                    common,
-                    root,
-                    target_version,
-                    resolved_sources,
-                )
-            )
-        overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
-        for path, source in resolved_sources.items():
-            try:
-                relative = path.relative_to(common)
-            except ValueError:
-                continue
-            target = root / relative
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(source, encoding="utf-8")
-            paths[path] = target
-            overlay_search_paths.add(target.parent)
-        _copy_project_configs(common, root)
-        yield TargetOverlay(
-            root=root,
-            paths=paths,
-            source_roots=tuple(roots),
-            search_paths=tuple(
-                sorted(
-                    (path for path in overlay_search_paths if path != root),
-                    key=lambda path: str(path),
-                )
-            ),
-        )
-
+    return roots, import_roots, common
 
 def _overlay_configured_search_paths(
     search_paths: tuple[Path, ...], common_root: Path, target_root: Path
@@ -454,15 +517,12 @@ def _validation_roots(path: Path, search_paths: tuple[Path, ...]) -> tuple[Path,
     return (_nearest_project_root(path.parent) or path.parent,)
 
 
-def _copy_validation_sources(
+def _walk_validation_sources(
     source_root: Path,
     import_roots: tuple[Path, ...],
     common_root: Path,
-    target_root: Path,
-    target_version: str,
     overrides: Mapping[Path, str],
-) -> set[Path]:
-    search_paths: set[Path] = set()
+) -> Iterator[tuple[Path, str]]:
     override_paths = set(overrides)
     queue: list[tuple[Path, str]] = []
     for path, source in overrides.items():
@@ -495,14 +555,29 @@ def _copy_validation_sources(
             queue.append((resolved, source))
             if resolved in override_paths:
                 continue
-            _copy_validation_source(
-                resolved,
-                source,
-                common_root,
-                target_root,
-                target_version,
-                search_paths,
-            )
+            yield resolved, source
+
+
+def _copy_validation_sources(
+    source_root: Path,
+    import_roots: tuple[Path, ...],
+    common_root: Path,
+    target_root: Path,
+    target_version: str,
+    overrides: Mapping[Path, str],
+) -> set[Path]:
+    search_paths: set[Path] = set()
+    for resolved, source in _walk_validation_sources(
+        source_root, import_roots, common_root, overrides
+    ):
+        _copy_validation_source(
+            resolved,
+            source,
+            common_root,
+            target_root,
+            target_version,
+            search_paths,
+        )
     return search_paths
 
 
@@ -684,7 +759,14 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
 
 
 def _copy_project_configs(source_root: Path, target_root: Path) -> None:
-    for pyproject in source_root.rglob("pyproject.toml"):
+    resolved_target = target_root.resolve()
+    for pyproject in list(source_root.rglob("pyproject.toml")):
+        resolved_pyproject = pyproject.resolve()
+        if (
+            resolved_pyproject == resolved_target
+            or resolved_target in resolved_pyproject.parents
+        ):
+            continue
         if any(part in {".git", ".venv", "venv", "node_modules"} for part in pyproject.parts):
             continue
         try:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from uv import find_uv_bin
 
 from .models import Config
+from .source import code_mask
 from .storage_layout import compare_storage_layouts, parse_storage_layout
 from .versions import (
     VyperVersion,
@@ -663,7 +664,12 @@ def _validation_import_sources(
     path: Path, source: str, source_root: Path, import_roots: tuple[Path, ...]
 ) -> tuple[Path, ...]:
     imports: list[Path] = []
-    for line in source.splitlines():
+    mask = code_mask(source)
+    code_source = "".join(
+        char if is_code or char in "\r\n" else " "
+        for char, is_code in zip(source, mask, strict=True)
+    )
+    for line in code_source.splitlines():
         stripped = line.split("#", 1)[0].strip()
         if not stripped:
             continue

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -206,7 +206,7 @@ def validate_migrations(
 ) -> ValidationDecision:
     """Validate one coherent candidate overlay and return its typed decision."""
     resolve_candidate = candidate_source or _unchanged_candidate
-    target_sources = _candidate_sources(batch, resolve_candidate)
+    target_sources = candidate_sources(batch, resolve_candidate)
 
     with target_overlay(
         target_sources, config.target_version, config.compiler_search_paths
@@ -296,7 +296,7 @@ def _unchanged_candidate(_path: Path, source: str) -> str:
     return source
 
 
-def _candidate_sources(
+def candidate_sources(
     batch: MigrationBatch, resolve_candidate: CandidateSource
 ) -> dict[Path, str]:
     candidates = [

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -17,6 +17,8 @@ from vyupgrade.compiler import (
     compile_source_ast,
     compile_source_file,
     compile_target_source,
+    materialize_target_overlay,
+    resolve_import_closure,
     target_overlay,
     unavailable_validation_artifacts,
 )
@@ -880,6 +882,207 @@ def test_compile_target_source_uses_source_dir_for_relative_imports(monkeypatch,
 
     assert result.status == "passed"
     assert calls["target_parent"] == contract.parent
+
+def _write_import_closure_fixture(
+    tmp_path: Path,
+) -> tuple[Path, dict[Path, str], tuple[Path, ...], tuple[Path, ...]]:
+    project = tmp_path / "project"
+    contract = project / "src" / "a.vy"
+    dependency = project / "src" / "b.vy"
+    transitive = project / "src" / "lib" / "c.vy"
+    interface = project / "src" / "interfaces" / "IThing.json"
+    contract.parent.mkdir(parents=True)
+    transitive.parent.mkdir(parents=True)
+    interface.parent.mkdir(parents=True)
+    source = "#pragma version 0.4.3\nfrom . import b\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text(
+        "# @version 0.4.0\n"
+        "from .lib import c\n"
+        "from .interfaces import IThing\n",
+        encoding="utf-8",
+    )
+    transitive.write_text("# @version 0.4.0\nVALUE: constant(uint256) = 1\n", encoding="utf-8")
+    interface.write_text("[]\n", encoding="utf-8")
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "closure-fixture"\n',
+        encoding="utf-8",
+    )
+    return (
+        contract,
+        {contract: source},
+        (project,),
+        tuple(sorted((dependency.resolve(), transitive.resolve(), interface.resolve()))),
+    )
+
+
+def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
+    contract, sources, search_paths, expected_dependencies = (
+        _write_import_closure_fixture(tmp_path)
+    )
+
+    closure = resolve_import_closure(sources, search_paths)
+
+    assert closure.roots == (contract.resolve(),)
+    assert closure.dependencies == expected_dependencies
+    assert closure.files == (contract.resolve(), *expected_dependencies)
+    assert closure.source_roots == (tmp_path / "project",)
+    assert closure.common_root == tmp_path / "project"
+
+
+def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    closure = resolve_import_closure(sources, search_paths)
+
+    with target_overlay(sources, "0.4.3", search_paths) as overlay:
+        assert overlay is not None
+        copied_files = {
+            path.relative_to(overlay.root)
+            for path in overlay.root.rglob("*")
+            if path.is_file()
+        }
+
+    override_files = {
+        path.resolve().relative_to(closure.common_root) for path in sources
+    }
+    config_files = {
+        path.relative_to(closure.common_root)
+        for path in closure.common_root.rglob("pyproject.toml")
+    }
+    create2_aliases = {
+        path
+        for path in copied_files
+        if path.name == "create2.vy"
+        and path.with_name("create2_address.vy") in copied_files
+    }
+    dependency_copies = copied_files - override_files - config_files - create2_aliases
+
+    assert dependency_copies == {
+        path.relative_to(closure.common_root) for path in closure.dependencies
+    }
+
+
+def test_resolve_import_closure_search_path_dependency(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "main.vy"
+    site_packages = tmp_path / "site-packages"
+    dependency = site_packages / "pkg" / "dep.vy"
+    escaped = tmp_path / "outside" / "escape.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    escaped.parent.mkdir(parents=True)
+    source = (
+        "#pragma version 0.4.3\n"
+        "from pkg import dep\n"
+        "from ...outside import escape\n"
+    )
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.4.0\n", encoding="utf-8")
+    escaped.write_text("# @version 0.4.0\n", encoding="utf-8")
+
+    closure = resolve_import_closure(
+        {contract: source},
+        (site_packages, project),
+    )
+
+    assert closure.dependencies == (dependency.resolve(),)
+    assert escaped.resolve() not in closure.files
+    with pytest.raises(ValueError):
+        dependency.resolve().relative_to(closure.common_root)
+    with target_overlay({contract: source}, "0.4.3", (site_packages, project)) as overlay:
+        assert overlay is not None
+        assert not any(
+            path.name == "dep.vy"
+            for path in overlay.root.rglob("*")
+            if path.is_file()
+        )
+
+
+def test_resolve_import_closure_create2_alias_resolves_to_real_file(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "factory.vy"
+    dependency = project / "snekmate" / "utils" / "create2_address.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    source = "#pragma version 0.4.3\nfrom snekmate.utils import create2\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.4.0\n", encoding="utf-8")
+
+    closure = resolve_import_closure({contract: source}, (project,))
+
+    assert closure.dependencies == (dependency.resolve(),)
+    assert all(path.name != "create2.vy" for path in closure.files)
+
+
+def test_resolve_import_closure_is_idempotent(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+
+    first = resolve_import_closure(sources, search_paths)
+    second = resolve_import_closure(sources, search_paths)
+
+    assert first == second
+
+
+def test_resolve_import_closure_empty_sources_raises() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^resolve_import_closure requires at least one source$",
+    ):
+        resolve_import_closure({})
+
+
+def test_materialize_target_overlay_writes_into_given_root(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    with target_overlay(sources, "0.4.3", search_paths) as temporary:
+        assert temporary is not None
+        expected_files = {
+            path.relative_to(temporary.root): path.read_bytes()
+            for path in temporary.root.rglob("*")
+            if path.is_file()
+        }
+
+    root = tmp_path / "materialized"
+    root.mkdir()
+    overlay = materialize_target_overlay(sources, "0.4.3", root, search_paths)
+
+    assert overlay is not None
+    assert overlay.root == root
+    assert all(path.is_relative_to(root) for path in overlay.paths.values())
+    assert {
+        path.relative_to(root): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    } == expected_files
+    assert root.exists()
+
+
+def test_materialize_target_overlay_output_root_under_project_root(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    project = tmp_path / "project"
+    root = project / "overlay-output"
+
+    overlay = materialize_target_overlay(sources, "0.4.3", root, search_paths)
+
+    assert overlay is not None
+    assert list(root.rglob("pyproject.toml")) == [root / "pyproject.toml"]
+    assert (root / "pyproject.toml").read_bytes() == (
+        project / "pyproject.toml"
+    ).read_bytes()
+
+
+def test_materialize_target_overlay_empty_sources_returns_none(tmp_path) -> None:
+    root = tmp_path / "materialized"
+
+    assert materialize_target_overlay({}, "0.4.3", root) is None
+
 
 
 def test_target_overlay_rewrites_imported_vyper_pragmas(monkeypatch, tmp_path) -> None:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -930,6 +930,31 @@ def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
     assert closure.common_root == tmp_path / "project"
 
 
+@pytest.mark.parametrize(
+    "documentation",
+    [
+        '"""\nimport ghost\n"""\n',
+        'EXAMPLE: constant(String[32]) = """\nimport ghost\n"""\n',
+    ],
+)
+def test_resolve_import_closure_ignores_imports_in_strings(
+    tmp_path: Path, documentation: str
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "main.vy"
+    dependency = project / "real.vy"
+    ghost = project / "ghost.vy"
+    project.mkdir()
+    source = f"# @version 0.3.10\n{documentation}from . import real\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.3.10\n", encoding="utf-8")
+    ghost.write_text("not valid Vyper\n", encoding="utf-8")
+
+    closure = resolve_import_closure({contract: source}, (project,))
+
+    assert closure.dependencies == (dependency.resolve(),)
+
+
 def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> None:
     _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
         tmp_path


### PR DESCRIPTION
_co-authored by claude opus 4.8_

This refactors compiler overlay validation so resolved-import traversal is single-sourced and exposed through `ImportClosure` and `resolve_import_closure`. It separates overlay materialization into a caller-owned root and fixes recursive project-config copying when the destination is nested under the project root, with no user-facing behavior change. The resulting primitive gives later dependency upgrades one authoritative view of the resolved import closure.

**Stacked on:** `master`. This is part of the stacked series implementing issue #23 and also provides the resolved import-closure primitive underlying issue #22.

**Tests:** Compiler unit tests and the full test suite are green.
