### PR TITLE
feat(cli): --include-dependencies upgrades and validates the import closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added a public import-closure primitive (resolve_import_closure) and a reusable overlay materializer, single-sourcing the validation dependency traversal.
 - Added opt-in closure-mode overlay materialization: the full import closure (including external search-path dependencies) can be materialized import-root-relative for dependency-closure upgrades.
+- Added opt-in `--include-dependencies` closure upgrading: the full import closure (including installed search-path dependencies) is rewritten and cross-validated in a closure-mode target overlay; JSON schema v2 adds file roles and a closure block; in-place dependency writes are structurally impossible.
 
 ## 0.5.1 - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added a public import-closure primitive (resolve_import_closure) and a reusable overlay materializer, single-sourcing the validation dependency traversal.
+- Added opt-in closure-mode overlay materialization: the full import closure (including external search-path dependencies) can be materialized import-root-relative for dependency-closure upgrades.
 
 ## 0.5.1 - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added a public import-closure primitive (resolve_import_closure) and a reusable overlay materializer, single-sourcing the validation dependency traversal.
+
 ## 0.5.1 - 2026-07-10
 
 - Extracted fail-closed storage-layout parsing, canonicalization, AST evidence,

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Poetry caret requirements, are skipped; use `--compiler-search-paths`,
 - `--write` — apply changes in place only after the validation decision passes.
 - `--check` — exit non-zero if any file would change; write nothing.
 - `--aggressive` — enable rewrites that change behavior or are not provably safe (e.g. `enum` → `flag`).
+- `--include-dependencies` (alias `--upgrade-closure`) — also upgrade and cross-validate the resolved import closure, including dependencies found via `--compiler-search-paths`; dependency sources are never rewritten in place, so `--write` additionally requires a closure destination.
 - `--split-interfaces` — move top-level `interface` blocks into sibling `.vyi` files and import them.
 - `--select` / `--ignore` — comma-separated rule codes to include or exclude.
 - `--report-json PATH` — write a JSON report of fixes, diagnostics, and validation results.
@@ -127,11 +128,11 @@ Poetry caret requirements, are skipped; use `--compiler-search-paths`,
 - `--allow-storage-layout-change` — write despite a storage-layout comparison mismatch.
 - `--config PATH` — read configuration from a specific `pyproject.toml`.
 
-JSON reports include a top-level `schema_version`. Version `1` preserves the
-existing report envelope and field paths; new fields may be added compatibly.
-Consumers should treat a missing version as the legacy unversioned format and
-require a new schema version before relying on renamed, removed, or
-type-changed fields.
+JSON reports include a top-level `schema_version`. Version `2` adds a per-file
+`role` and a top-level `closure` object; version `1` consumers must not assume
+their absence. Consumers should treat a missing version as the legacy
+unversioned format and require a new schema version before relying on renamed,
+removed, or type-changed fields.
 
 ### Configuration
 

--- a/src/vyupgrade/cli.py
+++ b/src/vyupgrade/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import os
+from dataclasses import replace
 import shlex
 import subprocess
 import sys
@@ -10,8 +12,8 @@ import tomllib
 from pathlib import Path
 from typing import TextIO
 
-from . import engine
-from .models import Config, FileReport, RunReport
+from . import compiler, engine
+from .models import ClosureReport, Config, FileReport, RunReport, ValidationDecision
 from .project import discover_files
 from .reporting import HumanReporter, write_json_report
 from .validation import decide_run_validation, validation_exit_code
@@ -40,6 +42,8 @@ def main(argv: list[str] | None = None) -> int:
         select=_split_rules(args.select),
         ignore=_split_rules(args.ignore),
         aggressive=args.aggressive or bool(pyproject.get("aggressive", False)),
+        include_dependencies=args.include_dependencies
+        or bool(pyproject.get("include-dependencies", False)),
         test_command=args.test_command,
         source_vyper=args.source_vyper,
         target_vyper=args.target_vyper,
@@ -65,6 +69,12 @@ def main(argv: list[str] | None = None) -> int:
     if config.write and config.check:
         print("--write and --check are mutually exclusive", file=sys.stderr)
         return 4
+    if config.write and config.include_dependencies:
+        print(
+            "--write with --include-dependencies requires a closure destination",
+            file=sys.stderr,
+        )
+        return 4
 
     files = discover_files(config.paths)
     human_reporter = None if config.diff else HumanReporter(sys.stdout)
@@ -77,12 +87,23 @@ def main(argv: list[str] | None = None) -> int:
         )
         for path in files
     ]
+    closure_report = (
+        ClosureReport(requested=True) if config.include_dependencies else None
+    )
+    if closure_report is not None and requests:
+        dependency_requests, closure = _dependency_requests(requests, config)
+        requests += dependency_requests
+        closure_report.dependencies = tuple(
+            str(path) for path in sorted(closure.dependencies)
+        )
     batch = engine.prepare_migrations(requests, config)
     reports, plan, plan_error = _build_migration_plan(batch)
     if plan_error is None:
-        validation_decision = engine.validate_migrations(
+        validation_decision = _validate_or_layout_conflict(
             batch, config, plan.candidate_source
         )
+        if validation_decision is None:
+            return 4
     else:
         validation_decision = decide_run_validation((), config)
 
@@ -93,6 +114,7 @@ def main(argv: list[str] | None = None) -> int:
         write_requested=config.write,
         validation_decision=validation_decision,
         test_command=config.test_command,
+        closure=closure_report,
     )
     if plan_error is not None:
         run_report.write_status = "failed"
@@ -102,9 +124,11 @@ def main(argv: list[str] | None = None) -> int:
         if config.format == "mamushi" and plan.writes:
             _run_mamushi(plan, run_report)
             if run_report.formatter_status == "passed":
-                validation_decision = engine.validate_migrations(
+                validation_decision = _validate_or_layout_conflict(
                     batch, config, plan.candidate_source
                 )
+                if validation_decision is None:
+                    return 4
                 run_report.validation_decision = validation_decision
                 if not validation_decision.write_allowed:
                     run_report.write_status = "blocked"
@@ -137,6 +161,8 @@ def main(argv: list[str] | None = None) -> int:
                     )
 
     diff_chunks = plan.diff_chunks()
+    if config.include_dependencies:
+        diff_chunks += _dependency_diff_chunks(batch)
     if config.diff and diff_chunks:
         _write_diff(diff_chunks, sys.stdout)
 
@@ -194,6 +220,9 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--select", default="")
     parser.add_argument("--ignore", default="")
     parser.add_argument("--aggressive", action="store_true")
+    parser.add_argument(
+        "--include-dependencies", "--upgrade-closure", action="store_true"
+    )
     parser.add_argument("--test-command")
     parser.add_argument("--source-vyper")
     parser.add_argument("--target-vyper")
