### PR TITLE
feat(compiler): opt-in closure-mode overlay materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added a public import-closure primitive (resolve_import_closure) and a reusable overlay materializer, single-sourcing the validation dependency traversal.
+- Added opt-in closure-mode overlay materialization: the full import closure (including external search-path dependencies) can be materialized import-root-relative for dependency-closure upgrades.
 
 ## 0.5.1 - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added a public import-closure primitive (resolve_import_closure) and a reusable overlay materializer, single-sourcing the validation dependency traversal.
+
 ## 0.5.1 - 2026-07-10
 
 - Extracted fail-closed storage-layout parsing, canonicalization, AST evidence,

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -91,6 +91,7 @@ class ImportClosure:
 class _ResolvedValidationImport:
     path: Path
     root: Path
+    relative_path: Path
 
 
 def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
@@ -495,10 +496,10 @@ def _materialize_closure_sources(
     placed: dict[Path, Path] = {}
     paths: dict[Path, Path] = {}
     search_paths: set[Path] = set()
-    for path, source, import_root, is_override in _walk_validation_closure(
+    for path, source, relative_path, is_override in _walk_validation_closure(
         source_roots, import_roots, common_root, overrides
     ):
-        target = target_root / path.relative_to(import_root)
+        target = target_root / relative_path
         if is_override:
             if _claim_overlay_destination(placed, target, path, source):
                 target.parent.mkdir(parents=True, exist_ok=True)
@@ -643,61 +644,84 @@ def _walk_validation_closure(
             path, source, common_root
         )
         for source_root in _containing_import_roots(path, source_roots):
+            relative_path = path.relative_to(source_root)
             incoming_overrides.update(
                 imported.path
                 for imported in _validation_import_sources(
-                    path, import_source, source_root, import_roots
+                    path,
+                    import_source,
+                    source_root,
+                    import_roots,
+                    relative_path,
                 )
                 if imported.path in override_paths
             )
 
     entry_paths = override_paths - incoming_overrides
-    queue = [
-        (
-            path,
-            overrides[path],
-            _containing_import_roots(path, source_roots)[0],
-            True,
+    queue: list[tuple[Path, str, Path, Path, bool]] = []
+    for path in sorted(entry_paths):
+        source_root = _containing_import_roots(path, source_roots)[0]
+        queue.append(
+            (
+                path,
+                overrides[path],
+                source_root,
+                path.relative_to(source_root),
+                True,
+            )
         )
-        for path in sorted(entry_paths)
-    ]
     layouts: dict[Path, Path] = {}
     processed: set[Path] = set()
     while queue or override_paths - processed:
         if not queue:
             path = min(override_paths - processed)
+            source_root = _containing_import_roots(path, source_roots)[0]
             queue.append(
                 (
                     path,
                     overrides[path],
-                    _containing_import_roots(path, source_roots)[0],
+                    source_root,
+                    path.relative_to(source_root),
                     True,
                 )
             )
-        current, current_source, current_root, is_override = queue.pop(0)
-        existing_root = layouts.get(current)
-        if existing_root is not None and existing_root != current_root:
+        (
+            current,
+            current_source,
+            current_root,
+            current_relative,
+            is_override,
+        ) = queue.pop(0)
+        existing_relative = layouts.get(current)
+        if (
+            existing_relative is not None
+            and existing_relative != current_relative
+        ):
             raise OverlayLayoutConflictError(
-                f"closure member {current} resolves relative to both "
-                f"{existing_root} and {current_root}"
+                f"closure member {current} maps to both "
+                f"{existing_relative} and {current_relative}"
             )
-        layouts[current] = current_root
+        layouts[current] = current_relative
         if current in processed:
             continue
         processed.add(current)
-        yield current, current_source, current_root, is_override
+        yield current, current_source, current_relative, is_override
         import_source = _standard_json_package_dependency_source(
             current, current_source, common_root
         )
         for imported in _validation_import_sources(
-            current, import_source, current_root, import_roots
+            current,
+            import_source,
+            current_root,
+            import_roots,
+            current_relative,
         ):
             if imported.path in processed:
-                existing_root = layouts[imported.path]
-                if existing_root != imported.root:
+                existing_relative = layouts[imported.path]
+                if existing_relative != imported.relative_path:
                     raise OverlayLayoutConflictError(
-                        f"closure member {imported.path} resolves relative to both "
-                        f"{existing_root} and {imported.root}"
+                        f"closure member {imported.path} maps to both "
+                        f"{existing_relative} and {imported.relative_path}"
                     )
                 continue
             source = overrides.get(imported.path)
@@ -707,7 +731,13 @@ def _walk_validation_closure(
                 except (OSError, UnicodeDecodeError):
                     continue
             queue.append(
-                (imported.path, source, imported.root, imported.path in override_paths)
+                (
+                    imported.path,
+                    source,
+                    imported.root,
+                    imported.relative_path,
+                    imported.path in override_paths,
+                )
             )
 
 
@@ -875,7 +905,11 @@ def _local_sibling_import_source(source_path: Path, source: str) -> str:
 
 
 def _validation_import_sources(
-    path: Path, source: str, source_root: Path, import_roots: tuple[Path, ...]
+    path: Path,
+    source: str,
+    source_root: Path,
+    import_roots: tuple[Path, ...],
+    relative_path: Path | None = None,
 ) -> tuple[_ResolvedValidationImport, ...]:
     imports: list[_ResolvedValidationImport] = []
     mask = code_mask(source)
@@ -894,7 +928,12 @@ def _validation_import_sources(
         if import_match:
             imports.extend(
                 _resolve_validation_import(
-                    path, source_root, import_match.group(1), (), import_roots
+                    path,
+                    source_root,
+                    import_match.group(1),
+                    (),
+                    import_roots,
+                    relative_path,
                 )
             )
             continue
@@ -906,7 +945,12 @@ def _validation_import_sources(
             names = tuple(_imported_module_names(from_match.group(2)))
             imports.extend(
                 _resolve_validation_import(
-                    path, source_root, from_match.group(1), names, import_roots
+                    path,
+                    source_root,
+                    from_match.group(1),
+                    names,
+                    import_roots,
+                    relative_path,
                 )
             )
     return tuple(dict.fromkeys(imports))
@@ -928,29 +972,42 @@ def _resolve_validation_import(
     module: str,
     names: tuple[str, ...],
     import_roots: tuple[Path, ...],
+    relative_path: Path | None,
 ) -> tuple[_ResolvedValidationImport, ...]:
-    bases, module_parts = _validation_import_bases(path, source_root, module, import_roots)
-    candidates: list[tuple[Path, Path]] = []
-    for base, import_root in bases:
+    bases, module_parts = _validation_import_bases(
+        path, source_root, module, import_roots, relative_path
+    )
+    candidates: list[tuple[Path, Path, Path]] = []
+    for base, import_root, relative_base in bases:
         module_path = base.joinpath(*module_parts) if module_parts else base
+        relative_module = (
+            relative_base.joinpath(*module_parts)
+            if module_parts
+            else relative_base
+        )
         if names:
             for name in names:
                 candidates.extend(
-                    (candidate, import_root)
-                    for candidate in _validation_module_candidates(module_path / name)
+                    _validation_module_candidate_layouts(
+                        module_path / name,
+                        relative_module / name,
+                        import_root,
+                    )
                 )
             candidates.extend(
-                (candidate, import_root)
-                for candidate in _validation_module_candidates(module_path)
+                _validation_module_candidate_layouts(
+                    module_path, relative_module, import_root
+                )
             )
         else:
             candidates.extend(
-                (candidate, import_root)
-                for candidate in _validation_module_candidates(module_path)
+                _validation_module_candidate_layouts(
+                    module_path, relative_module, import_root
+                )
             )
-    resolved: dict[Path, Path] = {}
+    resolved: dict[Path, tuple[Path, Path]] = {}
     roots = tuple(root.resolve() for root in (source_root, *import_roots))
-    for candidate, import_root in candidates:
+    for candidate, import_root, candidate_relative in candidates:
         try:
             resolved_candidate = candidate.resolve()
             if not any(_is_relative_to(resolved_candidate, root) for root in roots):
@@ -958,33 +1015,45 @@ def _resolve_validation_import(
         except (OSError, ValueError):
             continue
         if resolved_candidate.exists() and resolved_candidate.suffix in VALIDATION_SOURCE_SUFFIXES:
-            resolved.setdefault(resolved_candidate, import_root)
+            resolved.setdefault(
+                resolved_candidate, (import_root, candidate_relative)
+            )
     return tuple(
-        _ResolvedValidationImport(path, import_root)
-        for path, import_root in resolved.items()
+        _ResolvedValidationImport(path, import_root, candidate_relative)
+        for path, (import_root, candidate_relative) in resolved.items()
     )
 
 
 def _validation_import_bases(
-    path: Path, source_root: Path, module: str, import_roots: tuple[Path, ...]
-) -> tuple[tuple[tuple[Path, Path], ...], tuple[str, ...]]:
+    path: Path,
+    source_root: Path,
+    module: str,
+    import_roots: tuple[Path, ...],
+    relative_path: Path | None,
+) -> tuple[tuple[tuple[Path, Path, Path], ...], tuple[str, ...]]:
+    relative_parent = relative_path.parent if relative_path is not None else Path()
     if not module.startswith("."):
         bases = (
-            (path.parent, source_root),
-            (source_root, source_root),
-            *((root, root) for root in import_roots),
+            (path.parent, source_root, relative_parent),
+            (source_root, source_root, Path()),
+            *((root, root, Path()) for root in import_roots),
         )
-        unique_bases: dict[Path, Path] = {}
-        for base, root in bases:
-            unique_bases.setdefault(base, root)
-        return tuple(unique_bases.items()), tuple(
+        unique_bases: dict[Path, tuple[Path, Path]] = {}
+        for base, root, relative_base in bases:
+            unique_bases.setdefault(base, (root, relative_base))
+        return tuple(
+            (base, root, relative_base)
+            for base, (root, relative_base) in unique_bases.items()
+        ), tuple(
             part for part in module.split(".") if part
         )
     level = len(module) - len(module.lstrip("."))
     base = path.parent
+    relative_base = relative_parent
     for _ in range(max(level - 1, 0)):
         base = base.parent
-    return ((base, source_root),), tuple(
+        relative_base = relative_base.parent
+    return ((base, source_root, relative_base),), tuple(
         part for part in module[level:].split(".") if part
     )
 
@@ -1003,6 +1072,21 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
     if alias is not None:
         paths.append(path.with_name(alias))
     return tuple(candidate.with_suffix(suffix) for candidate in paths for suffix in sorted(VALIDATION_SOURCE_SUFFIXES))
+
+
+def _validation_module_candidate_layouts(
+    path: Path, relative_path: Path, import_root: Path
+) -> tuple[tuple[Path, Path, Path], ...]:
+    return tuple(
+        (
+            candidate,
+            import_root,
+            relative_path.with_name(candidate.name)
+            if relative_path.name
+            else Path(candidate.name),
+        )
+        for candidate in _validation_module_candidates(path)
+    )
 
 
 def _project_config_paths(

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -71,6 +71,17 @@ class TargetOverlay:
     source_roots: tuple[Path, ...]
     search_paths: tuple[Path, ...]
 
+@dataclass(frozen=True)
+class ImportClosure:
+    roots: tuple[Path, ...]
+    dependencies: tuple[Path, ...]
+    source_roots: tuple[Path, ...]
+    common_root: Path
+
+    @property
+    def files(self) -> tuple[Path, ...]:
+        return self.roots + self.dependencies
+
 
 def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
     artifacts = result.artifacts or {}
@@ -335,6 +346,36 @@ def _compile_target_interface(
             harness_path.unlink(missing_ok=True)
 
 
+def resolve_import_closure(
+    sources: Mapping[Path, str],
+    search_paths: tuple[Path, ...] = (),
+) -> ImportClosure:
+    """Resolve the full transitive closure, including external search-path files.
+
+    Overlay materialization copies only closure members under ``common_root``;
+    external configured-search-path dependencies remain available in place.
+    """
+    resolved_sources = {path.resolve(): source for path, source in sources.items()}
+    if not resolved_sources:
+        raise ValueError("resolve_import_closure requires at least one source")
+    source_roots, import_roots, common_root = _overlay_roots(
+        resolved_sources, search_paths
+    )
+    dependencies = [
+        path
+        for source_root in source_roots
+        for path, _source in _walk_validation_sources(
+            source_root, import_roots, common_root, resolved_sources
+        )
+    ]
+    return ImportClosure(
+        roots=tuple(sorted(resolved_sources)),
+        dependencies=tuple(sorted(dict.fromkeys(dependencies))),
+        source_roots=source_roots,
+        common_root=common_root,
+    )
+
+
 @contextmanager
 def target_overlay(
     sources: Mapping[Path, str],
@@ -345,6 +386,66 @@ def target_overlay(
     if not resolved_sources:
         yield None
         return
+    with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
+        overlay = materialize_target_overlay(
+            resolved_sources, target_version, Path(tmp), search_paths
+        )
+        assert overlay is not None
+        yield overlay
+
+
+def materialize_target_overlay(
+    sources: Mapping[Path, str],
+    target_version: str,
+    root: Path,
+    search_paths: tuple[Path, ...] = (),
+) -> TargetOverlay | None:
+    resolved_sources = {path.resolve(): source for path, source in sources.items()}
+    if not resolved_sources:
+        return None
+    roots, import_roots, common = _overlay_roots(resolved_sources, search_paths)
+    paths: dict[Path, Path] = {}
+    overlay_search_paths: set[Path] = set()
+    for source_root in roots:
+        overlay_search_paths.update(
+            _copy_validation_sources(
+                source_root,
+                import_roots,
+                common,
+                root,
+                target_version,
+                resolved_sources,
+            )
+        )
+    overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
+    for path, source in resolved_sources.items():
+        try:
+            relative = path.relative_to(common)
+        except ValueError:
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+        paths[path] = target
+        overlay_search_paths.add(target.parent)
+    _copy_project_configs(common, root)
+    return TargetOverlay(
+        root=root,
+        paths=paths,
+        source_roots=roots,
+        search_paths=tuple(
+            sorted(
+                (path for path in overlay_search_paths if path != root),
+                key=lambda path: str(path),
+            )
+        ),
+    )
+
+
+def _overlay_roots(
+    resolved_sources: Mapping[Path, str],
+    search_paths: tuple[Path, ...],
+) -> tuple[tuple[Path, ...], tuple[Path, ...], Path]:
     roots = tuple(
         dict.fromkeys(
             root
@@ -356,45 +457,7 @@ def target_overlay(
         dict.fromkeys((*roots, *(search_path.resolve() for search_path in search_paths)))
     )
     common = Path(os.path.commonpath([str(root) for root in roots]))
-    with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
-        root = Path(tmp)
-        paths: dict[Path, Path] = {}
-        overlay_search_paths: set[Path] = set()
-        for source_root in roots:
-            overlay_search_paths.update(
-                _copy_validation_sources(
-                    source_root,
-                    import_roots,
-                    common,
-                    root,
-                    target_version,
-                    resolved_sources,
-                )
-            )
-        overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
-        for path, source in resolved_sources.items():
-            try:
-                relative = path.relative_to(common)
-            except ValueError:
-                continue
-            target = root / relative
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(source, encoding="utf-8")
-            paths[path] = target
-            overlay_search_paths.add(target.parent)
-        _copy_project_configs(common, root)
-        yield TargetOverlay(
-            root=root,
-            paths=paths,
-            source_roots=tuple(roots),
-            search_paths=tuple(
-                sorted(
-                    (path for path in overlay_search_paths if path != root),
-                    key=lambda path: str(path),
-                )
-            ),
-        )
-
+    return roots, import_roots, common
 
 def _overlay_configured_search_paths(
     search_paths: tuple[Path, ...], common_root: Path, target_root: Path
@@ -454,15 +517,12 @@ def _validation_roots(path: Path, search_paths: tuple[Path, ...]) -> tuple[Path,
     return (_nearest_project_root(path.parent) or path.parent,)
 
 
-def _copy_validation_sources(
+def _walk_validation_sources(
     source_root: Path,
     import_roots: tuple[Path, ...],
     common_root: Path,
-    target_root: Path,
-    target_version: str,
     overrides: Mapping[Path, str],
-) -> set[Path]:
-    search_paths: set[Path] = set()
+) -> Iterator[tuple[Path, str]]:
     override_paths = set(overrides)
     queue: list[tuple[Path, str]] = []
     for path, source in overrides.items():
@@ -495,14 +555,29 @@ def _copy_validation_sources(
             queue.append((resolved, source))
             if resolved in override_paths:
                 continue
-            _copy_validation_source(
-                resolved,
-                source,
-                common_root,
-                target_root,
-                target_version,
-                search_paths,
-            )
+            yield resolved, source
+
+
+def _copy_validation_sources(
+    source_root: Path,
+    import_roots: tuple[Path, ...],
+    common_root: Path,
+    target_root: Path,
+    target_version: str,
+    overrides: Mapping[Path, str],
+) -> set[Path]:
+    search_paths: set[Path] = set()
+    for resolved, source in _walk_validation_sources(
+        source_root, import_roots, common_root, overrides
+    ):
+        _copy_validation_source(
+            resolved,
+            source,
+            common_root,
+            target_root,
+            target_version,
+            search_paths,
+        )
     return search_paths
 
 
@@ -684,7 +759,14 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
 
 
 def _copy_project_configs(source_root: Path, target_root: Path) -> None:
-    for pyproject in source_root.rglob("pyproject.toml"):
+    resolved_target = target_root.resolve()
+    for pyproject in list(source_root.rglob("pyproject.toml")):
+        resolved_pyproject = pyproject.resolve()
+        if (
+            resolved_pyproject == resolved_target
+            or resolved_target in resolved_pyproject.parents
+        ):
+            continue
         if any(part in {".git", ".venv", "venv", "node_modules"} for part in pyproject.parts):
             continue
         try:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from uv import find_uv_bin
 
 from .models import Config
+from .source import code_mask
 from .storage_layout import compare_storage_layouts, parse_storage_layout
 from .versions import (
     VyperVersion,
@@ -663,7 +664,12 @@ def _validation_import_sources(
     path: Path, source: str, source_root: Path, import_roots: tuple[Path, ...]
 ) -> tuple[Path, ...]:
     imports: list[Path] = []
-    for line in source.splitlines():
+    mask = code_mask(source)
+    code_source = "".join(
+        char if is_code or char in "\r\n" else " "
+        for char, is_code in zip(source, mask, strict=True)
+    )
+    for line in code_source.splitlines():
         stripped = line.split("#", 1)[0].strip()
         if not stripped:
             continue

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -87,6 +87,12 @@ class ImportClosure:
         return self.roots + self.dependencies
 
 
+@dataclass(frozen=True)
+class _ResolvedValidationImport:
+    path: Path
+    root: Path
+
+
 def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
     artifacts = result.artifacts or {}
     validators: dict[str, Callable[[object], bool]] = {
@@ -367,10 +373,10 @@ def resolve_import_closure(
     )
     dependencies = [
         path
-        for source_root in source_roots
-        for path, _source in _walk_validation_sources(
-            source_root, import_roots, common_root, resolved_sources
+        for path, _source, _import_root, is_override in _walk_validation_closure(
+            source_roots, import_roots, common_root, resolved_sources
         )
+        if not is_override
     ]
     return ImportClosure(
         roots=tuple(sorted(resolved_sources)),
@@ -416,49 +422,42 @@ def materialize_target_overlay(
     if not resolved_sources:
         return None
     roots, import_roots, common = _overlay_roots(resolved_sources, search_paths)
-    destination = _overlay_destination_resolver(
-        common, import_roots, root, include_dependencies
-    )
-    placed: dict[Path, Path] | None = {} if include_dependencies else None
-    members: dict[Path, Path] = {}
-    paths: dict[Path, Path] = {}
-    overlay_search_paths: set[Path] = set()
-    for source_root in roots:
-        copied_search_paths, copied = _copy_validation_sources(
-            source_root,
+    if include_dependencies:
+        paths, overlay_search_paths = _materialize_closure_sources(
+            roots,
             import_roots,
             common,
             root,
             target_version,
             resolved_sources,
-            destination,
-            placed,
         )
-        overlay_search_paths.update(copied_search_paths)
-        if include_dependencies:
-            members.update(copied)
-    if not include_dependencies:
+    else:
+        destination = _overlay_destination_resolver(common, root)
+        paths: dict[Path, Path] = {}
+        overlay_search_paths: set[Path] = set()
+        for source_root in roots:
+            copied_search_paths, _copied = _copy_validation_sources(
+                source_root,
+                import_roots,
+                common,
+                root,
+                target_version,
+                resolved_sources,
+                destination,
+                None,
+            )
+            overlay_search_paths.update(copied_search_paths)
         overlay_search_paths.update(
             _overlay_configured_search_paths(search_paths, common, root)
         )
-    for path, source in resolved_sources.items():
-        target = destination(path)
-        if target is None:
-            continue
-        if placed is None or _claim_overlay_destination(
-            placed, target, path, source
-        ):
+        for path, source in resolved_sources.items():
+            target = destination(path)
+            if target is None:
+                continue
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(source, encoding="utf-8")
-        paths[path] = target
-        overlay_search_paths.add(target.parent)
-        if include_dependencies and path.name == "create2_address.vy":
-            alias = target.with_name("create2.vy")
-            alias_source = _target_validation_create2_alias_source(source)
-            if placed is None or _claim_overlay_destination(
-                placed, alias, path, alias_source
-            ):
-                alias.write_text(alias_source, encoding="utf-8")
+            paths[path] = target
+            overlay_search_paths.add(target.parent)
     if include_dependencies:
         configured_search_paths = tuple(
             search_path.resolve() for search_path in search_paths
@@ -474,7 +473,7 @@ def materialize_target_overlay(
         _copy_project_configs(common, root)
     return TargetOverlay(
         root=root,
-        paths={**members, **paths} if include_dependencies else paths,
+        paths=paths,
         source_roots=import_roots if include_dependencies else roots,
         search_paths=tuple(
             sorted(
@@ -483,6 +482,45 @@ def materialize_target_overlay(
             )
         ),
     )
+
+
+def _materialize_closure_sources(
+    source_roots: tuple[Path, ...],
+    import_roots: tuple[Path, ...],
+    common_root: Path,
+    target_root: Path,
+    target_version: str,
+    overrides: Mapping[Path, str],
+) -> tuple[dict[Path, Path], set[Path]]:
+    placed: dict[Path, Path] = {}
+    paths: dict[Path, Path] = {}
+    search_paths: set[Path] = set()
+    for path, source, import_root, is_override in _walk_validation_closure(
+        source_roots, import_roots, common_root, overrides
+    ):
+        target = target_root / path.relative_to(import_root)
+        if is_override:
+            if _claim_overlay_destination(placed, target, path, source):
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(source, encoding="utf-8")
+            search_paths.add(target.parent)
+            if path.name == "create2_address.vy":
+                alias = target.with_name("create2.vy")
+                alias_source = _target_validation_create2_alias_source(source)
+                if _claim_overlay_destination(placed, alias, path, alias_source):
+                    alias.write_text(alias_source, encoding="utf-8")
+        else:
+            _copy_validation_source(
+                path,
+                source,
+                target,
+                common_root,
+                target_version,
+                search_paths,
+                placed,
+            )
+        paths[path] = target
+    return paths, search_paths
 
 
 def _overlay_roots(
@@ -503,28 +541,10 @@ def _overlay_roots(
     return roots, import_roots, common
 
 
-def _closure_import_root(path: Path, import_roots: tuple[Path, ...]) -> Path:
-    containing_roots = tuple(
-        root for root in import_roots if _is_relative_to(path, root)
-    )
-    assert containing_roots, f"closure member is outside import roots: {path}"
-    return max(containing_roots, key=lambda root: len(root.parts))
-
-
 def _overlay_destination_resolver(
     common_root: Path,
-    import_roots: tuple[Path, ...],
     target_root: Path,
-    include_dependencies: bool,
 ) -> Callable[[Path], Path | None]:
-    if include_dependencies:
-
-        def destination(path: Path) -> Path:
-            import_root = _closure_import_root(path, import_roots)
-            return target_root / path.relative_to(import_root)
-
-        return destination
-
     def destination(path: Path) -> Path | None:
         try:
             return target_root / path.relative_to(common_root)
@@ -610,6 +630,95 @@ def _validation_roots(path: Path, search_paths: tuple[Path, ...]) -> tuple[Path,
     return (_nearest_project_root(path.parent) or path.parent,)
 
 
+def _walk_validation_closure(
+    source_roots: tuple[Path, ...],
+    import_roots: tuple[Path, ...],
+    common_root: Path,
+    overrides: Mapping[Path, str],
+) -> Iterator[tuple[Path, str, Path, bool]]:
+    override_paths = set(overrides)
+    incoming_overrides: set[Path] = set()
+    for path, source in overrides.items():
+        import_source = _standard_json_package_dependency_source(
+            path, source, common_root
+        )
+        for source_root in _containing_import_roots(path, source_roots):
+            incoming_overrides.update(
+                imported.path
+                for imported in _validation_import_sources(
+                    path, import_source, source_root, import_roots
+                )
+                if imported.path in override_paths
+            )
+
+    entry_paths = override_paths - incoming_overrides
+    queue = [
+        (
+            path,
+            overrides[path],
+            _containing_import_roots(path, source_roots)[0],
+            True,
+        )
+        for path in sorted(entry_paths)
+    ]
+    layouts: dict[Path, Path] = {}
+    processed: set[Path] = set()
+    while queue or override_paths - processed:
+        if not queue:
+            path = min(override_paths - processed)
+            queue.append(
+                (
+                    path,
+                    overrides[path],
+                    _containing_import_roots(path, source_roots)[0],
+                    True,
+                )
+            )
+        current, current_source, current_root, is_override = queue.pop(0)
+        existing_root = layouts.get(current)
+        if existing_root is not None and existing_root != current_root:
+            raise OverlayLayoutConflictError(
+                f"closure member {current} resolves relative to both "
+                f"{existing_root} and {current_root}"
+            )
+        layouts[current] = current_root
+        if current in processed:
+            continue
+        processed.add(current)
+        yield current, current_source, current_root, is_override
+        import_source = _standard_json_package_dependency_source(
+            current, current_source, common_root
+        )
+        for imported in _validation_import_sources(
+            current, import_source, current_root, import_roots
+        ):
+            if imported.path in processed:
+                existing_root = layouts[imported.path]
+                if existing_root != imported.root:
+                    raise OverlayLayoutConflictError(
+                        f"closure member {imported.path} resolves relative to both "
+                        f"{existing_root} and {imported.root}"
+                    )
+                continue
+            source = overrides.get(imported.path)
+            if source is None:
+                try:
+                    source = imported.path.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
+            queue.append(
+                (imported.path, source, imported.root, imported.path in override_paths)
+            )
+
+
+def _containing_import_roots(
+    path: Path, import_roots: tuple[Path, ...]
+) -> tuple[Path, ...]:
+    roots = tuple(root for root in import_roots if _is_relative_to(path, root))
+    assert roots, f"closure member is outside import roots: {path}"
+    return tuple(sorted(roots, key=lambda root: len(root.parts)))
+
+
 def _walk_validation_sources(
     source_root: Path,
     import_roots: tuple[Path, ...],
@@ -634,9 +743,10 @@ def _walk_validation_sources(
         current_source = _standard_json_package_dependency_source(
             current, current_source, common_root
         )
-        for resolved in _validation_import_sources(
+        for imported in _validation_import_sources(
             current, current_source, source_root, import_roots
         ):
+            resolved = imported.path
             if resolved in processed:
                 continue
             source = overrides.get(resolved)
@@ -766,8 +876,8 @@ def _local_sibling_import_source(source_path: Path, source: str) -> str:
 
 def _validation_import_sources(
     path: Path, source: str, source_root: Path, import_roots: tuple[Path, ...]
-) -> tuple[Path, ...]:
-    imports: list[Path] = []
+) -> tuple[_ResolvedValidationImport, ...]:
+    imports: list[_ResolvedValidationImport] = []
     mask = code_mask(source)
     code_source = "".join(
         char if is_code or char in "\r\n" else " "
@@ -813,21 +923,34 @@ def _imported_module_names(imports: str) -> Iterator[str]:
 
 
 def _resolve_validation_import(
-    path: Path, source_root: Path, module: str, names: tuple[str, ...], import_roots: tuple[Path, ...]
-) -> tuple[Path, ...]:
+    path: Path,
+    source_root: Path,
+    module: str,
+    names: tuple[str, ...],
+    import_roots: tuple[Path, ...],
+) -> tuple[_ResolvedValidationImport, ...]:
     bases, module_parts = _validation_import_bases(path, source_root, module, import_roots)
-    candidates: list[Path] = []
-    for base in bases:
+    candidates: list[tuple[Path, Path]] = []
+    for base, import_root in bases:
         module_path = base.joinpath(*module_parts) if module_parts else base
         if names:
             for name in names:
-                candidates.extend(_validation_module_candidates(module_path / name))
-            candidates.extend(_validation_module_candidates(module_path))
+                candidates.extend(
+                    (candidate, import_root)
+                    for candidate in _validation_module_candidates(module_path / name)
+                )
+            candidates.extend(
+                (candidate, import_root)
+                for candidate in _validation_module_candidates(module_path)
+            )
         else:
-            candidates.extend(_validation_module_candidates(module_path))
-    resolved: list[Path] = []
+            candidates.extend(
+                (candidate, import_root)
+                for candidate in _validation_module_candidates(module_path)
+            )
+    resolved: dict[Path, Path] = {}
     roots = tuple(root.resolve() for root in (source_root, *import_roots))
-    for candidate in candidates:
+    for candidate, import_root in candidates:
         try:
             resolved_candidate = candidate.resolve()
             if not any(_is_relative_to(resolved_candidate, root) for root in roots):
@@ -835,21 +958,35 @@ def _resolve_validation_import(
         except (OSError, ValueError):
             continue
         if resolved_candidate.exists() and resolved_candidate.suffix in VALIDATION_SOURCE_SUFFIXES:
-            resolved.append(resolved_candidate)
-    return tuple(dict.fromkeys(resolved))
+            resolved.setdefault(resolved_candidate, import_root)
+    return tuple(
+        _ResolvedValidationImport(path, import_root)
+        for path, import_root in resolved.items()
+    )
 
 
 def _validation_import_bases(
     path: Path, source_root: Path, module: str, import_roots: tuple[Path, ...]
-) -> tuple[tuple[Path, ...], tuple[str, ...]]:
+) -> tuple[tuple[tuple[Path, Path], ...], tuple[str, ...]]:
     if not module.startswith("."):
-        bases = (path.parent, source_root, *import_roots)
-        return tuple(dict.fromkeys(bases)), tuple(part for part in module.split(".") if part)
+        bases = (
+            (path.parent, source_root),
+            (source_root, source_root),
+            *((root, root) for root in import_roots),
+        )
+        unique_bases: dict[Path, Path] = {}
+        for base, root in bases:
+            unique_bases.setdefault(base, root)
+        return tuple(unique_bases.items()), tuple(
+            part for part in module.split(".") if part
+        )
     level = len(module) - len(module.lstrip("."))
     base = path.parent
     for _ in range(max(level - 1, 0)):
         base = base.parent
-    return (base,), tuple(part for part in module[level:].split(".") if part)
+    return ((base, source_root),), tuple(
+        part for part in module[level:].split(".") if part
+    )
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -54,6 +54,9 @@ VALIDATION_MODULE_ALIASES = {
     "create2": "create2_address",
 }
 
+class OverlayLayoutConflictError(ValueError):
+    """Two closure members with different content map to one overlay path."""
+
 
 @dataclass
 class CompileResult:
@@ -352,8 +355,8 @@ def resolve_import_closure(
 ) -> ImportClosure:
     """Resolve the full transitive closure, including external search-path files.
 
-    Overlay materialization copies only closure members under ``common_root``;
-    external configured-search-path dependencies remain available in place.
+    Default overlay materialization copies only closure members under
+    ``common_root``; closure mode materializes external dependencies too.
     """
     resolved_sources = {path.resolve(): source for path, source in sources.items()}
     if not resolved_sources:
@@ -381,6 +384,8 @@ def target_overlay(
     sources: Mapping[Path, str],
     target_version: str,
     search_paths: tuple[Path, ...] = (),
+    *,
+    include_dependencies: bool = False,
 ) -> Iterator[TargetOverlay | None]:
     resolved_sources = {path.resolve(): source for path, source in sources.items()}
     if not resolved_sources:
@@ -388,7 +393,11 @@ def target_overlay(
         return
     with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
         overlay = materialize_target_overlay(
-            resolved_sources, target_version, Path(tmp), search_paths
+            resolved_sources,
+            target_version,
+            Path(tmp),
+            search_paths,
+            include_dependencies=include_dependencies,
         )
         assert overlay is not None
         yield overlay
@@ -399,40 +408,73 @@ def materialize_target_overlay(
     target_version: str,
     root: Path,
     search_paths: tuple[Path, ...] = (),
+    *,
+    include_dependencies: bool = False,
 ) -> TargetOverlay | None:
     resolved_sources = {path.resolve(): source for path, source in sources.items()}
     if not resolved_sources:
         return None
     roots, import_roots, common = _overlay_roots(resolved_sources, search_paths)
+    destination = _overlay_destination_resolver(
+        common, import_roots, root, include_dependencies
+    )
+    placed: dict[Path, Path] | None = {} if include_dependencies else None
+    members: dict[Path, Path] = {}
     paths: dict[Path, Path] = {}
     overlay_search_paths: set[Path] = set()
     for source_root in roots:
-        overlay_search_paths.update(
-            _copy_validation_sources(
-                source_root,
-                import_roots,
-                common,
-                root,
-                target_version,
-                resolved_sources,
-            )
+        copied_search_paths, copied = _copy_validation_sources(
+            source_root,
+            import_roots,
+            common,
+            root,
+            target_version,
+            resolved_sources,
+            destination,
+            placed,
         )
-    overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
+        overlay_search_paths.update(copied_search_paths)
+        if include_dependencies:
+            members.update(copied)
+    if not include_dependencies:
+        overlay_search_paths.update(
+            _overlay_configured_search_paths(search_paths, common, root)
+        )
     for path, source in resolved_sources.items():
-        try:
-            relative = path.relative_to(common)
-        except ValueError:
+        target = destination(path)
+        if target is None:
             continue
-        target = root / relative
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(source, encoding="utf-8")
+        if placed is None or _claim_overlay_destination(
+            placed, target, path, source
+        ):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(source, encoding="utf-8")
         paths[path] = target
         overlay_search_paths.add(target.parent)
-    _copy_project_configs(common, root)
+        if include_dependencies and path.name == "create2_address.vy":
+            alias = target.with_name("create2.vy")
+            alias_source = _target_validation_create2_alias_source(source)
+            if placed is None or _claim_overlay_destination(
+                placed, alias, path, alias_source
+            ):
+                alias.write_text(alias_source, encoding="utf-8")
+    if include_dependencies:
+        configured_search_paths = tuple(
+            search_path.resolve() for search_path in search_paths
+        )
+        for source_root in roots:
+            if source_root not in configured_search_paths:
+                _copy_project_configs(
+                    source_root,
+                    root,
+                    excluded_roots=configured_search_paths,
+                )
+    else:
+        _copy_project_configs(common, root)
     return TargetOverlay(
         root=root,
-        paths=paths,
-        source_roots=roots,
+        paths={**members, **paths} if include_dependencies else paths,
+        source_roots=import_roots if include_dependencies else roots,
         search_paths=tuple(
             sorted(
                 (path for path in overlay_search_paths if path != root),
@@ -458,6 +500,56 @@ def _overlay_roots(
     )
     common = Path(os.path.commonpath([str(root) for root in roots]))
     return roots, import_roots, common
+
+
+def _closure_import_root(path: Path, import_roots: tuple[Path, ...]) -> Path:
+    containing_roots = tuple(
+        root for root in import_roots if _is_relative_to(path, root)
+    )
+    assert containing_roots, f"closure member is outside import roots: {path}"
+    return max(containing_roots, key=lambda root: len(root.parts))
+
+
+def _overlay_destination_resolver(
+    common_root: Path,
+    import_roots: tuple[Path, ...],
+    target_root: Path,
+    include_dependencies: bool,
+) -> Callable[[Path], Path | None]:
+    if include_dependencies:
+
+        def destination(path: Path) -> Path:
+            import_root = _closure_import_root(path, import_roots)
+            return target_root / path.relative_to(import_root)
+
+        return destination
+
+    def destination(path: Path) -> Path | None:
+        try:
+            return target_root / path.relative_to(common_root)
+        except ValueError:
+            return None
+
+    return destination
+
+
+def _claim_overlay_destination(
+    placed: dict[Path, Path],
+    target: Path,
+    source_path: Path,
+    content: str,
+) -> bool:
+    existing_source = placed.get(target)
+    if existing_source is None:
+        placed[target] = source_path
+        return True
+    if existing_source == source_path:
+        return True
+    if target.read_bytes() == content.encode("utf-8"):
+        return False
+    raise OverlayLayoutConflictError(
+        f"overlay destination {target} maps both {existing_source} and {source_path}"
+    )
 
 def _overlay_configured_search_paths(
     search_paths: tuple[Path, ...], common_root: Path, target_root: Path
@@ -565,62 +657,74 @@ def _copy_validation_sources(
     target_root: Path,
     target_version: str,
     overrides: Mapping[Path, str],
-) -> set[Path]:
+    destination: Callable[[Path], Path | None],
+    placed: dict[Path, Path] | None,
+) -> tuple[set[Path], dict[Path, Path]]:
     search_paths: set[Path] = set()
+    copied: dict[Path, Path] = {}
     for resolved, source in _walk_validation_sources(
         source_root, import_roots, common_root, overrides
     ):
+        target = destination(resolved)
+        if target is None:
+            continue
         _copy_validation_source(
             resolved,
             source,
+            target,
             common_root,
-            target_root,
             target_version,
             search_paths,
+            placed,
         )
-    return search_paths
+        if resolved.suffix in VALIDATION_SOURCE_SUFFIXES:
+            copied[resolved] = target
+    return search_paths, copied
 
 
 def _copy_validation_source(
     source_path: Path,
     source: str,
+    target: Path,
     common_root: Path,
-    target_root: Path,
     target_version: str,
     search_paths: set[Path],
+    placed: dict[Path, Path] | None,
 ) -> None:
     if source_path.suffix not in VALIDATION_SOURCE_SUFFIXES:
         return
-    try:
-        relative = source_path.relative_to(common_root)
-    except ValueError:
-        return
-    target = target_root / relative
     target.parent.mkdir(parents=True, exist_ok=True)
     if source_path.suffix == ".json":
-        target.write_text(source, encoding="utf-8")
+        if placed is None or _claim_overlay_destination(
+            placed, target, source_path, source
+        ):
+            target.write_text(source, encoding="utf-8")
         search_paths.add(target.parent)
         return
-    source = _standard_json_package_dependency_source(source_path, source, common_root)
-    target.write_text(
-        _target_validation_source(
-            source,
-            target_version,
-            is_interface=source_path.suffix == ".vyi",
-        ),
-        encoding="utf-8",
+    source = _standard_json_package_dependency_source(
+        source_path, source, common_root
     )
+    content = _target_validation_source(
+        source,
+        target_version,
+        is_interface=source_path.suffix == ".vyi",
+    )
+    if placed is None or _claim_overlay_destination(
+        placed, target, source_path, content
+    ):
+        target.write_text(content, encoding="utf-8")
     search_paths.add(target.parent)
     if source_path.name == "create2_address.vy":
         alias = target.with_name("create2.vy")
-        alias.write_text(
-            _target_validation_source(
-                _target_validation_create2_alias_source(source),
-                target_version,
-                is_interface=False,
-            ),
-            encoding="utf-8",
+        alias_content = _target_validation_source(
+            _target_validation_create2_alias_source(source),
+            target_version,
+            is_interface=False,
         )
+        if placed is None or _claim_overlay_destination(
+            placed, alias, source_path, alias_content
+        ):
+            alias.write_text(alias_content, encoding="utf-8")
 
 
 def _standard_json_package_dependency_source(source_path: Path, source: str, common_root: Path) -> str:
@@ -758,16 +862,49 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
     return tuple(candidate.with_suffix(suffix) for candidate in paths for suffix in sorted(VALIDATION_SOURCE_SUFFIXES))
 
 
-def _copy_project_configs(source_root: Path, target_root: Path) -> None:
+def _project_config_paths(
+    source_root: Path,
+    excluded_roots: tuple[Path, ...],
+) -> Iterator[Path]:
+    if not excluded_roots:
+        yield from source_root.rglob("pyproject.toml")
+        return
+    for directory, directories, files in os.walk(source_root):
+        current = Path(directory)
+        directories[:] = [
+            name
+            for name in directories
+            if not any(
+                _is_relative_to((current / name).resolve(), excluded_root)
+                for excluded_root in excluded_roots
+            )
+        ]
+        if "pyproject.toml" in files:
+            yield current / "pyproject.toml"
+
+
+def _copy_project_configs(
+    source_root: Path,
+    target_root: Path,
+    *,
+    excluded_roots: tuple[Path, ...] = (),
+) -> None:
     resolved_target = target_root.resolve()
-    for pyproject in list(source_root.rglob("pyproject.toml")):
+    for pyproject in _project_config_paths(source_root, excluded_roots):
         resolved_pyproject = pyproject.resolve()
         if (
             resolved_pyproject == resolved_target
             or resolved_target in resolved_pyproject.parents
+            or any(
+                _is_relative_to(resolved_pyproject, excluded_root)
+                for excluded_root in excluded_roots
+            )
         ):
             continue
-        if any(part in {".git", ".venv", "venv", "node_modules"} for part in pyproject.parts):
+        if any(
+            part in {".git", ".venv", "venv", "node_modules"}
+            for part in pyproject.parts
+        ):
             continue
         try:
             relative = pyproject.relative_to(source_root)

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -206,7 +206,7 @@ def validate_migrations(
 ) -> ValidationDecision:
     """Validate one coherent candidate overlay and return its typed decision."""
     resolve_candidate = candidate_source or _unchanged_candidate
-    target_sources = _candidate_sources(batch, resolve_candidate)
+    target_sources = candidate_sources(batch, resolve_candidate)
 
     with target_overlay(
         target_sources, config.target_version, config.compiler_search_paths
@@ -296,7 +296,7 @@ def _unchanged_candidate(_path: Path, source: str) -> str:
     return source
 
 
-def _candidate_sources(
+def candidate_sources(
     batch: MigrationBatch, resolve_candidate: CandidateSource
 ) -> dict[Path, str]:
     candidates = [

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1226,6 +1226,36 @@ def test_closure_overlay_places_external_candidate_bytes(tmp_path) -> None:
     assert overlay.paths[dependency.resolve()] == target
 
 
+def test_closure_overlay_preserves_root_that_resolved_nested_dependency(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "main.vy"
+    nested_search_path = project / "contracts"
+    dependency = nested_search_path / "dep.vy"
+    dependency.parent.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\nname='project'\n")
+    source = "#pragma version 0.4.3\nfrom contracts import dep\n"
+    dependency_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    contract.write_text(source)
+    dependency.write_text(dependency_source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {contract: source},
+        "0.4.3",
+        root,
+        (project, nested_search_path),
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "contracts" / "dep.vy"
+    assert overlay.paths[dependency.resolve()] == target
+    assert target.read_text() == dependency_source
+    assert not (root / "dep.vy").exists()
+
+
 def test_closure_overlay_paths_equal_resolved_closure(tmp_path) -> None:
     _contract, _dependency, sources, search_paths = _write_external_import_fixture(
         tmp_path

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1256,6 +1256,36 @@ def test_closure_overlay_preserves_root_that_resolved_nested_dependency(
     assert not (root / "dep.vy").exists()
 
 
+def test_closure_overlay_preserves_symlinked_import_path(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "main.vy"
+    search_path = tmp_path / "site-packages"
+    dependency = search_path / "depkg" / "mod.vy"
+    dependency.parent.mkdir(parents=True)
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[project]\nname='project'\n")
+    (project / "alias").symlink_to(dependency.parent, target_is_directory=True)
+    source = "#pragma version 0.4.3\nfrom alias import mod\n"
+    dependency_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    contract.write_text(source)
+    dependency.write_text(dependency_source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {contract: source},
+        "0.4.3",
+        root,
+        (search_path,),
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "alias" / "mod.vy"
+    assert overlay.paths[dependency.resolve()] == target
+    assert target.read_text() == dependency_source
+    assert not (root / "depkg" / "mod.vy").exists()
+
+
 def test_closure_overlay_paths_equal_resolved_closure(tmp_path) -> None:
     _contract, _dependency, sources, search_paths = _write_external_import_fixture(
         tmp_path

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -7,7 +7,9 @@ import pytest
 
 from vyupgrade.compiler import (
     CompileResult,
+    OverlayLayoutConflictError,
     _compiler_command,
+    _overlay_search_paths,
     _run_compile,
     _supports_warning_policy,
     _target_validation_source,
@@ -916,6 +918,67 @@ def _write_import_closure_fixture(
     )
 
 
+def _write_external_import_fixture(
+    tmp_path: Path,
+) -> tuple[Path, Path, dict[Path, str], tuple[Path, ...]]:
+    project = tmp_path / "project"
+    contract = project / "src" / "main.vy"
+    local_dependency = project / "src" / "local.vy"
+    site_packages = tmp_path / "site-packages"
+    external_dependency = site_packages / "depkg" / "util.vy"
+    contract.parent.mkdir(parents=True)
+    external_dependency.parent.mkdir(parents=True)
+    source = (
+        "#pragma version 0.4.3\n"
+        "from . import local\n"
+        "from depkg import util\n"
+    )
+    contract.write_text(source, encoding="utf-8")
+    local_dependency.write_text(
+        "# @version 0.3.10\nLOCAL: constant(uint256) = 1\n",
+        encoding="utf-8",
+    )
+    external_dependency.write_text(
+        "# @version 0.3.10\nEXTERNAL: constant(uint256) = 2\n",
+        encoding="utf-8",
+    )
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "overlay-project"\n',
+        encoding="utf-8",
+    )
+    return contract, external_dependency, {contract: source}, (site_packages,)
+
+
+def _write_create2_collision_fixture(
+    tmp_path: Path,
+    create2_source: str | None,
+) -> tuple[Path, Path, dict[Path, str]]:
+    project = tmp_path / "project"
+    contract = project / "factory.vy"
+    utils = project / "snekmate" / "utils"
+    create2_address = utils / "create2_address.vy"
+    create2 = utils / "create2.vy"
+    utils.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\nname='create2'\n")
+    contract_source = (
+        "#pragma version 0.4.3\n"
+        "from snekmate.utils import create2_address, create2\n"
+    )
+    create2_address_source = (
+        "# @version 0.3.10\n"
+        "def _compute_address(value: uint256) -> address:\n"
+        "    return empty(address)\n"
+    )
+    if create2_source is None:
+        create2_source = create2_address_source.replace(
+            "_compute_address", "_compute_create2_address"
+        )
+    contract.write_text(contract_source)
+    create2_address.write_text(create2_address_source)
+    create2.write_text(create2_source)
+    return create2_address, create2, {contract: contract_source}
+
+
 def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
     contract, sources, search_paths, expected_dependencies = (
         _write_import_closure_fixture(tmp_path)
@@ -1082,6 +1145,418 @@ def test_materialize_target_overlay_empty_sources_returns_none(tmp_path) -> None
     root = tmp_path / "materialized"
 
     assert materialize_target_overlay({}, "0.4.3", root) is None
+
+
+def test_closure_overlay_places_external_dep_import_root_relative(
+    tmp_path,
+) -> None:
+    contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "depkg" / "util.vy"
+    assert target.read_text(encoding="utf-8") == _target_validation_source(
+        dependency.read_text(encoding="utf-8"), "0.4.3"
+    )
+    assert overlay.paths[dependency.resolve()] == target
+    assert overlay.source_roots == (
+        contract.parents[1].resolve(),
+        search_paths[0].resolve(),
+    )
+
+
+def test_closure_overlay_places_external_candidate_bytes(tmp_path) -> None:
+    _contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    candidate = (
+        "#pragma version 0.4.3\n"
+        "EXTERNAL: constant(uint256) = 99\n"
+        "# candidate bytes stay exact\n"
+    )
+    sources[dependency] = candidate
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "depkg" / "util.vy"
+    assert target.read_bytes() == candidate.encode()
+    assert overlay.paths[dependency.resolve()] == target
+
+
+def test_closure_overlay_paths_equal_resolved_closure(tmp_path) -> None:
+    _contract, _dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    closure = resolve_import_closure(sources, search_paths)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert set(overlay.paths) == set(closure.files)
+    assert (root / "pyproject.toml").is_file()
+    assert root / "pyproject.toml" not in overlay.paths.values()
+
+
+def test_closure_overlay_multi_root_placement(tmp_path) -> None:
+    first_root = tmp_path / "repo" / "a"
+    second_root = tmp_path / "repo" / "b"
+    first = first_root / "x.vy"
+    second = second_root / "y.vy"
+    first_root.mkdir(parents=True)
+    second_root.mkdir(parents=True)
+    (first_root / "pyproject.toml").write_text("[project]\nname='a'\n")
+    (second_root / "pyproject.toml").write_text("[project]\nname='b'\n")
+    first_source = "#pragma version 0.4.3\nX: constant(uint256) = 1\n"
+    second_source = "#pragma version 0.4.3\nY: constant(uint256) = 2\n"
+    first.write_text(first_source)
+    second.write_text(second_source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {first: first_source, second: second_source},
+        "0.4.3",
+        root,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert (root / "x.vy").read_text() == first_source
+    assert (root / "y.vy").read_text() == second_source
+    assert not (root / "a" / "x.vy").exists()
+    assert not (root / "b" / "y.vy").exists()
+    assert overlay.source_roots == (first_root.resolve(), second_root.resolve())
+
+
+def test_closure_overlay_conflicting_destinations_raise(tmp_path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = first_root / "pkg" / "util.vy"
+    second = second_root / "pkg" / "util.vy"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    (first_root / "pyproject.toml").write_text("[project]\nname='first'\n")
+    (second_root / "pyproject.toml").write_text("[project]\nname='second'\n")
+    first_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    second_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 2\n"
+    first.write_text(first_source)
+    second.write_text(second_source)
+    target = tmp_path / "overlay" / "pkg" / "util.vy"
+
+    with pytest.raises(OverlayLayoutConflictError) as exc_info:
+        materialize_target_overlay(
+            {first: first_source, second: second_source},
+            "0.4.3",
+            tmp_path / "overlay",
+            include_dependencies=True,
+        )
+
+    message = str(exc_info.value)
+    assert str(first.resolve()) in message
+    assert str(second.resolve()) in message
+    assert str(target) in message
+
+
+def test_closure_overlay_identical_content_collisions_dedupe(tmp_path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = first_root / "pkg" / "util.vy"
+    second = second_root / "pkg" / "util.vy"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    (first_root / "pyproject.toml").write_text("[project]\nname='first'\n")
+    (second_root / "pyproject.toml").write_text("[project]\nname='second'\n")
+    source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    first.write_text(source)
+    second.write_text(source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {first: source, second: source},
+        "0.4.3",
+        root,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "pkg" / "util.vy"
+    assert target.read_text() == source
+    assert overlay.paths[first.resolve()] == target
+    assert overlay.paths[second.resolve()] == target
+    assert list((root / "pkg").glob("util.vy")) == [target]
+
+
+def test_closure_overlay_drops_external_search_paths_from_compile_paths(
+    tmp_path,
+) -> None:
+    _contract, _dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+
+    with target_overlay(
+        sources,
+        "0.4.3",
+        search_paths,
+        include_dependencies=True,
+    ) as closure_overlay:
+        assert closure_overlay is not None
+        closure_paths = _overlay_search_paths(closure_overlay, search_paths)
+    with target_overlay(sources, "0.4.3", search_paths) as default_overlay:
+        assert default_overlay is not None
+        default_paths = _overlay_search_paths(default_overlay, search_paths)
+
+    assert search_paths[0] not in closure_paths
+    assert search_paths[0] in default_paths
+
+
+def test_closure_overlay_create2_alias_beside_override(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "factory.vy"
+    create2_address = project / "snekmate" / "utils" / "create2_address.vy"
+    create2_address.parent.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\nname='create2'\n")
+    contract_source = (
+        "#pragma version 0.4.3\nfrom snekmate.utils import create2\n"
+    )
+    candidate = (
+        "#pragma version 0.4.3\n"
+        "def _compute_address(value: uint256) -> address:\n"
+        "    return empty(address)\n"
+    )
+    contract.write_text(contract_source)
+    create2_address.write_text(candidate)
+    sources = {contract: contract_source, create2_address: candidate}
+
+    closure_root = tmp_path / "closure"
+    closure = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        closure_root,
+        include_dependencies=True,
+    )
+    default_root = tmp_path / "default"
+    default = materialize_target_overlay(sources, "0.4.3", default_root)
+
+    assert closure is not None
+    assert default is not None
+    alias = closure_root / "snekmate" / "utils" / "create2.vy"
+    assert (
+        alias.read_text()
+        == candidate.replace("_compute_address", "_compute_create2_address")
+    )
+    assert (
+        closure_root / "snekmate" / "utils" / "create2_address.vy"
+    ).read_text() == candidate
+    assert alias not in closure.paths.values()
+    assert not (default_root / "snekmate" / "utils" / "create2.vy").exists()
+
+
+def test_default_overlay_create2_alias_collision_preserves_last_write(
+    tmp_path,
+) -> None:
+    create2_source = (
+        "# @version 0.3.10\n"
+        "REAL_CREATE2: constant(uint256) = 2\n"
+    )
+    _create2_address, _create2, sources = _write_create2_collision_fixture(
+        tmp_path, create2_source
+    )
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(sources, "0.4.3", root)
+
+    assert overlay is not None
+    assert (root / "snekmate" / "utils" / "create2.vy").read_text() == (
+        _target_validation_source(create2_source, "0.4.3")
+    )
+
+
+def test_closure_overlay_create2_alias_collision_raises(tmp_path) -> None:
+    create2_source = (
+        "# @version 0.3.10\n"
+        "REAL_CREATE2: constant(uint256) = 2\n"
+    )
+    create2_address, create2, sources = _write_create2_collision_fixture(
+        tmp_path, create2_source
+    )
+
+    with pytest.raises(OverlayLayoutConflictError) as exc_info:
+        materialize_target_overlay(
+            sources,
+            "0.4.3",
+            tmp_path / "overlay",
+            include_dependencies=True,
+        )
+
+    message = str(exc_info.value)
+    assert str(create2_address.resolve()) in message
+    assert str(create2.resolve()) in message
+
+
+def test_closure_overlay_create2_alias_identical_content_dedupes(
+    tmp_path,
+) -> None:
+    _create2_address, create2, sources = _write_create2_collision_fixture(
+        tmp_path, None
+    )
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "snekmate" / "utils" / "create2.vy"
+    assert target.read_text() == _target_validation_source(
+        create2.read_text(), "0.4.3"
+    )
+    assert overlay.paths[create2.resolve()] == target
+
+
+def test_closure_overlay_copies_project_pyproject_only(tmp_path) -> None:
+    _contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    project_pyproject = tmp_path / "project" / "pyproject.toml"
+    site_pyproject = search_paths[0] / "pyproject.toml"
+    site_pyproject.write_text("[project]\nname='site-packages'\n")
+    sources[dependency] = dependency.read_text()
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert (root / "pyproject.toml").read_bytes() == project_pyproject.read_bytes()
+    assert site_pyproject.read_bytes() not in {
+        path.read_bytes()
+        for path in root.rglob("pyproject.toml")
+    }
+
+
+def test_closure_overlay_excludes_nested_search_path_pyprojects(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "main.vy"
+    search_path = project / "vendor" / "site-packages"
+    dependency = search_path / "depkg" / "util.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    project_pyproject = project / "pyproject.toml"
+    dependency_pyproject = dependency.parent / "pyproject.toml"
+    project_pyproject.write_text("[project]\nname='project'\n")
+    dependency_pyproject.write_text("[project]\nname='dependency'\n")
+    source = "#pragma version 0.4.3\nfrom depkg import util\n"
+    contract.write_text(source)
+    dependency.write_text("# @version 0.3.10\n")
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {contract: source},
+        "0.4.3",
+        root,
+        (search_path,),
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert (root / "pyproject.toml").read_bytes() == project_pyproject.read_bytes()
+    assert overlay.paths[dependency.resolve()] == root / "depkg" / "util.vy"
+    assert not (
+        root
+        / "vendor"
+        / "site-packages"
+        / "depkg"
+        / "pyproject.toml"
+    ).exists()
+    assert dependency_pyproject.read_bytes() not in {
+        path.read_bytes()
+        for path in root.rglob("pyproject.toml")
+    }
+
+
+def test_materialize_default_mode_ignores_external_deps(tmp_path) -> None:
+    contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    project = contract.parents[1]
+    local_dependency = contract.with_name("local.vy")
+    implicit_root = tmp_path / "implicit"
+    explicit_root = tmp_path / "explicit"
+
+    implicit = materialize_target_overlay(
+        sources, "0.4.3", implicit_root, search_paths
+    )
+    explicit = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        explicit_root,
+        search_paths,
+        include_dependencies=False,
+    )
+
+    assert implicit is not None
+    assert explicit is not None
+
+    def tree(root: Path) -> dict[Path, bytes]:
+        return {
+            path.relative_to(root): path.read_bytes()
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+
+    expected_tree = {
+        Path("pyproject.toml"): (project / "pyproject.toml").read_bytes(),
+        Path("src/local.vy"): _target_validation_source(
+            local_dependency.read_text(), "0.4.3"
+        ).encode(),
+        Path("src/main.vy"): sources[contract].encode(),
+    }
+    assert tree(implicit_root) == expected_tree
+    assert tree(explicit_root) == expected_tree
+    assert dependency.resolve() not in implicit.paths
+    assert {
+        path: target.relative_to(implicit_root)
+        for path, target in implicit.paths.items()
+    } == {contract.resolve(): Path("src/main.vy")}
+    assert {
+        path: target.relative_to(explicit_root)
+        for path, target in explicit.paths.items()
+    } == {contract.resolve(): Path("src/main.vy")}
+    assert implicit.source_roots == explicit.source_roots == (project.resolve(),)
 
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -17,6 +17,8 @@ from vyupgrade.compiler import (
     compile_source_ast,
     compile_source_file,
     compile_target_source,
+    materialize_target_overlay,
+    resolve_import_closure,
     target_overlay,
     unavailable_validation_artifacts,
 )
@@ -880,6 +882,207 @@ def test_compile_target_source_uses_source_dir_for_relative_imports(monkeypatch,
 
     assert result.status == "passed"
     assert calls["target_parent"] == contract.parent
+
+def _write_import_closure_fixture(
+    tmp_path: Path,
+) -> tuple[Path, dict[Path, str], tuple[Path, ...], tuple[Path, ...]]:
+    project = tmp_path / "project"
+    contract = project / "src" / "a.vy"
+    dependency = project / "src" / "b.vy"
+    transitive = project / "src" / "lib" / "c.vy"
+    interface = project / "src" / "interfaces" / "IThing.json"
+    contract.parent.mkdir(parents=True)
+    transitive.parent.mkdir(parents=True)
+    interface.parent.mkdir(parents=True)
+    source = "#pragma version 0.4.3\nfrom . import b\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text(
+        "# @version 0.4.0\n"
+        "from .lib import c\n"
+        "from .interfaces import IThing\n",
+        encoding="utf-8",
+    )
+    transitive.write_text("# @version 0.4.0\nVALUE: constant(uint256) = 1\n", encoding="utf-8")
+    interface.write_text("[]\n", encoding="utf-8")
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "closure-fixture"\n',
+        encoding="utf-8",
+    )
+    return (
+        contract,
+        {contract: source},
+        (project,),
+        tuple(sorted((dependency.resolve(), transitive.resolve(), interface.resolve()))),
+    )
+
+
+def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
+    contract, sources, search_paths, expected_dependencies = (
+        _write_import_closure_fixture(tmp_path)
+    )
+
+    closure = resolve_import_closure(sources, search_paths)
+
+    assert closure.roots == (contract.resolve(),)
+    assert closure.dependencies == expected_dependencies
+    assert closure.files == (contract.resolve(), *expected_dependencies)
+    assert closure.source_roots == (tmp_path / "project",)
+    assert closure.common_root == tmp_path / "project"
+
+
+def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    closure = resolve_import_closure(sources, search_paths)
+
+    with target_overlay(sources, "0.4.3", search_paths) as overlay:
+        assert overlay is not None
+        copied_files = {
+            path.relative_to(overlay.root)
+            for path in overlay.root.rglob("*")
+            if path.is_file()
+        }
+
+    override_files = {
+        path.resolve().relative_to(closure.common_root) for path in sources
+    }
+    config_files = {
+        path.relative_to(closure.common_root)
+        for path in closure.common_root.rglob("pyproject.toml")
+    }
+    create2_aliases = {
+        path
+        for path in copied_files
+        if path.name == "create2.vy"
+        and path.with_name("create2_address.vy") in copied_files
+    }
+    dependency_copies = copied_files - override_files - config_files - create2_aliases
+
+    assert dependency_copies == {
+        path.relative_to(closure.common_root) for path in closure.dependencies
+    }
+
+
+def test_resolve_import_closure_search_path_dependency(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "main.vy"
+    site_packages = tmp_path / "site-packages"
+    dependency = site_packages / "pkg" / "dep.vy"
+    escaped = tmp_path / "outside" / "escape.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    escaped.parent.mkdir(parents=True)
+    source = (
+        "#pragma version 0.4.3\n"
+        "from pkg import dep\n"
+        "from ...outside import escape\n"
+    )
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.4.0\n", encoding="utf-8")
+    escaped.write_text("# @version 0.4.0\n", encoding="utf-8")
+
+    closure = resolve_import_closure(
+        {contract: source},
+        (site_packages, project),
+    )
+
+    assert closure.dependencies == (dependency.resolve(),)
+    assert escaped.resolve() not in closure.files
+    with pytest.raises(ValueError):
+        dependency.resolve().relative_to(closure.common_root)
+    with target_overlay({contract: source}, "0.4.3", (site_packages, project)) as overlay:
+        assert overlay is not None
+        assert not any(
+            path.name == "dep.vy"
+            for path in overlay.root.rglob("*")
+            if path.is_file()
+        )
+
+
+def test_resolve_import_closure_create2_alias_resolves_to_real_file(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "factory.vy"
+    dependency = project / "snekmate" / "utils" / "create2_address.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    source = "#pragma version 0.4.3\nfrom snekmate.utils import create2\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.4.0\n", encoding="utf-8")
+
+    closure = resolve_import_closure({contract: source}, (project,))
+
+    assert closure.dependencies == (dependency.resolve(),)
+    assert all(path.name != "create2.vy" for path in closure.files)
+
+
+def test_resolve_import_closure_is_idempotent(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+
+    first = resolve_import_closure(sources, search_paths)
+    second = resolve_import_closure(sources, search_paths)
+
+    assert first == second
+
+
+def test_resolve_import_closure_empty_sources_raises() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^resolve_import_closure requires at least one source$",
+    ):
+        resolve_import_closure({})
+
+
+def test_materialize_target_overlay_writes_into_given_root(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    with target_overlay(sources, "0.4.3", search_paths) as temporary:
+        assert temporary is not None
+        expected_files = {
+            path.relative_to(temporary.root): path.read_bytes()
+            for path in temporary.root.rglob("*")
+            if path.is_file()
+        }
+
+    root = tmp_path / "materialized"
+    root.mkdir()
+    overlay = materialize_target_overlay(sources, "0.4.3", root, search_paths)
+
+    assert overlay is not None
+    assert overlay.root == root
+    assert all(path.is_relative_to(root) for path in overlay.paths.values())
+    assert {
+        path.relative_to(root): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    } == expected_files
+    assert root.exists()
+
+
+def test_materialize_target_overlay_output_root_under_project_root(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    project = tmp_path / "project"
+    root = project / "overlay-output"
+
+    overlay = materialize_target_overlay(sources, "0.4.3", root, search_paths)
+
+    assert overlay is not None
+    assert list(root.rglob("pyproject.toml")) == [root / "pyproject.toml"]
+    assert (root / "pyproject.toml").read_bytes() == (
+        project / "pyproject.toml"
+    ).read_bytes()
+
+
+def test_materialize_target_overlay_empty_sources_returns_none(tmp_path) -> None:
+    root = tmp_path / "materialized"
+
+    assert materialize_target_overlay({}, "0.4.3", root) is None
+
 
 
 def test_target_overlay_rewrites_imported_vyper_pragmas(monkeypatch, tmp_path) -> None:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -930,6 +930,31 @@ def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
     assert closure.common_root == tmp_path / "project"
 
 
+@pytest.mark.parametrize(
+    "documentation",
+    [
+        '"""\nimport ghost\n"""\n',
+        'EXAMPLE: constant(String[32]) = """\nimport ghost\n"""\n',
+    ],
+)
+def test_resolve_import_closure_ignores_imports_in_strings(
+    tmp_path: Path, documentation: str
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "main.vy"
+    dependency = project / "real.vy"
+    ghost = project / "ghost.vy"
+    project.mkdir()
+    source = f"# @version 0.3.10\n{documentation}from . import real\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.3.10\n", encoding="utf-8")
+    ghost.write_text("not valid Vyper\n", encoding="utf-8")
+
+    closure = resolve_import_closure({contract: source}, (project,))
+
+    assert closure.dependencies == (dependency.resolve(),)
+
+
 def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> None:
     _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
         tmp_path


### PR DESCRIPTION
_co-authored by claude opus 4.8_

This adds an opt-in closure mode to compiler overlay materialization. In that mode, the full resolved import closure is copied import-root-relative, overlay paths cover every closure member, and compilation resolves strictly against the materialized tree. Identical destination contents are deduplicated while ambiguous layouts raise `OverlayLayoutConflictError`; the default overlay path remains unchanged.

**Stacked on:** `issue-23-closure-primitive`. This is part of the stacked series implementing issue #23.

**Tests:** Compiler overlay unit tests and the full test suite are green.