@@ -218,6 +247,8 @@ def _build_migration_plan(
     plan = MigrationPlan()
     try:
         for migration in batch.files:
+            if migration.request.role == "dependency":
+                continue
             plan.add_source(
                 migration.path,
                 migration.original,
@@ -233,6 +264,58 @@ def _build_migration_plan(
     except PlanConflictError as exc:
         return reports, plan, str(exc)
     return reports, plan, None
+
+
+def _dependency_requests(
+    requests: list[engine.MigrationRequest], config: Config
+) -> tuple[list[engine.MigrationRequest], compiler.ImportClosure]:
+    closure = compiler.resolve_import_closure(
+        {request.path: request.original for request in requests},
+        config.compiler_search_paths,
+    )
+    dependency_config = replace(config, source_version=None)
+    dependencies = [
+        engine.bounded_migration_request(
+            path,
+            path.read_text(encoding="utf-8"),
+            dependency_config,
+            role="dependency",
+        )
+        for path in closure.dependencies
+        if path.suffix in {".vy", ".vyi"}
+    ]
+    return dependencies, closure
+
+
+def _dependency_diff_chunks(batch: engine.MigrationBatch) -> list[str]:
+    chunks: list[str] = []
+    for migration in batch.files:
+        if (
+            migration.request.role != "dependency"
+            or migration.original == migration.rewrite.source
+        ):
+            continue
+        chunks.extend(
+            difflib.unified_diff(
+                migration.original.splitlines(keepends=True),
+                migration.rewrite.source.splitlines(keepends=True),
+                fromfile=str(migration.path),
+                tofile=str(migration.path),
+            )
+        )
+    return chunks
+
+
+def _validate_or_layout_conflict(
+    batch: engine.MigrationBatch,
+    config: Config,
+    candidate_source: engine.CandidateSource,
+) -> ValidationDecision | None:
+    try:
+        return engine.validate_migrations(batch, config, candidate_source)
+    except compiler.OverlayLayoutConflictError as exc:
+        print(str(exc), file=sys.stderr)
+        return None
 
 
 def _write_diff(diff_chunks: list[str], stream: TextIO) -> None:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -91,6 +91,7 @@ class ImportClosure:
 class _ResolvedValidationImport:
     path: Path
     root: Path
+    relative_path: Path
 
 
 def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
@@ -495,10 +496,10 @@ def _materialize_closure_sources(
     placed: dict[Path, Path] = {}
     paths: dict[Path, Path] = {}
     search_paths: set[Path] = set()
-    for path, source, import_root, is_override in _walk_validation_closure(
+    for path, source, relative_path, is_override in _walk_validation_closure(
         source_roots, import_roots, common_root, overrides
     ):
-        target = target_root / path.relative_to(import_root)
+        target = target_root / relative_path
         if is_override:
             if _claim_overlay_destination(placed, target, path, source):
                 target.parent.mkdir(parents=True, exist_ok=True)
@@ -643,61 +644,84 @@ def _walk_validation_closure(
             path, source, common_root
         )
         for source_root in _containing_import_roots(path, source_roots):
+            relative_path = path.relative_to(source_root)
             incoming_overrides.update(
                 imported.path
                 for imported in _validation_import_sources(
-                    path, import_source, source_root, import_roots
+                    path,
+                    import_source,
+                    source_root,
+                    import_roots,
+                    relative_path,
                 )
                 if imported.path in override_paths
             )
 
     entry_paths = override_paths - incoming_overrides
-    queue = [
-        (
-            path,
-            overrides[path],
-            _containing_import_roots(path, source_roots)[0],
-            True,
+    queue: list[tuple[Path, str, Path, Path, bool]] = []
+    for path in sorted(entry_paths):
+        source_root = _containing_import_roots(path, source_roots)[0]
+        queue.append(
+            (
+                path,
+                overrides[path],
+                source_root,
+                path.relative_to(source_root),
+                True,
+            )
         )
-        for path in sorted(entry_paths)
-    ]
     layouts: dict[Path, Path] = {}
     processed: set[Path] = set()
     while queue or override_paths - processed:
         if not queue:
             path = min(override_paths - processed)
+            source_root = _containing_import_roots(path, source_roots)[0]
             queue.append(
                 (
                     path,
                     overrides[path],
-                    _containing_import_roots(path, source_roots)[0],
+                    source_root,
+                    path.relative_to(source_root),
                     True,
                 )
             )
-        current, current_source, current_root, is_override = queue.pop(0)
-        existing_root = layouts.get(current)
-        if existing_root is not None and existing_root != current_root:
+        (
+            current,
+            current_source,
+            current_root,
+            current_relative,
+            is_override,
+        ) = queue.pop(0)
+        existing_relative = layouts.get(current)
+        if (
+            existing_relative is not None
+            and existing_relative != current_relative
+        ):
             raise OverlayLayoutConflictError(
-                f"closure member {current} resolves relative to both "
-                f"{existing_root} and {current_root}"
+                f"closure member {current} maps to both "
+                f"{existing_relative} and {current_relative}"
             )
-        layouts[current] = current_root
+        layouts[current] = current_relative
         if current in processed:
             continue
         processed.add(current)
-        yield current, current_source, current_root, is_override
+        yield current, current_source, current_relative, is_override
         import_source = _standard_json_package_dependency_source(
             current, current_source, common_root
         )
         for imported in _validation_import_sources(
-            current, import_source, current_root, import_roots
+            current,
+            import_source,
+            current_root,
+            import_roots,
+            current_relative,
         ):
             if imported.path in processed:
-                existing_root = layouts[imported.path]
-                if existing_root != imported.root:
+                existing_relative = layouts[imported.path]
+                if existing_relative != imported.relative_path:
                     raise OverlayLayoutConflictError(
-                        f"closure member {imported.path} resolves relative to both "
-                        f"{existing_root} and {imported.root}"
+                        f"closure member {imported.path} maps to both "
+                        f"{existing_relative} and {imported.relative_path}"
                     )
                 continue
             source = overrides.get(imported.path)
@@ -707,7 +731,13 @@ def _walk_validation_closure(
                 except (OSError, UnicodeDecodeError):
                     continue
             queue.append(
-                (imported.path, source, imported.root, imported.path in override_paths)
+                (
+                    imported.path,
+                    source,
+                    imported.root,
+                    imported.relative_path,
+                    imported.path in override_paths,
+                )
             )
 
 
@@ -875,7 +905,11 @@ def _local_sibling_import_source(source_path: Path, source: str) -> str:
 
 
 def _validation_import_sources(
-    path: Path, source: str, source_root: Path, import_roots: tuple[Path, ...]
+    path: Path,
+    source: str,
+    source_root: Path,
+    import_roots: tuple[Path, ...],
+    relative_path: Path | None = None,
 ) -> tuple[_ResolvedValidationImport, ...]:
     imports: list[_ResolvedValidationImport] = []
     mask = code_mask(source)
@@ -894,7 +928,12 @@ def _validation_import_sources(
         if import_match:
             imports.extend(
                 _resolve_validation_import(
-                    path, source_root, import_match.group(1), (), import_roots
+                    path,
+                    source_root,
+                    import_match.group(1),
+                    (),
+                    import_roots,
+                    relative_path,
                 )
             )
             continue
@@ -906,7 +945,12 @@ def _validation_import_sources(
             names = tuple(_imported_module_names(from_match.group(2)))
             imports.extend(
                 _resolve_validation_import(
-                    path, source_root, from_match.group(1), names, import_roots
+                    path,
+                    source_root,
+                    from_match.group(1),
+                    names,
+                    import_roots,
+                    relative_path,
                 )
             )
     return tuple(dict.fromkeys(imports))
@@ -928,29 +972,42 @@ def _resolve_validation_import(
     module: str,
     names: tuple[str, ...],
     import_roots: tuple[Path, ...],
+    relative_path: Path | None,
 ) -> tuple[_ResolvedValidationImport, ...]:
-    bases, module_parts = _validation_import_bases(path, source_root, module, import_roots)
-    candidates: list[tuple[Path, Path]] = []
-    for base, import_root in bases:
+    bases, module_parts = _validation_import_bases(
+        path, source_root, module, import_roots, relative_path
+    )
+    candidates: list[tuple[Path, Path, Path]] = []
+    for base, import_root, relative_base in bases:
         module_path = base.joinpath(*module_parts) if module_parts else base
+        relative_module = (
+            relative_base.joinpath(*module_parts)
+            if module_parts
+            else relative_base
+        )
         if names:
             for name in names:
                 candidates.extend(
-                    (candidate, import_root)
-                    for candidate in _validation_module_candidates(module_path / name)
+                    _validation_module_candidate_layouts(
+                        module_path / name,
+                        relative_module / name,
+                        import_root,
+                    )
                 )
             candidates.extend(
-                (candidate, import_root)
-                for candidate in _validation_module_candidates(module_path)
+                _validation_module_candidate_layouts(
+                    module_path, relative_module, import_root
+                )
             )
         else:
             candidates.extend(
-                (candidate, import_root)
-                for candidate in _validation_module_candidates(module_path)
+                _validation_module_candidate_layouts(
+                    module_path, relative_module, import_root
+                )
             )
-    resolved: dict[Path, Path] = {}
+    resolved: dict[Path, tuple[Path, Path]] = {}
     roots = tuple(root.resolve() for root in (source_root, *import_roots))
-    for candidate, import_root in candidates:
+    for candidate, import_root, candidate_relative in candidates:
         try:
             resolved_candidate = candidate.resolve()
             if not any(_is_relative_to(resolved_candidate, root) for root in roots):
@@ -958,33 +1015,45 @@ def _resolve_validation_import(
         except (OSError, ValueError):
             continue
         if resolved_candidate.exists() and resolved_candidate.suffix in VALIDATION_SOURCE_SUFFIXES:
-            resolved.setdefault(resolved_candidate, import_root)
+            resolved.setdefault(
+                resolved_candidate, (import_root, candidate_relative)
+            )
     return tuple(
-        _ResolvedValidationImport(path, import_root)
-        for path, import_root in resolved.items()
+        _ResolvedValidationImport(path, import_root, candidate_relative)
+        for path, (import_root, candidate_relative) in resolved.items()
     )
 
 
 def _validation_import_bases(
-    path: Path, source_root: Path, module: str, import_roots: tuple[Path, ...]
-) -> tuple[tuple[tuple[Path, Path], ...], tuple[str, ...]]:
+    path: Path,
+    source_root: Path,
+    module: str,
+    import_roots: tuple[Path, ...],
+    relative_path: Path | None,
+) -> tuple[tuple[tuple[Path, Path, Path], ...], tuple[str, ...]]:
+    relative_parent = relative_path.parent if relative_path is not None else Path()
     if not module.startswith("."):
         bases = (
-            (path.parent, source_root),
-            (source_root, source_root),
-            *((root, root) for root in import_roots),
+            (path.parent, source_root, relative_parent),
+            (source_root, source_root, Path()),
+            *((root, root, Path()) for root in import_roots),
         )
-        unique_bases: dict[Path, Path] = {}
-        for base, root in bases:
-            unique_bases.setdefault(base, root)
-        return tuple(unique_bases.items()), tuple(
+        unique_bases: dict[Path, tuple[Path, Path]] = {}
+        for base, root, relative_base in bases:
+            unique_bases.setdefault(base, (root, relative_base))
+        return tuple(
+            (base, root, relative_base)
+            for base, (root, relative_base) in unique_bases.items()
+        ), tuple(
             part for part in module.split(".") if part
         )
     level = len(module) - len(module.lstrip("."))
     base = path.parent
+    relative_base = relative_parent
     for _ in range(max(level - 1, 0)):
         base = base.parent
-    return ((base, source_root),), tuple(
+        relative_base = relative_base.parent
+    return ((base, source_root, relative_base),), tuple(
         part for part in module[level:].split(".") if part
     )
 
@@ -1003,6 +1072,21 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
     if alias is not None:
         paths.append(path.with_name(alias))
     return tuple(candidate.with_suffix(suffix) for candidate in paths for suffix in sorted(VALIDATION_SOURCE_SUFFIXES))
+
+
+def _validation_module_candidate_layouts(
+    path: Path, relative_path: Path, import_root: Path
+) -> tuple[tuple[Path, Path, Path], ...]:
+    return tuple(
+        (
+            candidate,
+            import_root,
+            relative_path.with_name(candidate.name)
+            if relative_path.name
+            else Path(candidate.name),
+        )
+        for candidate in _validation_module_candidates(path)
+    )
 
 
 def _project_config_paths(

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -71,6 +71,17 @@ class TargetOverlay:
     source_roots: tuple[Path, ...]
     search_paths: tuple[Path, ...]
 
+@dataclass(frozen=True)
+class ImportClosure:
+    roots: tuple[Path, ...]
+    dependencies: tuple[Path, ...]
+    source_roots: tuple[Path, ...]
+    common_root: Path
+
+    @property
+    def files(self) -> tuple[Path, ...]:
+        return self.roots + self.dependencies
+
 
 def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
     artifacts = result.artifacts or {}
@@ -335,6 +346,36 @@ def _compile_target_interface(
             harness_path.unlink(missing_ok=True)
 
 
+def resolve_import_closure(
+    sources: Mapping[Path, str],
+    search_paths: tuple[Path, ...] = (),
+) -> ImportClosure:
+    """Resolve the full transitive closure, including external search-path files.
+
+    Overlay materialization copies only closure members under ``common_root``;
+    external configured-search-path dependencies remain available in place.
+    """
+    resolved_sources = {path.resolve(): source for path, source in sources.items()}
+    if not resolved_sources:
+        raise ValueError("resolve_import_closure requires at least one source")
+    source_roots, import_roots, common_root = _overlay_roots(
+        resolved_sources, search_paths
+    )
+    dependencies = [
+        path
+        for source_root in source_roots
+        for path, _source in _walk_validation_sources(
+            source_root, import_roots, common_root, resolved_sources
+        )
+    ]
+    return ImportClosure(
+        roots=tuple(sorted(resolved_sources)),
+        dependencies=tuple(sorted(dict.fromkeys(dependencies))),
+        source_roots=source_roots,
+        common_root=common_root,
+    )
+
+
 @contextmanager
 def target_overlay(
     sources: Mapping[Path, str],
@@ -345,6 +386,66 @@ def target_overlay(
     if not resolved_sources:
         yield None
         return
+    with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
+        overlay = materialize_target_overlay(
+            resolved_sources, target_version, Path(tmp), search_paths
+        )
+        assert overlay is not None
+        yield overlay
+
+
+def materialize_target_overlay(
+    sources: Mapping[Path, str],
+    target_version: str,
+    root: Path,
+    search_paths: tuple[Path, ...] = (),
+) -> TargetOverlay | None:
+    resolved_sources = {path.resolve(): source for path, source in sources.items()}
+    if not resolved_sources:
+        return None
+    roots, import_roots, common = _overlay_roots(resolved_sources, search_paths)
+    paths: dict[Path, Path] = {}
+    overlay_search_paths: set[Path] = set()
+    for source_root in roots:
+        overlay_search_paths.update(
+            _copy_validation_sources(
+                source_root,
+                import_roots,
+                common,
+                root,
+                target_version,
+                resolved_sources,
+            )
+        )
+    overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
+    for path, source in resolved_sources.items():
+        try:
+            relative = path.relative_to(common)
+        except ValueError:
+            continue
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+        paths[path] = target
+        overlay_search_paths.add(target.parent)
+    _copy_project_configs(common, root)
+    return TargetOverlay(
+        root=root,
+        paths=paths,
+        source_roots=roots,
+        search_paths=tuple(
+            sorted(
+                (path for path in overlay_search_paths if path != root),
+                key=lambda path: str(path),
+            )
+        ),
+    )
+
+
+def _overlay_roots(
+    resolved_sources: Mapping[Path, str],
+    search_paths: tuple[Path, ...],
+) -> tuple[tuple[Path, ...], tuple[Path, ...], Path]:
     roots = tuple(
         dict.fromkeys(
             root
@@ -356,45 +457,7 @@ def target_overlay(
         dict.fromkeys((*roots, *(search_path.resolve() for search_path in search_paths)))
     )
     common = Path(os.path.commonpath([str(root) for root in roots]))
-    with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
-        root = Path(tmp)
-        paths: dict[Path, Path] = {}
-        overlay_search_paths: set[Path] = set()
-        for source_root in roots:
-            overlay_search_paths.update(
-                _copy_validation_sources(
-                    source_root,
-                    import_roots,
-                    common,
-                    root,
-                    target_version,
-                    resolved_sources,
-                )
-            )
-        overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
-        for path, source in resolved_sources.items():
-            try:
-                relative = path.relative_to(common)
-            except ValueError:
-                continue
-            target = root / relative
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(source, encoding="utf-8")
-            paths[path] = target
-            overlay_search_paths.add(target.parent)
-        _copy_project_configs(common, root)
-        yield TargetOverlay(
-            root=root,
-            paths=paths,
-            source_roots=tuple(roots),
-            search_paths=tuple(
-                sorted(
-                    (path for path in overlay_search_paths if path != root),
-                    key=lambda path: str(path),
-                )
-            ),
-        )
-
+    return roots, import_roots, common
 
 def _overlay_configured_search_paths(
     search_paths: tuple[Path, ...], common_root: Path, target_root: Path
@@ -454,15 +517,12 @@ def _validation_roots(path: Path, search_paths: tuple[Path, ...]) -> tuple[Path,
     return (_nearest_project_root(path.parent) or path.parent,)
 
 
-def _copy_validation_sources(
+def _walk_validation_sources(
     source_root: Path,
     import_roots: tuple[Path, ...],
     common_root: Path,
-    target_root: Path,
-    target_version: str,
     overrides: Mapping[Path, str],
-) -> set[Path]:
-    search_paths: set[Path] = set()
+) -> Iterator[tuple[Path, str]]:
     override_paths = set(overrides)
     queue: list[tuple[Path, str]] = []
     for path, source in overrides.items():
@@ -495,14 +555,29 @@ def _copy_validation_sources(
             queue.append((resolved, source))
             if resolved in override_paths:
                 continue
-            _copy_validation_source(
-                resolved,
-                source,
-                common_root,
-                target_root,
-                target_version,
-                search_paths,
-            )
+            yield resolved, source
+
+
+def _copy_validation_sources(
+    source_root: Path,
+    import_roots: tuple[Path, ...],
+    common_root: Path,
+    target_root: Path,
+    target_version: str,
+    overrides: Mapping[Path, str],
+) -> set[Path]:
+    search_paths: set[Path] = set()
+    for resolved, source in _walk_validation_sources(
+        source_root, import_roots, common_root, overrides
+    ):
+        _copy_validation_source(
+            resolved,
+            source,
+            common_root,
+            target_root,
+            target_version,
+            search_paths,
+        )
     return search_paths
 
 
@@ -684,7 +759,14 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
 
 
 def _copy_project_configs(source_root: Path, target_root: Path) -> None:
-    for pyproject in source_root.rglob("pyproject.toml"):
+    resolved_target = target_root.resolve()
+    for pyproject in list(source_root.rglob("pyproject.toml")):
+        resolved_pyproject = pyproject.resolve()
+        if (
+            resolved_pyproject == resolved_target
+            or resolved_target in resolved_pyproject.parents
+        ):
+            continue
         if any(part in {".git", ".venv", "venv", "node_modules"} for part in pyproject.parts):
             continue
         try:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from uv import find_uv_bin
 
 from .models import Config
+from .source import code_mask
 from .storage_layout import compare_storage_layouts, parse_storage_layout
 from .versions import (
     VyperVersion,
@@ -663,7 +664,12 @@ def _validation_import_sources(
     path: Path, source: str, source_root: Path, import_roots: tuple[Path, ...]
 ) -> tuple[Path, ...]:
     imports: list[Path] = []
-    for line in source.splitlines():
+    mask = code_mask(source)
+    code_source = "".join(
+        char if is_code or char in "\r\n" else " "
+        for char, is_code in zip(source, mask, strict=True)
+    )
+    for line in code_source.splitlines():
         stripped = line.split("#", 1)[0].strip()
         if not stripped:
             continue

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -87,6 +87,12 @@ class ImportClosure:
         return self.roots + self.dependencies
 
 
+@dataclass(frozen=True)
+class _ResolvedValidationImport:
+    path: Path
+    root: Path
+
+
 def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
     artifacts = result.artifacts or {}
     validators: dict[str, Callable[[object], bool]] = {
@@ -367,10 +373,10 @@ def resolve_import_closure(
     )
     dependencies = [
         path
-        for source_root in source_roots
-        for path, _source in _walk_validation_sources(
-            source_root, import_roots, common_root, resolved_sources
+        for path, _source, _import_root, is_override in _walk_validation_closure(
+            source_roots, import_roots, common_root, resolved_sources
         )
+        if not is_override
     ]
     return ImportClosure(
         roots=tuple(sorted(resolved_sources)),
@@ -416,49 +422,42 @@ def materialize_target_overlay(
     if not resolved_sources:
         return None
     roots, import_roots, common = _overlay_roots(resolved_sources, search_paths)
-    destination = _overlay_destination_resolver(
-        common, import_roots, root, include_dependencies
-    )
-    placed: dict[Path, Path] | None = {} if include_dependencies else None
-    members: dict[Path, Path] = {}
-    paths: dict[Path, Path] = {}
-    overlay_search_paths: set[Path] = set()
-    for source_root in roots:
-        copied_search_paths, copied = _copy_validation_sources(
-            source_root,
+    if include_dependencies:
+        paths, overlay_search_paths = _materialize_closure_sources(
+            roots,
             import_roots,
             common,
             root,
             target_version,
             resolved_sources,
-            destination,
-            placed,
         )
-        overlay_search_paths.update(copied_search_paths)
-        if include_dependencies:
-            members.update(copied)
-    if not include_dependencies:
+    else:
+        destination = _overlay_destination_resolver(common, root)
+        paths: dict[Path, Path] = {}
+        overlay_search_paths: set[Path] = set()
+        for source_root in roots:
+            copied_search_paths, _copied = _copy_validation_sources(
+                source_root,
+                import_roots,
+                common,
+                root,
+                target_version,
+                resolved_sources,
+                destination,
+                None,
+            )
+            overlay_search_paths.update(copied_search_paths)
         overlay_search_paths.update(
             _overlay_configured_search_paths(search_paths, common, root)
         )
-    for path, source in resolved_sources.items():
-        target = destination(path)
-        if target is None:
-            continue
-        if placed is None or _claim_overlay_destination(
-            placed, target, path, source
-        ):
+        for path, source in resolved_sources.items():
+            target = destination(path)
+            if target is None:
+                continue
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(source, encoding="utf-8")
-        paths[path] = target
-        overlay_search_paths.add(target.parent)
-        if include_dependencies and path.name == "create2_address.vy":
-            alias = target.with_name("create2.vy")
-            alias_source = _target_validation_create2_alias_source(source)
-            if placed is None or _claim_overlay_destination(
-                placed, alias, path, alias_source
-            ):
-                alias.write_text(alias_source, encoding="utf-8")
+            paths[path] = target
+            overlay_search_paths.add(target.parent)
     if include_dependencies:
         configured_search_paths = tuple(
             search_path.resolve() for search_path in search_paths
@@ -474,7 +473,7 @@ def materialize_target_overlay(
         _copy_project_configs(common, root)
     return TargetOverlay(
         root=root,
-        paths={**members, **paths} if include_dependencies else paths,
+        paths=paths,
         source_roots=import_roots if include_dependencies else roots,
         search_paths=tuple(
             sorted(
@@ -483,6 +482,45 @@ def materialize_target_overlay(
             )
         ),
     )
+
+
+def _materialize_closure_sources(
+    source_roots: tuple[Path, ...],
+    import_roots: tuple[Path, ...],
+    common_root: Path,
+    target_root: Path,
+    target_version: str,
+    overrides: Mapping[Path, str],
+) -> tuple[dict[Path, Path], set[Path]]:
+    placed: dict[Path, Path] = {}
+    paths: dict[Path, Path] = {}
+    search_paths: set[Path] = set()
+    for path, source, import_root, is_override in _walk_validation_closure(
+        source_roots, import_roots, common_root, overrides
+    ):
+        target = target_root / path.relative_to(import_root)
+        if is_override:
+            if _claim_overlay_destination(placed, target, path, source):
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(source, encoding="utf-8")
+            search_paths.add(target.parent)
+            if path.name == "create2_address.vy":
+                alias = target.with_name("create2.vy")
+                alias_source = _target_validation_create2_alias_source(source)
+                if _claim_overlay_destination(placed, alias, path, alias_source):
+                    alias.write_text(alias_source, encoding="utf-8")
+        else:
+            _copy_validation_source(
+                path,
+                source,
+                target,
+                common_root,
+                target_version,
+                search_paths,
+                placed,
+            )
+        paths[path] = target
+    return paths, search_paths
 
 
 def _overlay_roots(
@@ -503,28 +541,10 @@ def _overlay_roots(
     return roots, import_roots, common
 
 
-def _closure_import_root(path: Path, import_roots: tuple[Path, ...]) -> Path:
-    containing_roots = tuple(
-        root for root in import_roots if _is_relative_to(path, root)
-    )
-    assert containing_roots, f"closure member is outside import roots: {path}"
-    return max(containing_roots, key=lambda root: len(root.parts))
-
-
 def _overlay_destination_resolver(
     common_root: Path,
-    import_roots: tuple[Path, ...],
     target_root: Path,
-    include_dependencies: bool,
 ) -> Callable[[Path], Path | None]:
-    if include_dependencies:
-
-        def destination(path: Path) -> Path:
-            import_root = _closure_import_root(path, import_roots)
-            return target_root / path.relative_to(import_root)
-
-        return destination
-
     def destination(path: Path) -> Path | None:
         try:
             return target_root / path.relative_to(common_root)
@@ -610,6 +630,95 @@ def _validation_roots(path: Path, search_paths: tuple[Path, ...]) -> tuple[Path,
     return (_nearest_project_root(path.parent) or path.parent,)
 
 
+def _walk_validation_closure(
+    source_roots: tuple[Path, ...],
+    import_roots: tuple[Path, ...],
+    common_root: Path,
+    overrides: Mapping[Path, str],
+) -> Iterator[tuple[Path, str, Path, bool]]:
+    override_paths = set(overrides)
+    incoming_overrides: set[Path] = set()
+    for path, source in overrides.items():
+        import_source = _standard_json_package_dependency_source(
+            path, source, common_root
+        )
+        for source_root in _containing_import_roots(path, source_roots):
+            incoming_overrides.update(
+                imported.path
+                for imported in _validation_import_sources(
+                    path, import_source, source_root, import_roots
+                )
+                if imported.path in override_paths
+            )
+
+    entry_paths = override_paths - incoming_overrides
+    queue = [
+        (
+            path,
+            overrides[path],
+            _containing_import_roots(path, source_roots)[0],
+            True,
+        )
+        for path in sorted(entry_paths)
+    ]
+    layouts: dict[Path, Path] = {}
+    processed: set[Path] = set()
+    while queue or override_paths - processed:
+        if not queue:
+            path = min(override_paths - processed)
+            queue.append(
+                (
+                    path,
+                    overrides[path],
+                    _containing_import_roots(path, source_roots)[0],
+                    True,
+                )
+            )
+        current, current_source, current_root, is_override = queue.pop(0)
+        existing_root = layouts.get(current)
+        if existing_root is not None and existing_root != current_root:
+            raise OverlayLayoutConflictError(
+                f"closure member {current} resolves relative to both "
+                f"{existing_root} and {current_root}"
+            )
+        layouts[current] = current_root
+        if current in processed:
+            continue
+        processed.add(current)
+        yield current, current_source, current_root, is_override
+        import_source = _standard_json_package_dependency_source(
+            current, current_source, common_root
+        )
+        for imported in _validation_import_sources(
+            current, import_source, current_root, import_roots
+        ):
+            if imported.path in processed:
+                existing_root = layouts[imported.path]
+                if existing_root != imported.root:
+                    raise OverlayLayoutConflictError(
+                        f"closure member {imported.path} resolves relative to both "
+                        f"{existing_root} and {imported.root}"
+                    )
+                continue
+            source = overrides.get(imported.path)
+            if source is None:
+                try:
+                    source = imported.path.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
+            queue.append(
+                (imported.path, source, imported.root, imported.path in override_paths)
+            )
+
+
+def _containing_import_roots(
+    path: Path, import_roots: tuple[Path, ...]
+) -> tuple[Path, ...]:
+    roots = tuple(root for root in import_roots if _is_relative_to(path, root))
+    assert roots, f"closure member is outside import roots: {path}"
+    return tuple(sorted(roots, key=lambda root: len(root.parts)))
+
+
 def _walk_validation_sources(
     source_root: Path,
     import_roots: tuple[Path, ...],
@@ -634,9 +743,10 @@ def _walk_validation_sources(
         current_source = _standard_json_package_dependency_source(
             current, current_source, common_root
         )
-        for resolved in _validation_import_sources(
+        for imported in _validation_import_sources(
             current, current_source, source_root, import_roots
         ):
+            resolved = imported.path
             if resolved in processed:
                 continue
             source = overrides.get(resolved)
@@ -766,8 +876,8 @@ def _local_sibling_import_source(source_path: Path, source: str) -> str:
 
 def _validation_import_sources(
     path: Path, source: str, source_root: Path, import_roots: tuple[Path, ...]
-) -> tuple[Path, ...]:
-    imports: list[Path] = []
+) -> tuple[_ResolvedValidationImport, ...]:
+    imports: list[_ResolvedValidationImport] = []
     mask = code_mask(source)
     code_source = "".join(
         char if is_code or char in "\r\n" else " "
@@ -813,21 +923,34 @@ def _imported_module_names(imports: str) -> Iterator[str]:
 
 
 def _resolve_validation_import(
-    path: Path, source_root: Path, module: str, names: tuple[str, ...], import_roots: tuple[Path, ...]
-) -> tuple[Path, ...]:
+    path: Path,
+    source_root: Path,
+    module: str,
+    names: tuple[str, ...],
+    import_roots: tuple[Path, ...],
+) -> tuple[_ResolvedValidationImport, ...]:
     bases, module_parts = _validation_import_bases(path, source_root, module, import_roots)
-    candidates: list[Path] = []
-    for base in bases:
+    candidates: list[tuple[Path, Path]] = []
+    for base, import_root in bases:
         module_path = base.joinpath(*module_parts) if module_parts else base
         if names:
             for name in names:
-                candidates.extend(_validation_module_candidates(module_path / name))
-            candidates.extend(_validation_module_candidates(module_path))
+                candidates.extend(
+                    (candidate, import_root)
+                    for candidate in _validation_module_candidates(module_path / name)
+                )
+            candidates.extend(
+                (candidate, import_root)
+                for candidate in _validation_module_candidates(module_path)
+            )
         else:
-            candidates.extend(_validation_module_candidates(module_path))
-    resolved: list[Path] = []
+            candidates.extend(
+                (candidate, import_root)
+                for candidate in _validation_module_candidates(module_path)
+            )
+    resolved: dict[Path, Path] = {}
     roots = tuple(root.resolve() for root in (source_root, *import_roots))
-    for candidate in candidates:
+    for candidate, import_root in candidates:
         try:
             resolved_candidate = candidate.resolve()
             if not any(_is_relative_to(resolved_candidate, root) for root in roots):
@@ -835,21 +958,35 @@ def _resolve_validation_import(
         except (OSError, ValueError):
             continue
         if resolved_candidate.exists() and resolved_candidate.suffix in VALIDATION_SOURCE_SUFFIXES:
-            resolved.append(resolved_candidate)
-    return tuple(dict.fromkeys(resolved))
+            resolved.setdefault(resolved_candidate, import_root)
+    return tuple(
+        _ResolvedValidationImport(path, import_root)
+        for path, import_root in resolved.items()
+    )
 
 
 def _validation_import_bases(
     path: Path, source_root: Path, module: str, import_roots: tuple[Path, ...]
-) -> tuple[tuple[Path, ...], tuple[str, ...]]:
+) -> tuple[tuple[tuple[Path, Path], ...], tuple[str, ...]]:
     if not module.startswith("."):
-        bases = (path.parent, source_root, *import_roots)
-        return tuple(dict.fromkeys(bases)), tuple(part for part in module.split(".") if part)
+        bases = (
+            (path.parent, source_root),
+            (source_root, source_root),
+            *((root, root) for root in import_roots),
+        )
+        unique_bases: dict[Path, Path] = {}
+        for base, root in bases:
+            unique_bases.setdefault(base, root)
+        return tuple(unique_bases.items()), tuple(
+            part for part in module.split(".") if part
+        )
     level = len(module) - len(module.lstrip("."))
     base = path.parent
     for _ in range(max(level - 1, 0)):
         base = base.parent
-    return (base,), tuple(part for part in module[level:].split(".") if part)
+    return ((base, source_root),), tuple(
+        part for part in module[level:].split(".") if part
+    )
 
 
 def _is_relative_to(path: Path, root: Path) -> bool:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -54,6 +54,9 @@ VALIDATION_MODULE_ALIASES = {
     "create2": "create2_address",
 }
 
+class OverlayLayoutConflictError(ValueError):
+    """Two closure members with different content map to one overlay path."""
+
 
 @dataclass
 class CompileResult:
@@ -352,8 +355,8 @@ def resolve_import_closure(
 ) -> ImportClosure:
     """Resolve the full transitive closure, including external search-path files.
 
-    Overlay materialization copies only closure members under ``common_root``;
-    external configured-search-path dependencies remain available in place.
+    Default overlay materialization copies only closure members under
+    ``common_root``; closure mode materializes external dependencies too.
     """
     resolved_sources = {path.resolve(): source for path, source in sources.items()}
     if not resolved_sources:
@@ -381,6 +384,8 @@ def target_overlay(
     sources: Mapping[Path, str],
     target_version: str,
     search_paths: tuple[Path, ...] = (),
+    *,
+    include_dependencies: bool = False,
 ) -> Iterator[TargetOverlay | None]:
     resolved_sources = {path.resolve(): source for path, source in sources.items()}
     if not resolved_sources:
@@ -388,7 +393,11 @@ def target_overlay(
         return
     with tempfile.TemporaryDirectory(prefix="vyupgrade-target-") as tmp:
         overlay = materialize_target_overlay(
-            resolved_sources, target_version, Path(tmp), search_paths
+            resolved_sources,
+            target_version,
+            Path(tmp),
+            search_paths,
+            include_dependencies=include_dependencies,
         )
         assert overlay is not None
         yield overlay
@@ -399,40 +408,73 @@ def materialize_target_overlay(
     target_version: str,
     root: Path,
     search_paths: tuple[Path, ...] = (),
+    *,
+    include_dependencies: bool = False,
 ) -> TargetOverlay | None:
     resolved_sources = {path.resolve(): source for path, source in sources.items()}
     if not resolved_sources:
         return None
     roots, import_roots, common = _overlay_roots(resolved_sources, search_paths)
+    destination = _overlay_destination_resolver(
+        common, import_roots, root, include_dependencies
+    )
+    placed: dict[Path, Path] | None = {} if include_dependencies else None
+    members: dict[Path, Path] = {}
     paths: dict[Path, Path] = {}
     overlay_search_paths: set[Path] = set()
     for source_root in roots:
-        overlay_search_paths.update(
-            _copy_validation_sources(
-                source_root,
-                import_roots,
-                common,
-                root,
-                target_version,
-                resolved_sources,
-            )
+        copied_search_paths, copied = _copy_validation_sources(
+            source_root,
+            import_roots,
+            common,
+            root,
+            target_version,
+            resolved_sources,
+            destination,
+            placed,
         )
-    overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
+        overlay_search_paths.update(copied_search_paths)
+        if include_dependencies:
+            members.update(copied)
+    if not include_dependencies:
+        overlay_search_paths.update(
+            _overlay_configured_search_paths(search_paths, common, root)
+        )
     for path, source in resolved_sources.items():
-        try:
-            relative = path.relative_to(common)
-        except ValueError:
+        target = destination(path)
+        if target is None:
             continue
-        target = root / relative
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(source, encoding="utf-8")
+        if placed is None or _claim_overlay_destination(
+            placed, target, path, source
+        ):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(source, encoding="utf-8")
         paths[path] = target
         overlay_search_paths.add(target.parent)
-    _copy_project_configs(common, root)
+        if include_dependencies and path.name == "create2_address.vy":
+            alias = target.with_name("create2.vy")
+            alias_source = _target_validation_create2_alias_source(source)
+            if placed is None or _claim_overlay_destination(
+                placed, alias, path, alias_source
+            ):
+                alias.write_text(alias_source, encoding="utf-8")
+    if include_dependencies:
+        configured_search_paths = tuple(
+            search_path.resolve() for search_path in search_paths
+        )
+        for source_root in roots:
+            if source_root not in configured_search_paths:
+                _copy_project_configs(
+                    source_root,
+                    root,
+                    excluded_roots=configured_search_paths,
+                )
+    else:
+        _copy_project_configs(common, root)
     return TargetOverlay(
         root=root,
-        paths=paths,
-        source_roots=roots,
+        paths={**members, **paths} if include_dependencies else paths,
+        source_roots=import_roots if include_dependencies else roots,
         search_paths=tuple(
             sorted(
                 (path for path in overlay_search_paths if path != root),
@@ -458,6 +500,56 @@ def _overlay_roots(
     )
     common = Path(os.path.commonpath([str(root) for root in roots]))
     return roots, import_roots, common
+
+
+def _closure_import_root(path: Path, import_roots: tuple[Path, ...]) -> Path:
+    containing_roots = tuple(
+        root for root in import_roots if _is_relative_to(path, root)
+    )
+    assert containing_roots, f"closure member is outside import roots: {path}"
+    return max(containing_roots, key=lambda root: len(root.parts))
+
+
+def _overlay_destination_resolver(
+    common_root: Path,
+    import_roots: tuple[Path, ...],
+    target_root: Path,
+    include_dependencies: bool,
+) -> Callable[[Path], Path | None]:
+    if include_dependencies:
+
+        def destination(path: Path) -> Path:
+            import_root = _closure_import_root(path, import_roots)
+            return target_root / path.relative_to(import_root)
+
+        return destination
+
+    def destination(path: Path) -> Path | None:
+        try:
+            return target_root / path.relative_to(common_root)
+        except ValueError:
+            return None
+
+    return destination
+
+
+def _claim_overlay_destination(
+    placed: dict[Path, Path],
+    target: Path,
+    source_path: Path,
+    content: str,
+) -> bool:
+    existing_source = placed.get(target)
+    if existing_source is None:
+        placed[target] = source_path
+        return True
+    if existing_source == source_path:
+        return True
+    if target.read_bytes() == content.encode("utf-8"):
+        return False
+    raise OverlayLayoutConflictError(
+        f"overlay destination {target} maps both {existing_source} and {source_path}"
+    )
 
 def _overlay_configured_search_paths(
     search_paths: tuple[Path, ...], common_root: Path, target_root: Path
@@ -565,62 +657,74 @@ def _copy_validation_sources(
     target_root: Path,
     target_version: str,
     overrides: Mapping[Path, str],
-) -> set[Path]:
+    destination: Callable[[Path], Path | None],
+    placed: dict[Path, Path] | None,
+) -> tuple[set[Path], dict[Path, Path]]:
     search_paths: set[Path] = set()
+    copied: dict[Path, Path] = {}
     for resolved, source in _walk_validation_sources(
         source_root, import_roots, common_root, overrides
     ):
+        target = destination(resolved)
+        if target is None:
+            continue
         _copy_validation_source(
             resolved,
             source,
+            target,
             common_root,
-            target_root,
             target_version,
             search_paths,
+            placed,
         )
-    return search_paths
+        if resolved.suffix in VALIDATION_SOURCE_SUFFIXES:
+            copied[resolved] = target
+    return search_paths, copied
 
 
 def _copy_validation_source(
     source_path: Path,
     source: str,
+    target: Path,
     common_root: Path,
-    target_root: Path,
     target_version: str,
     search_paths: set[Path],
+    placed: dict[Path, Path] | None,
 ) -> None:
     if source_path.suffix not in VALIDATION_SOURCE_SUFFIXES:
         return
-    try:
-        relative = source_path.relative_to(common_root)
-    except ValueError:
-        return
-    target = target_root / relative
     target.parent.mkdir(parents=True, exist_ok=True)
     if source_path.suffix == ".json":
-        target.write_text(source, encoding="utf-8")
+        if placed is None or _claim_overlay_destination(
+            placed, target, source_path, source
+        ):
+            target.write_text(source, encoding="utf-8")
         search_paths.add(target.parent)
         return
-    source = _standard_json_package_dependency_source(source_path, source, common_root)
-    target.write_text(
-        _target_validation_source(
-            source,
-            target_version,
-            is_interface=source_path.suffix == ".vyi",
-        ),
-        encoding="utf-8",
+    source = _standard_json_package_dependency_source(
+        source_path, source, common_root
     )
+    content = _target_validation_source(
+        source,
+        target_version,
+        is_interface=source_path.suffix == ".vyi",
+    )
+    if placed is None or _claim_overlay_destination(
+        placed, target, source_path, content
+    ):
+        target.write_text(content, encoding="utf-8")
     search_paths.add(target.parent)
     if source_path.name == "create2_address.vy":
         alias = target.with_name("create2.vy")
-        alias.write_text(
-            _target_validation_source(
-                _target_validation_create2_alias_source(source),
-                target_version,
-                is_interface=False,
-            ),
-            encoding="utf-8",
+        alias_content = _target_validation_source(
+            _target_validation_create2_alias_source(source),
+            target_version,
+            is_interface=False,
         )
+        if placed is None or _claim_overlay_destination(
+            placed, alias, source_path, alias_content
+        ):
+            alias.write_text(alias_content, encoding="utf-8")
 
 
 def _standard_json_package_dependency_source(source_path: Path, source: str, common_root: Path) -> str:
@@ -758,16 +862,49 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
     return tuple(candidate.with_suffix(suffix) for candidate in paths for suffix in sorted(VALIDATION_SOURCE_SUFFIXES))
 
 
-def _copy_project_configs(source_root: Path, target_root: Path) -> None:
+def _project_config_paths(
+    source_root: Path,
+    excluded_roots: tuple[Path, ...],
+) -> Iterator[Path]:
+    if not excluded_roots:
+        yield from source_root.rglob("pyproject.toml")
+        return
+    for directory, directories, files in os.walk(source_root):
+        current = Path(directory)
+        directories[:] = [
+            name
+            for name in directories
+            if not any(
+                _is_relative_to((current / name).resolve(), excluded_root)
+                for excluded_root in excluded_roots
+            )
+        ]
+        if "pyproject.toml" in files:
+            yield current / "pyproject.toml"
+
+
+def _copy_project_configs(
+    source_root: Path,
+    target_root: Path,
+    *,
+    excluded_roots: tuple[Path, ...] = (),
+) -> None:
     resolved_target = target_root.resolve()
-    for pyproject in list(source_root.rglob("pyproject.toml")):
+    for pyproject in _project_config_paths(source_root, excluded_roots):
         resolved_pyproject = pyproject.resolve()
         if (
             resolved_pyproject == resolved_target
             or resolved_target in resolved_pyproject.parents
+            or any(
+                _is_relative_to(resolved_pyproject, excluded_root)
+                for excluded_root in excluded_roots
+            )
         ):
             continue
-        if any(part in {".git", ".venv", "venv", "node_modules"} for part in pyproject.parts):
+        if any(
+            part in {".git", ".venv", "venv", "node_modules"}
+            for part in pyproject.parts
+        ):
             continue
         try:
             relative = pyproject.relative_to(source_root)

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -163,25 +163,34 @@ def compile_source_file(path: Path, config: Config, source_version: str | None) 
         allow_unsupported_formats=True,
     )
     if _should_retry_source_with_final_newline(path, result):
-        return _compile_source_file_with_final_newline(command, path, config, suppress_warnings)
+        return _compile_source_file_with_final_newline(
+            command, path, config, suppress_warnings, result
+        )
     return result
 
 
 def _compile_source_file_with_final_newline(
-    command: list[str], path: Path, config: Config, suppress_warnings: bool
+    command: list[str],
+    path: Path,
+    config: Config,
+    suppress_warnings: bool,
+    original_result: CompileResult,
 ) -> CompileResult:
     try:
         source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return CompileResult("failed", stderr="could not read source for final-newline retry")
-    tmp = tempfile.NamedTemporaryFile(
-        "w",
-        encoding="utf-8",
-        prefix=f".{path.stem}.vyupgrade.source.",
-        suffix=path.suffix,
-        dir=path.parent,
-        delete=False,
-    )
+    try:
+        tmp = tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            prefix=f".{path.stem}.vyupgrade.source.",
+            suffix=path.suffix,
+            dir=path.parent,
+            delete=False,
+        )
+    except OSError:
+        return original_result
     tmp_path = Path(tmp.name)
     try:
         with tmp:

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -57,6 +57,7 @@ class MigrationRequest:
     source_version: str | None
     source_attempts: tuple[SourceCompileAttempt, ...]
     skip_target_on_vyd016: bool = True
+    role: str = "project"
 
 
 @dataclass
@@ -100,7 +101,9 @@ class MigrationBatch:
         ]
 
 
-def bounded_migration_request(path: Path, original: str, config: Config) -> MigrationRequest:
+def bounded_migration_request(
+    path: Path, original: str, config: Config, *, role: str = "project"
+) -> MigrationRequest:
     """Build the target-bounded source compiler request used by the CLI."""
     source_version = config.source_version or infer_pragma(original)
     context = MigrationContext.from_specs(source_version, config.target_version)
@@ -113,7 +116,7 @@ def bounded_migration_request(path: Path, original: str, config: Config) -> Migr
             source_version, config.target_version, original
         )
         attempts = (SourceCompileAttempt(compiler, source_version, compiler),)
-    return MigrationRequest(path, original, source_version, attempts)
+    return MigrationRequest(path, original, source_version, attempts, role=role)
 
 
 def prepare_migrations(
@@ -141,6 +144,7 @@ def prepare_migrations(
         if (
             config.split_interfaces
             and request.path.suffix == ".vy"
+            and request.role == "project"
             and not MigrationContext.from_specs(
                 source_version, config.target_version
             ).source_newer_than_target()
@@ -153,6 +157,7 @@ def prepare_migrations(
 
         report = FileReport(
             path=request.path,
+            role=request.role,
             changed=request.original != rewrite.source,
             fixes=rewrite.fixes,
             # Validation diagnostics belong to the report, not the rule result.
@@ -209,7 +214,10 @@ def validate_migrations(
     target_sources = candidate_sources(batch, resolve_candidate)
 
     with target_overlay(
-        target_sources, config.target_version, config.compiler_search_paths
+        target_sources,
+        config.target_version,
+        config.compiler_search_paths,
+        include_dependencies=config.include_dependencies,
     ) as overlay:
         for migration in batch.files:
             _reset_target_validation(

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -206,7 +206,7 @@ def validate_migrations(
 ) -> ValidationDecision:
     """Validate one coherent candidate overlay and return its typed decision."""
     resolve_candidate = candidate_source or _unchanged_candidate
-    target_sources = _candidate_sources(batch, resolve_candidate)
+    target_sources = candidate_sources(batch, resolve_candidate)
 
     with target_overlay(
         target_sources, config.target_version, config.compiler_search_paths
@@ -296,7 +296,7 @@ def _unchanged_candidate(_path: Path, source: str) -> str:
     return source
 
 
-def _candidate_sources(
+def candidate_sources(
     batch: MigrationBatch, resolve_candidate: CandidateSource
 ) -> dict[Path, str]:
     candidates = [

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -17,7 +17,7 @@ ValidationIssueCode = Literal[
     "method_identifiers_changed",
     "storage_layout_changed",
 ]
-REPORT_SCHEMA_VERSION = 1
+REPORT_SCHEMA_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -87,6 +87,7 @@ class ValidationDecision:
 @dataclass
 class FileReport:
     path: Path
+    role: str = "project"
     changed: bool = False
     fixes: list[Fix] = field(default_factory=list)
     diagnostics: list[Diagnostic] = field(default_factory=list)
@@ -112,6 +113,29 @@ class FileReport:
     final_sha256: str | None = None
     final_matches_candidate: bool | None = None
 
+@dataclass
+class ClosureReport:
+    requested: bool = False
+    dependencies: tuple[str, ...] = ()
+    output_dir: str | None = None
+    output_status: str = "skipped"
+    output_error: str | None = None
+    archive: str | None = None
+    archive_status: str = "skipped"
+    archive_error: str | None = None
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
+            "requested": self.requested,
+            "dependencies": list(self.dependencies),
+            "output_dir": self.output_dir,
+            "output_status": self.output_status,
+            "output_error": self.output_error,
+            "archive": self.archive,
+            "archive_status": self.archive_status,
+            "archive_error": self.archive_error,
+        }
+
 
 @dataclass(frozen=True)
 class Config:
@@ -133,6 +157,7 @@ class Config:
     compiler_search_paths: tuple[Path, ...] = ()
     enable_decimals: bool = False
     split_interfaces: bool = False
+    include_dependencies: bool = False
     format: str = "none"
     allow_unvalidated_source: bool = False
     allow_abi_change: bool = False
@@ -157,6 +182,7 @@ class RunReport:
     test_command: str | None = None
     test_status: str = "skipped"
     test_output: str | None = None
+    closure: ClosureReport | None = None
 
     @property
     def changed_count(self) -> int:
@@ -182,6 +208,7 @@ class RunReport:
             "validation_decision": self.validation_decision.to_json_obj(),
             "files": [
                 {
+                    "role": file.role,
                     "path": str(file.path),
                     "changed": file.changed,
                     "original_sha256": file.original_sha256,
@@ -218,4 +245,5 @@ class RunReport:
             "test_command": self.test_command,
             "test_status": self.test_status,
             "test_output": self.test_output,
+            "closure": self.closure.to_json_obj() if self.closure else None,
         }

--- a/src/vyupgrade/reporting.py
+++ b/src/vyupgrade/reporting.py
@@ -169,12 +169,18 @@ def _render_text_summary(report: RunReport) -> str:
         f"left {report.diagnostic_count} review diagnostics",
         f"write validation: {report.validation_decision.status}",
     ]
+    if report.closure is not None:
+        lines.append(f"dependencies: {len(report.closure.dependencies)} upgraded")
     waiver_flags = sorted(
         {issue.waiver for issue in report.validation_decision.waivers if issue.waiver}
     )
     if waiver_flags:
         lines.append(f"validation waivers: {', '.join(waiver_flags)}")
-    if not report.write_requested and report.changed_count:
+    if (
+        not report.write_requested
+        and report.changed_count
+        and report.closure is None
+    ):
         lines.append("run with --write to apply these changes")
     if report.write_status != "skipped":
         lines.append(f"write transaction: {report.write_status}")
@@ -210,12 +216,24 @@ def _render_summary(console: Console, report: RunReport) -> None:
             _status_style(report.validation_decision.status),
         )
     )
+    if report.closure is not None:
+        console.print(
+            _label_value(
+                "dependencies",
+                f"{len(report.closure.dependencies)} upgraded",
+                _count_style(len(report.closure.dependencies)),
+            )
+        )
     waiver_flags = sorted(
         {issue.waiver for issue in report.validation_decision.waivers if issue.waiver}
     )
     if waiver_flags:
         console.print(_label_value("validation waivers", ", ".join(waiver_flags), "vy.warning"))
-    if not report.write_requested and report.changed_count:
+    if (
+        not report.write_requested
+        and report.changed_count
+        and report.closure is None
+    ):
         console.print(Text("run with --write to apply these changes", style="vy.muted"))
     if report.write_status != "skipped":
         console.print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1365,3 +1365,352 @@ def f() -> uint256:
     assert file_report["diagnostics"][0]["severity"] == "error"
     assert file_report["validation"]["source_compile"] == "skipped"
     assert file_report["validation"]["target_compile"] == "skipped"
+
+
+def _write_dependency_cli_fixture(
+    tmp_path: Path,
+    *,
+    dependency_source: str = "# @version 0.3.10\nVALUE: constant(uint256) = 1\n",
+    include_json: bool = False,
+) -> tuple[Path, Path, Path, Path | None]:
+    project_root = tmp_path / "project"
+    project = project_root / "main.vy"
+    search_path = tmp_path / "site-packages"
+    dependency = search_path / "depkg" / "mod.vy"
+    dependency.parent.mkdir(parents=True)
+    project_root.mkdir()
+    (project_root / "pyproject.toml").write_text("[project]\nname='project'\n")
+    imported = "mod, IMod" if include_json else "mod"
+    project.write_text(
+        f"#pragma version 0.4.3\nfrom depkg import {imported}\n",
+        encoding="utf-8",
+    )
+    dependency.write_text(dependency_source, encoding="utf-8")
+    json_dependency = dependency.with_name("IMod.json") if include_json else None
+    if json_dependency is not None:
+        json_dependency.write_text("[]\n", encoding="utf-8")
+    return project, dependency, search_path, json_dependency
+
+
+def test_include_dependencies_reports_dependency_roles(
+    tmp_path: Path, passing_compiler
+) -> None:
+    project, dependency, search_path, _json_dependency = (
+        _write_dependency_cli_fixture(tmp_path)
+    )
+    closure_report = tmp_path / "closure.json"
+    project_report = tmp_path / "project.json"
+
+    closure_code = main(
+        [
+            str(project),
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+            "--report-json",
+            str(closure_report),
+        ]
+    )
+    project_code = main(
+        [
+            str(project),
+            "--compiler-search-paths",
+            str(search_path),
+            "--report-json",
+            str(project_report),
+        ]
+    )
+
+    assert closure_code == 0
+    assert project_code == 0
+    closure_files = {
+        Path(file["path"]): file for file in json.loads(closure_report.read_text())["files"]
+    }
+    assert closure_files[project.resolve()]["role"] == "project"
+    assert closure_files[dependency.resolve()]["role"] == "dependency"
+    project_files = json.loads(project_report.read_text())["files"]
+    assert [Path(file["path"]) for file in project_files] == [project.resolve()]
+    assert project_files[0]["role"] == "project"
+
+
+def test_include_dependencies_write_without_destination_exits_4(
+    tmp_path: Path, passing_compiler
+) -> None:
+    project, dependency, search_path, _json_dependency = (
+        _write_dependency_cli_fixture(tmp_path)
+    )
+    project_original = project.read_bytes()
+    dependency_original = dependency.read_bytes()
+
+    code = main(
+        [
+            str(project),
+            "--write",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+        ]
+    )
+
+    assert code == 4
+    assert project.read_bytes() == project_original
+    assert dependency.read_bytes() == dependency_original
+
+
+def test_include_dependencies_never_plans_dependency_writes(
+    tmp_path: Path, passing_compiler, capsys
+) -> None:
+    project, dependency, search_path, _json_dependency = (
+        _write_dependency_cli_fixture(tmp_path)
+    )
+    project_original = project.read_bytes()
+    dependency_original = dependency.read_bytes()
+    config = Config(
+        paths=(project,),
+        compiler_search_paths=(search_path,),
+        include_dependencies=True,
+    )
+    project_request = engine.bounded_migration_request(
+        project, project.read_text(), config
+    )
+    dependency_requests, _closure = cli._dependency_requests([project_request], config)
+    batch = engine.prepare_migrations([project_request, *dependency_requests], config)
+
+    _reports, plan, plan_error = cli._build_migration_plan(batch)
+    diff_code = main(
+        [
+            str(project),
+            "--diff",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+        ]
+    )
+    write_code = main(
+        [
+            str(project),
+            "--write",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+        ]
+    )
+
+    assert plan_error is None
+    assert [entry.path for entry in plan.entries] == [project.resolve()]
+    assert diff_code == 0
+    assert f"--- {dependency.resolve()}" in capsys.readouterr().out
+    assert write_code == 4
+    assert project.read_bytes() == project_original
+    assert dependency.read_bytes() == dependency_original
+
+
+def test_include_dependencies_check_exits_1_on_dep_only_change(
+    tmp_path: Path, passing_compiler
+) -> None:
+    project, _dependency, search_path, _json_dependency = (
+        _write_dependency_cli_fixture(tmp_path)
+    )
+
+    code = main(
+        [
+            str(project),
+            "--check",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+        ]
+    )
+
+    assert code == 1
+
+
+def test_include_dependencies_diff_covers_dependencies(
+    tmp_path: Path, passing_compiler, capsys
+) -> None:
+    project, dependency, search_path, _json_dependency = (
+        _write_dependency_cli_fixture(tmp_path)
+    )
+
+    code = main(
+        [
+            str(project),
+            "--diff",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+        ]
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert f"--- {dependency.resolve()}" in output
+    assert f"+++ {dependency.resolve()}" in output
+
+
+def test_upgrade_closure_alias_and_pyproject_key(
+    tmp_path: Path, passing_compiler
+) -> None:
+    project, dependency, search_path, _json_dependency = (
+        _write_dependency_cli_fixture(tmp_path)
+    )
+    alias_report = tmp_path / "alias.json"
+    config_report = tmp_path / "config.json"
+    config_path = tmp_path / "pyproject.toml"
+    config_path.write_text(
+        "[tool.vyupgrade]\n"
+        f'paths = ["{project}"]\n'
+        f'compiler-search-paths = ["{search_path}"]\n'
+        "include-dependencies = true\n"
+        f'report-json = "{config_report}"\n'
+    )
+
+    alias_code = main(
+        [
+            str(project),
+            "--upgrade-closure",
+            "--compiler-search-paths",
+            str(search_path),
+            "--report-json",
+            str(alias_report),
+        ]
+    )
+    config_code = main(["--config", str(config_path)])
+
+    assert alias_code == 0
+    assert config_code == 0
+    for report_path in (alias_report, config_report):
+        closure = json.loads(report_path.read_text())["closure"]
+        assert closure["requested"] is True
+        assert closure["dependencies"] == [str(dependency.resolve())]
+
+
+def test_dependency_source_version_inferred_from_dep_pragma(
+    tmp_path: Path, passing_compiler
+) -> None:
+    project, dependency, search_path, _json_dependency = (
+        _write_dependency_cli_fixture(tmp_path)
+    )
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(project),
+            "--source-version",
+            "0.2.16",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 0
+    files = {Path(file["path"]): file for file in json.loads(report.read_text())["files"]}
+    assert files[dependency.resolve()]["validation"]["source_version"] == "0.3.10"
+
+
+def test_overlay_layout_conflict_exits_4(
+    tmp_path: Path, passing_compiler, capsys
+) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = first_root / "pkg" / "util.vy"
+    second = second_root / "pkg" / "util.vy"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    (first_root / "pyproject.toml").write_text("[project]\nname='first'\n")
+    (second_root / "pyproject.toml").write_text("[project]\nname='second'\n")
+    first.write_text("#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n")
+    second.write_text("#pragma version 0.4.3\nVALUE: constant(uint256) = 2\n")
+
+    code = main([str(first), str(second), "--include-dependencies"])
+
+    assert code == 4
+    stderr = capsys.readouterr().err
+    assert str(first.resolve()) in stderr
+    assert str(second.resolve()) in stderr
+
+
+def test_report_json_schema_v2(tmp_path: Path, passing_compiler) -> None:
+    project, dependency, search_path, json_dependency = (
+        _write_dependency_cli_fixture(tmp_path, include_json=True)
+    )
+    assert json_dependency is not None
+    project_report = tmp_path / "project.json"
+    closure_report = tmp_path / "closure.json"
+
+    project_code = main(
+        [
+            str(project),
+            "--compiler-search-paths",
+            str(search_path),
+            "--report-json",
+            str(project_report),
+        ]
+    )
+    closure_code = main(
+        [
+            str(project),
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+            "--report-json",
+            str(closure_report),
+        ]
+    )
+
+    assert project_code == 0
+    assert closure_code == 0
+    project_data = json.loads(project_report.read_text())
+    closure_data = json.loads(closure_report.read_text())
+    assert project_data["schema_version"] == 2
+    assert project_data["closure"] is None
+    assert all(file["role"] == "project" for file in project_data["files"])
+    assert closure_data["schema_version"] == 2
+    assert closure_data["closure"] == {
+        "requested": True,
+        "dependencies": sorted(
+            [str(dependency.resolve()), str(json_dependency.resolve())]
+        ),
+        "output_dir": None,
+        "output_status": "skipped",
+        "output_error": None,
+        "archive": None,
+        "archive_status": "skipped",
+        "archive_error": None,
+    }
+    assert {file["role"] for file in closure_data["files"]} == {
+        "project",
+        "dependency",
+    }
+
+
+def test_include_dependencies_empty_project_reports_requested_closure(
+    tmp_path: Path,
+) -> None:
+    empty_project = tmp_path / "empty"
+    empty_project.mkdir()
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(empty_project),
+            "--include-dependencies",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 0
+    assert json.loads(report.read_text())["closure"] == {
+        "requested": True,
+        "dependencies": [],
+        "output_dir": None,
+        "output_status": "skipped",
+        "output_error": None,
+        "archive": None,
+        "archive_status": "skipped",
+        "archive_error": None,
+    }

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -612,3 +612,54 @@ def test_target_validation_does_not_normalize_selected_candidate(tmp_path: Path)
 
     assert code == 2
     assert contract.read_text(encoding="utf-8") == original
+
+
+def test_real_compiler_include_dependencies_upgrades_closure(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    project = project_root / "main.vy"
+    search_path = tmp_path / "site-packages"
+    dependency = search_path / "depkg" / "mod.vy"
+    dependency.parent.mkdir(parents=True)
+    project_root.mkdir()
+    (project_root / "pyproject.toml").write_text("[project]\nname='project'\n")
+    (project_root / "depkg").symlink_to(dependency.parent, target_is_directory=True)
+    project_source = (
+        "# @version 0.3.10\n"
+        "from depkg import mod\n"
+        "\n"
+        "@external\n"
+        "def value() -> uint256:\n"
+        "    return 1\n"
+    )
+    dependency_source = (
+        "# @version 0.3.10\n"
+        "VALUE: constant(uint256) = 1\n"
+    )
+    project.write_text(project_source, encoding="utf-8")
+    dependency.write_text(dependency_source, encoding="utf-8")
+    report = tmp_path / "report.json"
+    second_report = tmp_path / "second-report.json"
+    arguments = [
+        str(project),
+        "--include-dependencies",
+        "--compiler-search-paths",
+        str(search_path),
+        "--report-json",
+    ]
+
+    code = main([*arguments, str(report)])
+    second_code = main([*arguments, str(second_report)])
+
+    assert code == 0
+    assert second_code == 0
+    assert project.read_text(encoding="utf-8") == project_source
+    assert dependency.read_text(encoding="utf-8") == dependency_source
+    data = json.loads(report.read_text())
+    second_data = json.loads(second_report.read_text())
+    assert data == second_data
+    files = {Path(file["path"]): file for file in data["files"]}
+    assert files[project.resolve()]["validation"]["target_compile"] == "passed"
+    assert files[dependency.resolve()]["validation"]["target_compile"] == "passed"
+    assert files[dependency.resolve()]["role"] == "dependency"

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1226,6 +1226,36 @@ def test_closure_overlay_places_external_candidate_bytes(tmp_path) -> None:
     assert overlay.paths[dependency.resolve()] == target
 
 
+def test_closure_overlay_preserves_root_that_resolved_nested_dependency(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "main.vy"
+    nested_search_path = project / "contracts"
+    dependency = nested_search_path / "dep.vy"
+    dependency.parent.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\nname='project'\n")
+    source = "#pragma version 0.4.3\nfrom contracts import dep\n"
+    dependency_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    contract.write_text(source)
+    dependency.write_text(dependency_source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {contract: source},
+        "0.4.3",
+        root,
+        (project, nested_search_path),
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "contracts" / "dep.vy"
+    assert overlay.paths[dependency.resolve()] == target
+    assert target.read_text() == dependency_source
+    assert not (root / "dep.vy").exists()
+
+
 def test_closure_overlay_paths_equal_resolved_closure(tmp_path) -> None:
     _contract, _dependency, sources, search_paths = _write_external_import_fixture(
         tmp_path

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1256,6 +1256,36 @@ def test_closure_overlay_preserves_root_that_resolved_nested_dependency(
     assert not (root / "dep.vy").exists()
 
 
+def test_closure_overlay_preserves_symlinked_import_path(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "main.vy"
+    search_path = tmp_path / "site-packages"
+    dependency = search_path / "depkg" / "mod.vy"
+    dependency.parent.mkdir(parents=True)
+    project.mkdir()
+    (project / "pyproject.toml").write_text("[project]\nname='project'\n")
+    (project / "alias").symlink_to(dependency.parent, target_is_directory=True)
+    source = "#pragma version 0.4.3\nfrom alias import mod\n"
+    dependency_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    contract.write_text(source)
+    dependency.write_text(dependency_source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {contract: source},
+        "0.4.3",
+        root,
+        (search_path,),
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "alias" / "mod.vy"
+    assert overlay.paths[dependency.resolve()] == target
+    assert target.read_text() == dependency_source
+    assert not (root / "depkg" / "mod.vy").exists()
+
+
 def test_closure_overlay_paths_equal_resolved_closure(tmp_path) -> None:
     _contract, _dependency, sources, search_paths = _write_external_import_fixture(
         tmp_path

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -7,7 +7,9 @@ import pytest
 
 from vyupgrade.compiler import (
     CompileResult,
+    OverlayLayoutConflictError,
     _compiler_command,
+    _overlay_search_paths,
     _run_compile,
     _supports_warning_policy,
     _target_validation_source,
@@ -916,6 +918,67 @@ def _write_import_closure_fixture(
     )
 
 
+def _write_external_import_fixture(
+    tmp_path: Path,
+) -> tuple[Path, Path, dict[Path, str], tuple[Path, ...]]:
+    project = tmp_path / "project"
+    contract = project / "src" / "main.vy"
+    local_dependency = project / "src" / "local.vy"
+    site_packages = tmp_path / "site-packages"
+    external_dependency = site_packages / "depkg" / "util.vy"
+    contract.parent.mkdir(parents=True)
+    external_dependency.parent.mkdir(parents=True)
+    source = (
+        "#pragma version 0.4.3\n"
+        "from . import local\n"
+        "from depkg import util\n"
+    )
+    contract.write_text(source, encoding="utf-8")
+    local_dependency.write_text(
+        "# @version 0.3.10\nLOCAL: constant(uint256) = 1\n",
+        encoding="utf-8",
+    )
+    external_dependency.write_text(
+        "# @version 0.3.10\nEXTERNAL: constant(uint256) = 2\n",
+        encoding="utf-8",
+    )
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "overlay-project"\n',
+        encoding="utf-8",
+    )
+    return contract, external_dependency, {contract: source}, (site_packages,)
+
+
+def _write_create2_collision_fixture(
+    tmp_path: Path,
+    create2_source: str | None,
+) -> tuple[Path, Path, dict[Path, str]]:
+    project = tmp_path / "project"
+    contract = project / "factory.vy"
+    utils = project / "snekmate" / "utils"
+    create2_address = utils / "create2_address.vy"
+    create2 = utils / "create2.vy"
+    utils.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\nname='create2'\n")
+    contract_source = (
+        "#pragma version 0.4.3\n"
+        "from snekmate.utils import create2_address, create2\n"
+    )
+    create2_address_source = (
+        "# @version 0.3.10\n"
+        "def _compute_address(value: uint256) -> address:\n"
+        "    return empty(address)\n"
+    )
+    if create2_source is None:
+        create2_source = create2_address_source.replace(
+            "_compute_address", "_compute_create2_address"
+        )
+    contract.write_text(contract_source)
+    create2_address.write_text(create2_address_source)
+    create2.write_text(create2_source)
+    return create2_address, create2, {contract: contract_source}
+
+
 def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
     contract, sources, search_paths, expected_dependencies = (
         _write_import_closure_fixture(tmp_path)
@@ -1082,6 +1145,418 @@ def test_materialize_target_overlay_empty_sources_returns_none(tmp_path) -> None
     root = tmp_path / "materialized"
 
     assert materialize_target_overlay({}, "0.4.3", root) is None
+
+
+def test_closure_overlay_places_external_dep_import_root_relative(
+    tmp_path,
+) -> None:
+    contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "depkg" / "util.vy"
+    assert target.read_text(encoding="utf-8") == _target_validation_source(
+        dependency.read_text(encoding="utf-8"), "0.4.3"
+    )
+    assert overlay.paths[dependency.resolve()] == target
+    assert overlay.source_roots == (
+        contract.parents[1].resolve(),
+        search_paths[0].resolve(),
+    )
+
+
+def test_closure_overlay_places_external_candidate_bytes(tmp_path) -> None:
+    _contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    candidate = (
+        "#pragma version 0.4.3\n"
+        "EXTERNAL: constant(uint256) = 99\n"
+        "# candidate bytes stay exact\n"
+    )
+    sources[dependency] = candidate
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "depkg" / "util.vy"
+    assert target.read_bytes() == candidate.encode()
+    assert overlay.paths[dependency.resolve()] == target
+
+
+def test_closure_overlay_paths_equal_resolved_closure(tmp_path) -> None:
+    _contract, _dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    closure = resolve_import_closure(sources, search_paths)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert set(overlay.paths) == set(closure.files)
+    assert (root / "pyproject.toml").is_file()
+    assert root / "pyproject.toml" not in overlay.paths.values()
+
+
+def test_closure_overlay_multi_root_placement(tmp_path) -> None:
+    first_root = tmp_path / "repo" / "a"
+    second_root = tmp_path / "repo" / "b"
+    first = first_root / "x.vy"
+    second = second_root / "y.vy"
+    first_root.mkdir(parents=True)
+    second_root.mkdir(parents=True)
+    (first_root / "pyproject.toml").write_text("[project]\nname='a'\n")
+    (second_root / "pyproject.toml").write_text("[project]\nname='b'\n")
+    first_source = "#pragma version 0.4.3\nX: constant(uint256) = 1\n"
+    second_source = "#pragma version 0.4.3\nY: constant(uint256) = 2\n"
+    first.write_text(first_source)
+    second.write_text(second_source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {first: first_source, second: second_source},
+        "0.4.3",
+        root,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert (root / "x.vy").read_text() == first_source
+    assert (root / "y.vy").read_text() == second_source
+    assert not (root / "a" / "x.vy").exists()
+    assert not (root / "b" / "y.vy").exists()
+    assert overlay.source_roots == (first_root.resolve(), second_root.resolve())
+
+
+def test_closure_overlay_conflicting_destinations_raise(tmp_path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = first_root / "pkg" / "util.vy"
+    second = second_root / "pkg" / "util.vy"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    (first_root / "pyproject.toml").write_text("[project]\nname='first'\n")
+    (second_root / "pyproject.toml").write_text("[project]\nname='second'\n")
+    first_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    second_source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 2\n"
+    first.write_text(first_source)
+    second.write_text(second_source)
+    target = tmp_path / "overlay" / "pkg" / "util.vy"
+
+    with pytest.raises(OverlayLayoutConflictError) as exc_info:
+        materialize_target_overlay(
+            {first: first_source, second: second_source},
+            "0.4.3",
+            tmp_path / "overlay",
+            include_dependencies=True,
+        )
+
+    message = str(exc_info.value)
+    assert str(first.resolve()) in message
+    assert str(second.resolve()) in message
+    assert str(target) in message
+
+
+def test_closure_overlay_identical_content_collisions_dedupe(tmp_path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = first_root / "pkg" / "util.vy"
+    second = second_root / "pkg" / "util.vy"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    (first_root / "pyproject.toml").write_text("[project]\nname='first'\n")
+    (second_root / "pyproject.toml").write_text("[project]\nname='second'\n")
+    source = "#pragma version 0.4.3\nVALUE: constant(uint256) = 1\n"
+    first.write_text(source)
+    second.write_text(source)
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {first: source, second: source},
+        "0.4.3",
+        root,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "pkg" / "util.vy"
+    assert target.read_text() == source
+    assert overlay.paths[first.resolve()] == target
+    assert overlay.paths[second.resolve()] == target
+    assert list((root / "pkg").glob("util.vy")) == [target]
+
+
+def test_closure_overlay_drops_external_search_paths_from_compile_paths(
+    tmp_path,
+) -> None:
+    _contract, _dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+
+    with target_overlay(
+        sources,
+        "0.4.3",
+        search_paths,
+        include_dependencies=True,
+    ) as closure_overlay:
+        assert closure_overlay is not None
+        closure_paths = _overlay_search_paths(closure_overlay, search_paths)
+    with target_overlay(sources, "0.4.3", search_paths) as default_overlay:
+        assert default_overlay is not None
+        default_paths = _overlay_search_paths(default_overlay, search_paths)
+
+    assert search_paths[0] not in closure_paths
+    assert search_paths[0] in default_paths
+
+
+def test_closure_overlay_create2_alias_beside_override(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "factory.vy"
+    create2_address = project / "snekmate" / "utils" / "create2_address.vy"
+    create2_address.parent.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\nname='create2'\n")
+    contract_source = (
+        "#pragma version 0.4.3\nfrom snekmate.utils import create2\n"
+    )
+    candidate = (
+        "#pragma version 0.4.3\n"
+        "def _compute_address(value: uint256) -> address:\n"
+        "    return empty(address)\n"
+    )
+    contract.write_text(contract_source)
+    create2_address.write_text(candidate)
+    sources = {contract: contract_source, create2_address: candidate}
+
+    closure_root = tmp_path / "closure"
+    closure = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        closure_root,
+        include_dependencies=True,
+    )
+    default_root = tmp_path / "default"
+    default = materialize_target_overlay(sources, "0.4.3", default_root)
+
+    assert closure is not None
+    assert default is not None
+    alias = closure_root / "snekmate" / "utils" / "create2.vy"
+    assert (
+        alias.read_text()
+        == candidate.replace("_compute_address", "_compute_create2_address")
+    )
+    assert (
+        closure_root / "snekmate" / "utils" / "create2_address.vy"
+    ).read_text() == candidate
+    assert alias not in closure.paths.values()
+    assert not (default_root / "snekmate" / "utils" / "create2.vy").exists()
+
+
+def test_default_overlay_create2_alias_collision_preserves_last_write(
+    tmp_path,
+) -> None:
+    create2_source = (
+        "# @version 0.3.10\n"
+        "REAL_CREATE2: constant(uint256) = 2\n"
+    )
+    _create2_address, _create2, sources = _write_create2_collision_fixture(
+        tmp_path, create2_source
+    )
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(sources, "0.4.3", root)
+
+    assert overlay is not None
+    assert (root / "snekmate" / "utils" / "create2.vy").read_text() == (
+        _target_validation_source(create2_source, "0.4.3")
+    )
+
+
+def test_closure_overlay_create2_alias_collision_raises(tmp_path) -> None:
+    create2_source = (
+        "# @version 0.3.10\n"
+        "REAL_CREATE2: constant(uint256) = 2\n"
+    )
+    create2_address, create2, sources = _write_create2_collision_fixture(
+        tmp_path, create2_source
+    )
+
+    with pytest.raises(OverlayLayoutConflictError) as exc_info:
+        materialize_target_overlay(
+            sources,
+            "0.4.3",
+            tmp_path / "overlay",
+            include_dependencies=True,
+        )
+
+    message = str(exc_info.value)
+    assert str(create2_address.resolve()) in message
+    assert str(create2.resolve()) in message
+
+
+def test_closure_overlay_create2_alias_identical_content_dedupes(
+    tmp_path,
+) -> None:
+    _create2_address, create2, sources = _write_create2_collision_fixture(
+        tmp_path, None
+    )
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    target = root / "snekmate" / "utils" / "create2.vy"
+    assert target.read_text() == _target_validation_source(
+        create2.read_text(), "0.4.3"
+    )
+    assert overlay.paths[create2.resolve()] == target
+
+
+def test_closure_overlay_copies_project_pyproject_only(tmp_path) -> None:
+    _contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    project_pyproject = tmp_path / "project" / "pyproject.toml"
+    site_pyproject = search_paths[0] / "pyproject.toml"
+    site_pyproject.write_text("[project]\nname='site-packages'\n")
+    sources[dependency] = dependency.read_text()
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        root,
+        search_paths,
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert (root / "pyproject.toml").read_bytes() == project_pyproject.read_bytes()
+    assert site_pyproject.read_bytes() not in {
+        path.read_bytes()
+        for path in root.rglob("pyproject.toml")
+    }
+
+
+def test_closure_overlay_excludes_nested_search_path_pyprojects(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "main.vy"
+    search_path = project / "vendor" / "site-packages"
+    dependency = search_path / "depkg" / "util.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    project_pyproject = project / "pyproject.toml"
+    dependency_pyproject = dependency.parent / "pyproject.toml"
+    project_pyproject.write_text("[project]\nname='project'\n")
+    dependency_pyproject.write_text("[project]\nname='dependency'\n")
+    source = "#pragma version 0.4.3\nfrom depkg import util\n"
+    contract.write_text(source)
+    dependency.write_text("# @version 0.3.10\n")
+    root = tmp_path / "overlay"
+
+    overlay = materialize_target_overlay(
+        {contract: source},
+        "0.4.3",
+        root,
+        (search_path,),
+        include_dependencies=True,
+    )
+
+    assert overlay is not None
+    assert (root / "pyproject.toml").read_bytes() == project_pyproject.read_bytes()
+    assert overlay.paths[dependency.resolve()] == root / "depkg" / "util.vy"
+    assert not (
+        root
+        / "vendor"
+        / "site-packages"
+        / "depkg"
+        / "pyproject.toml"
+    ).exists()
+    assert dependency_pyproject.read_bytes() not in {
+        path.read_bytes()
+        for path in root.rglob("pyproject.toml")
+    }
+
+
+def test_materialize_default_mode_ignores_external_deps(tmp_path) -> None:
+    contract, dependency, sources, search_paths = _write_external_import_fixture(
+        tmp_path
+    )
+    project = contract.parents[1]
+    local_dependency = contract.with_name("local.vy")
+    implicit_root = tmp_path / "implicit"
+    explicit_root = tmp_path / "explicit"
+
+    implicit = materialize_target_overlay(
+        sources, "0.4.3", implicit_root, search_paths
+    )
+    explicit = materialize_target_overlay(
+        sources,
+        "0.4.3",
+        explicit_root,
+        search_paths,
+        include_dependencies=False,
+    )
+
+    assert implicit is not None
+    assert explicit is not None
+
+    def tree(root: Path) -> dict[Path, bytes]:
+        return {
+            path.relative_to(root): path.read_bytes()
+            for path in root.rglob("*")
+            if path.is_file()
+        }
+
+    expected_tree = {
+        Path("pyproject.toml"): (project / "pyproject.toml").read_bytes(),
+        Path("src/local.vy"): _target_validation_source(
+            local_dependency.read_text(), "0.4.3"
+        ).encode(),
+        Path("src/main.vy"): sources[contract].encode(),
+    }
+    assert tree(implicit_root) == expected_tree
+    assert tree(explicit_root) == expected_tree
+    assert dependency.resolve() not in implicit.paths
+    assert {
+        path: target.relative_to(implicit_root)
+        for path, target in implicit.paths.items()
+    } == {contract.resolve(): Path("src/main.vy")}
+    assert {
+        path: target.relative_to(explicit_root)
+        for path, target in explicit.paths.items()
+    } == {contract.resolve(): Path("src/main.vy")}
+    assert implicit.source_roots == explicit.source_roots == (project.resolve(),)
 
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -17,6 +17,8 @@ from vyupgrade.compiler import (
     compile_source_ast,
     compile_source_file,
     compile_target_source,
+    materialize_target_overlay,
+    resolve_import_closure,
     target_overlay,
     unavailable_validation_artifacts,
 )
@@ -880,6 +882,207 @@ def test_compile_target_source_uses_source_dir_for_relative_imports(monkeypatch,
 
     assert result.status == "passed"
     assert calls["target_parent"] == contract.parent
+
+def _write_import_closure_fixture(
+    tmp_path: Path,
+) -> tuple[Path, dict[Path, str], tuple[Path, ...], tuple[Path, ...]]:
+    project = tmp_path / "project"
+    contract = project / "src" / "a.vy"
+    dependency = project / "src" / "b.vy"
+    transitive = project / "src" / "lib" / "c.vy"
+    interface = project / "src" / "interfaces" / "IThing.json"
+    contract.parent.mkdir(parents=True)
+    transitive.parent.mkdir(parents=True)
+    interface.parent.mkdir(parents=True)
+    source = "#pragma version 0.4.3\nfrom . import b\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text(
+        "# @version 0.4.0\n"
+        "from .lib import c\n"
+        "from .interfaces import IThing\n",
+        encoding="utf-8",
+    )
+    transitive.write_text("# @version 0.4.0\nVALUE: constant(uint256) = 1\n", encoding="utf-8")
+    interface.write_text("[]\n", encoding="utf-8")
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "closure-fixture"\n',
+        encoding="utf-8",
+    )
+    return (
+        contract,
+        {contract: source},
+        (project,),
+        tuple(sorted((dependency.resolve(), transitive.resolve(), interface.resolve()))),
+    )
+
+
+def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
+    contract, sources, search_paths, expected_dependencies = (
+        _write_import_closure_fixture(tmp_path)
+    )
+
+    closure = resolve_import_closure(sources, search_paths)
+
+    assert closure.roots == (contract.resolve(),)
+    assert closure.dependencies == expected_dependencies
+    assert closure.files == (contract.resolve(), *expected_dependencies)
+    assert closure.source_roots == (tmp_path / "project",)
+    assert closure.common_root == tmp_path / "project"
+
+
+def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    closure = resolve_import_closure(sources, search_paths)
+
+    with target_overlay(sources, "0.4.3", search_paths) as overlay:
+        assert overlay is not None
+        copied_files = {
+            path.relative_to(overlay.root)
+            for path in overlay.root.rglob("*")
+            if path.is_file()
+        }
+
+    override_files = {
+        path.resolve().relative_to(closure.common_root) for path in sources
+    }
+    config_files = {
+        path.relative_to(closure.common_root)
+        for path in closure.common_root.rglob("pyproject.toml")
+    }
+    create2_aliases = {
+        path
+        for path in copied_files
+        if path.name == "create2.vy"
+        and path.with_name("create2_address.vy") in copied_files
+    }
+    dependency_copies = copied_files - override_files - config_files - create2_aliases
+
+    assert dependency_copies == {
+        path.relative_to(closure.common_root) for path in closure.dependencies
+    }
+
+
+def test_resolve_import_closure_search_path_dependency(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "main.vy"
+    site_packages = tmp_path / "site-packages"
+    dependency = site_packages / "pkg" / "dep.vy"
+    escaped = tmp_path / "outside" / "escape.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    escaped.parent.mkdir(parents=True)
+    source = (
+        "#pragma version 0.4.3\n"
+        "from pkg import dep\n"
+        "from ...outside import escape\n"
+    )
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.4.0\n", encoding="utf-8")
+    escaped.write_text("# @version 0.4.0\n", encoding="utf-8")
+
+    closure = resolve_import_closure(
+        {contract: source},
+        (site_packages, project),
+    )
+
+    assert closure.dependencies == (dependency.resolve(),)
+    assert escaped.resolve() not in closure.files
+    with pytest.raises(ValueError):
+        dependency.resolve().relative_to(closure.common_root)
+    with target_overlay({contract: source}, "0.4.3", (site_packages, project)) as overlay:
+        assert overlay is not None
+        assert not any(
+            path.name == "dep.vy"
+            for path in overlay.root.rglob("*")
+            if path.is_file()
+        )
+
+
+def test_resolve_import_closure_create2_alias_resolves_to_real_file(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "src" / "factory.vy"
+    dependency = project / "snekmate" / "utils" / "create2_address.vy"
+    contract.parent.mkdir(parents=True)
+    dependency.parent.mkdir(parents=True)
+    source = "#pragma version 0.4.3\nfrom snekmate.utils import create2\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.4.0\n", encoding="utf-8")
+
+    closure = resolve_import_closure({contract: source}, (project,))
+
+    assert closure.dependencies == (dependency.resolve(),)
+    assert all(path.name != "create2.vy" for path in closure.files)
+
+
+def test_resolve_import_closure_is_idempotent(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+
+    first = resolve_import_closure(sources, search_paths)
+    second = resolve_import_closure(sources, search_paths)
+
+    assert first == second
+
+
+def test_resolve_import_closure_empty_sources_raises() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"^resolve_import_closure requires at least one source$",
+    ):
+        resolve_import_closure({})
+
+
+def test_materialize_target_overlay_writes_into_given_root(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    with target_overlay(sources, "0.4.3", search_paths) as temporary:
+        assert temporary is not None
+        expected_files = {
+            path.relative_to(temporary.root): path.read_bytes()
+            for path in temporary.root.rglob("*")
+            if path.is_file()
+        }
+
+    root = tmp_path / "materialized"
+    root.mkdir()
+    overlay = materialize_target_overlay(sources, "0.4.3", root, search_paths)
+
+    assert overlay is not None
+    assert overlay.root == root
+    assert all(path.is_relative_to(root) for path in overlay.paths.values())
+    assert {
+        path.relative_to(root): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    } == expected_files
+    assert root.exists()
+
+
+def test_materialize_target_overlay_output_root_under_project_root(tmp_path) -> None:
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
+        tmp_path
+    )
+    project = tmp_path / "project"
+    root = project / "overlay-output"
+
+    overlay = materialize_target_overlay(sources, "0.4.3", root, search_paths)
+
+    assert overlay is not None
+    assert list(root.rglob("pyproject.toml")) == [root / "pyproject.toml"]
+    assert (root / "pyproject.toml").read_bytes() == (
+        project / "pyproject.toml"
+    ).read_bytes()
+
+
+def test_materialize_target_overlay_empty_sources_returns_none(tmp_path) -> None:
+    root = tmp_path / "materialized"
+
+    assert materialize_target_overlay({}, "0.4.3", root) is None
+
 
 
 def test_target_overlay_rewrites_imported_vyper_pragmas(monkeypatch, tmp_path) -> None:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -930,6 +930,31 @@ def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
     assert closure.common_root == tmp_path / "project"
 
 
+@pytest.mark.parametrize(
+    "documentation",
+    [
+        '"""\nimport ghost\n"""\n',
+        'EXAMPLE: constant(String[32]) = """\nimport ghost\n"""\n',
+    ],
+)
+def test_resolve_import_closure_ignores_imports_in_strings(
+    tmp_path: Path, documentation: str
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "main.vy"
+    dependency = project / "real.vy"
+    ghost = project / "ghost.vy"
+    project.mkdir()
+    source = f"# @version 0.3.10\n{documentation}from . import real\n"
+    contract.write_text(source, encoding="utf-8")
+    dependency.write_text("# @version 0.3.10\n", encoding="utf-8")
+    ghost.write_text("not valid Vyper\n", encoding="utf-8")
+
+    closure = resolve_import_closure({contract: source}, (project,))
+
+    assert closure.dependencies == (dependency.resolve(),)
+
+
 def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> None:
     _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
         tmp_path

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from vyupgrade import engine
+from vyupgrade import compiler, engine
 from vyupgrade.compiler import CompileResult
 from vyupgrade.engine import MigrationRequest, SourceCompileAttempt
 from vyupgrade.models import Config, Diagnostic, Fix, GeneratedFile, RewriteResult
@@ -255,7 +255,10 @@ def test_generated_interface_and_cross_file_sources_share_one_overlay(
         return RewriteResult(source, [], [], generated)
 
     @contextmanager
-    def overlay(sources, target_version, search_paths):
+    def overlay(
+        sources, target_version, search_paths, *, include_dependencies=False
+    ):
+        assert include_dependencies is False
         overlay_sources.update(sources)
         yield overlay_token
 
@@ -396,3 +399,174 @@ def test_interface_validation_is_target_only(
 
     assert batch.files[0].report.source_compile == "skipped"
     assert decision.status == expected
+
+
+def test_prepare_migrations_skips_interface_split_for_dependencies(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "dependency.vy"
+    source = (
+        "#pragma version 0.3.10\n"
+        "interface Token:\n"
+        "    def balanceOf(owner: address) -> uint256: view\n"
+    )
+    request = MigrationRequest(
+        path,
+        source,
+        "0.3.10",
+        (SourceCompileAttempt("0.3.10", "0.3.10"),),
+        role="dependency",
+    )
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+
+    def unexpected_split(*_args):
+        raise AssertionError("dependency interface splitting must not run")
+
+    monkeypatch.setattr(engine, "split_interfaces_to_vyi", unexpected_split)
+
+    batch = engine.prepare_migrations(
+        (request,), _config(tmp_path, split_interfaces=True)
+    )
+
+    assert batch.files[0].report.role == "dependency"
+    assert batch.generated == []
+
+
+def test_validate_migrations_threads_closure_mode(
+    monkeypatch, tmp_path: Path
+) -> None:
+    project_root = tmp_path / "project"
+    project = project_root / "main.vy"
+    search_path = tmp_path / "site-packages"
+    dependency = search_path / "depkg" / "mod.vy"
+    dependency.parent.mkdir(parents=True)
+    project_root.mkdir()
+    (project_root / "pyproject.toml").write_text("[project]\nname='project'\n")
+    project_source = "#pragma version 0.4.3\nfrom depkg import mod\n"
+    dependency_source = "#pragma version 0.3.10\nVALUE: constant(uint256) = 1\n"
+    project.write_text(project_source)
+    dependency.write_text(dependency_source)
+    rewritten_dependency = dependency_source.replace("0.3.10", "0.4.3")
+    real_target_overlay = engine.target_overlay
+    observed_flags: list[bool] = []
+    observed_search_paths: dict[bool, tuple[Path, ...]] = {}
+
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+
+    def apply(source, config, path):
+        rewritten = rewritten_dependency if path == dependency else source
+        return RewriteResult(rewritten, [], [])
+
+    @contextmanager
+    def target_overlay(
+        sources,
+        target_version,
+        search_paths,
+        *,
+        include_dependencies=False,
+    ):
+        observed_flags.append(include_dependencies)
+        with real_target_overlay(
+            sources,
+            target_version,
+            search_paths,
+            include_dependencies=include_dependencies,
+        ) as overlay:
+            yield overlay
+
+    def compile_target(path, source, config, overlay):
+        assert overlay is not None
+        observed_search_paths[config.include_dependencies] = (
+            compiler._overlay_search_paths(overlay, config.compiler_search_paths)
+        )
+        if path == dependency:
+            target = overlay.paths[dependency.resolve()]
+            assert target == overlay.root / "depkg" / "mod.vy"
+            assert target.read_text() == rewritten_dependency
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    monkeypatch.setattr(engine, "apply_rules", apply)
+    monkeypatch.setattr(engine, "target_overlay", target_overlay)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target)
+    project_request = MigrationRequest(
+        project,
+        project_source,
+        "0.4.3",
+        (SourceCompileAttempt("0.4.3", "0.4.3"),),
+    )
+    dependency_request = MigrationRequest(
+        dependency,
+        dependency_source,
+        "0.3.10",
+        (SourceCompileAttempt("0.3.10", "0.3.10"),),
+        role="dependency",
+    )
+    closure_config = _config(
+        tmp_path,
+        compiler_search_paths=(search_path,),
+        include_dependencies=True,
+    )
+    default_config = _config(
+        tmp_path,
+        compiler_search_paths=(search_path,),
+    )
+
+    closure_batch = engine.prepare_migrations(
+        (project_request, dependency_request), closure_config
+    )
+    default_batch = engine.prepare_migrations((project_request,), default_config)
+    engine.validate_migrations(closure_batch, closure_config)
+    engine.validate_migrations(default_batch, default_config)
+
+    assert observed_flags == [True, False]
+    assert search_path.resolve() not in observed_search_paths[True]
+    assert search_path.resolve() in observed_search_paths[False]
+
+
+def test_dependency_source_final_newline_retry_handles_read_only_directory(
+    monkeypatch, tmp_path: Path
+) -> None:
+    dependency_directory = tmp_path / "site-packages" / "depkg"
+    dependency_directory.mkdir(parents=True)
+    dependency = dependency_directory / "mod.vy"
+    source = "#pragma version 0.3.10\nVALUE: constant(uint256) = 1"
+    dependency.write_text(source)
+    original_failure = CompileResult(
+        "failed",
+        stderr="ValueError: start (2, 0) precedes previous end",
+    )
+    request = MigrationRequest(
+        dependency,
+        source,
+        "0.3.10",
+        (SourceCompileAttempt("0.3.10", "0.3.10"),),
+        role="dependency",
+    )
+    original_entries = set(dependency_directory.iterdir())
+
+    monkeypatch.setattr(
+        compiler,
+        "_run_compile_with_formats",
+        lambda *_args, **_kwargs: original_failure,
+    )
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+
+    def deny_temporary_file(*_args, **_kwargs):
+        raise OSError("read-only dependency directory")
+
+    monkeypatch.setattr(compiler.tempfile, "NamedTemporaryFile", deny_temporary_file)
+
+    batch = engine.prepare_migrations((request,), _config(tmp_path))
+
+    assert batch.files[0].source_compile is original_failure
+    assert batch.files[0].report.source_compile == "failed"
+    assert set(dependency_directory.iterdir()) == original_entries

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,6 +7,7 @@ from rich.console import Console
 
 from vyupgrade import __version__
 from vyupgrade.models import (
+    ClosureReport,
     Diagnostic,
     FileReport,
     Fix,
@@ -54,9 +55,30 @@ def test_json_report_declares_additive_schema_version() -> None:
 
     data = report.to_json_obj()
 
-    assert data["schema_version"] == 1
+    assert data["schema_version"] == 2
     assert data["files"] == []
     assert data["target_version"] == "0.4.3"
+    assert data["closure"] is None
+
+
+def test_closure_summary_reports_upgraded_dependency_count() -> None:
+    report = RunReport(
+        source_version=None,
+        target_version="0.4.3",
+        files=[],
+        closure=ClosureReport(
+            requested=True,
+            dependencies=("/deps/a.vy", "/deps/b.json"),
+        ),
+    )
+    stream = StringIO()
+    console = Console(file=stream, no_color=True, width=120)
+
+    text = render_text(report)
+    render_rich(report, console)
+
+    assert "dependencies: 2 upgraded" in text
+    assert "dependencies: 2 upgraded" in stream.getvalue()
 
 
 def test_render_text_hides_stderr_for_successful_compiles() -> None:
@@ -315,3 +337,29 @@ def test_render_rich_splits_diagnostic_line_styles() -> None:
         "\x1b[32m modernized version pragma\x1b[0m"
         "\x1b[2m (line 2)\x1b[0m"
     ) in stream.getvalue()
+
+
+def test_closure_summary_omits_impossible_write_hint() -> None:
+    report = RunReport(
+        source_version=None,
+        target_version="0.4.3",
+        files=[
+            FileReport(
+                path=Path("/deps/changed.vy"),
+                role="dependency",
+                changed=True,
+            )
+        ],
+        closure=ClosureReport(
+            requested=True,
+            dependencies=("/deps/changed.vy",),
+        ),
+    )
+    stream = StringIO()
+    console = Console(file=stream, no_color=True, width=120)
+
+    text = render_text(report)
+    render_rich(report, console)
+
+    assert "run with --write" not in text
+    assert "run with --write" not in stream.getvalue()


### PR DESCRIPTION
_co-authored by claude opus 4.8_

This adds opt-in `--include-dependencies` (with `--upgrade-closure` as an alias) so resolved `.vy` and `.vyi` dependencies join the migration batch and are cross-validated against the upgraded closure. Dependency results participate in `--check`, `--diff`, and report schema v2, but dependency sources are never written in place. `--write` with closure upgrades is rejected until a closure destination is supplied, and import-layout conflicts are reported as usage errors.

**Stacked on:** `issue-23-overlay-closure-mode`. This is part of the stacked series implementing issue #23.

**Tests:** CLI and engine unit tests, real-compiler integration tests, and the full test suite are green.
