### PR TITLE
fix(rules): make math imports collision-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Reject source version specifications that match no compiler supported by the
+  current release instead of attempting an unvalidated target migration.
+- Made `sqrt`/`isqrt` math imports module-docstring-safe and collision-free by
+  reusing existing builtin imports or choosing a deterministic fresh alias.
 - Added a public import-closure primitive (resolve_import_closure) and a reusable overlay materializer, single-sourcing the validation dependency traversal.
 - Added opt-in closure-mode overlay materialization: the full import closure (including external search-path dependencies) can be materialized import-root-relative for dependency-closure upgrades.
 - Added opt-in `--include-dependencies` closure upgrading: the full import closure (including installed search-path dependencies) is rewritten and cross-validated in a closure-mode target overlay; JSON schema v2 adds file roles and a closure block; in-place dependency writes are structurally impossible.

--- a/src/vyupgrade/interfaces.py
+++ b/src/vyupgrade/interfaces.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .models import Fix, GeneratedFile
+from .rule_helpers import insert_import
 from .source import TextEdit, apply_edits, code_mask, find_matching, line_number, span_is_code
 
 
@@ -112,20 +113,9 @@ def _existing_imports(source: str) -> set[str]:
 
 
 def _insert_imports(source: str, imports: list[str]) -> str:
-    lines = source.splitlines(keepends=True)
-    insert_at = 0
-    while insert_at < len(lines) and (
-        lines[insert_at].startswith("#pragma")
-        or lines[insert_at].startswith("# @version")
-        or lines[insert_at].strip() == ""
-    ):
-        insert_at += 1
-    while insert_at < len(lines) and (
-        lines[insert_at].startswith("import ") or lines[insert_at].startswith("from ")
-    ):
-        insert_at += 1
-    lines[insert_at:insert_at] = imports
-    return "".join(lines)
+    for line in imports:
+        source = insert_import(source, line)
+    return source
 
 
 def _interface_body_to_vyi(body: str) -> str:

--- a/src/vyupgrade/rule_groups/numeric.py
+++ b/src/vyupgrade/rule_groups/numeric.py
@@ -20,6 +20,7 @@ from ..rule_registry import Rule, RuleContext, crossing
 from ..source import (
     TextEdit,
     apply_edits,
+    code_identifiers,
     code_mask,
     find_matching,
     line_number,
@@ -122,6 +123,15 @@ def _math_builtin(
     if _name_is_user_defined(facts, name) or _name_is_imported(source, name):
         return source, [], []
     mask = rule_context.code_mask
+    math_binding = _absolute_math_import_binding(source)
+    import_line: str | None = None
+    if math_binding is None:
+        math_binding = _fresh_math_binding(source)
+        import_line = (
+            "import math\n"
+            if math_binding == "math"
+            else f"import math as {math_binding}\n"
+        )
     edits: list[TextEdit] = []
     fixes: list[Fix] = []
     for match in re.finditer(rf"(?<!\.)\b{re.escape(name)}\s*\(", source):
@@ -130,7 +140,7 @@ def _math_builtin(
             continue
         if not span_is_code(mask, match.start(), match.end()):
             continue
-        after = f"math.{name}"
+        after = f"{math_binding}.{name}"
         edits.append(TextEdit(match.start(), match.start() + len(name), after))
         fixes.append(
             Fix(
@@ -142,10 +152,36 @@ def _math_builtin(
             )
         )
     next_source = apply_edits(source, edits)
-    if edits and not re.search(r"^\s*import\s+math\s*$", next_source, re.MULTILINE):
-        next_source = _insert_import(next_source, "import math\n")
-        fixes.append(Fix(rule, 1, "added math import", "", "import math"))
+    if edits and import_line is not None:
+        next_source = _insert_import(next_source, import_line)
+        fixes.append(Fix(rule, 1, "added math import", "", import_line.strip()))
     return next_source, fixes, []
+
+
+def _absolute_math_import_binding(source: str) -> str | None:
+    mask = code_mask(source)
+    pattern = re.compile(
+        r"^[ \t]*import[ \t]+math"
+        r"(?:[ \t]+as[ \t]+(?P<alias>[A-Za-z_][A-Za-z0-9_]*))?"
+        r"[ \t]*(?:#[^\n]*)?$",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(source):
+        if _line_match_starts_outside_string(source, mask, match.start()):
+            return match.group("alias") or "math"
+    return None
+
+
+def _fresh_math_binding(source: str) -> str:
+    identifiers = code_identifiers(source)
+    if "math" not in identifiers:
+        return "math"
+    binding = "builtin_math"
+    suffix = 2
+    while binding in identifiers:
+        binding = f"builtin_math_{suffix}"
+        suffix += 1
+    return binding
 
 
 def _bitwise(

--- a/src/vyupgrade/rule_helpers.py
+++ b/src/vyupgrade/rule_helpers.py
@@ -114,20 +114,44 @@ def is_keyword_argument_name(source: str, start: int, end: int) -> bool:
 
 def insert_import(source: str, line: str) -> str:
     lines = source.splitlines(keepends=True)
-    insert_at = 0
-    while insert_at < len(lines) and (
-        lines[insert_at].startswith("#pragma")
-        or lines[insert_at].startswith("# @version")
-        or lines[insert_at].strip() == ""
-        or lines[insert_at].startswith('"""')
-    ):
-        insert_at += 1
+    insert_at = _import_prelude_end(source, lines)
     while insert_at < len(lines) and lines[insert_at].startswith("import "):
         insert_at += 1
     while insert_at < len(lines) and lines[insert_at].startswith("from "):
         insert_at += 1
     lines.insert(insert_at, line)
     return "".join(lines)
+
+
+def _import_prelude_end(source: str, lines: list[str]) -> int:
+    offsets: list[int] = []
+    offset = 0
+    for current in lines:
+        offsets.append(offset)
+        offset += len(current)
+
+    insert_at = 0
+    while insert_at < len(lines):
+        stripped = lines[insert_at].strip()
+        if stripped and not stripped.startswith("#"):
+            break
+        insert_at += 1
+
+    if insert_at < len(lines):
+        line = lines[insert_at]
+        leading = len(line) - len(line.lstrip())
+        start = offsets[insert_at] + leading
+        if source.startswith(('"""', "'''"), start):
+            mask = code_mask(source)
+            end = start + 3
+            while end < len(source) and not mask[end]:
+                end += 1
+            while insert_at < len(lines) and offsets[insert_at] <= end:
+                insert_at += 1
+            while insert_at < len(lines) and not lines[insert_at].strip():
+                insert_at += 1
+
+    return insert_at
 
 
 def remove_constructor_decorators(

--- a/tests/rule_groups/test_legacy_interfaces.py
+++ b/tests/rule_groups/test_legacy_interfaces.py
@@ -91,6 +91,30 @@ def factoryAddress() -> address(Factory):
     assert "staticcall IERC20(self.token).balanceOf(self)" in result.source
 
 
+def test_legacy_interface_import_follows_module_docstring(config) -> None:
+    source = '''# @version 0.1.0b4
+"""
+@title Legacy token
+"""
+
+token: address(ERC20)
+'''
+
+    result = apply_rules(source, config(target_version="0.4.3"))
+
+    assert (
+        result.source
+        == '''#pragma version 0.4.3
+"""
+@title Legacy token
+"""
+
+from ethereum.ercs import IERC20
+token: address
+'''
+    )
+
+
 def test_legacy_interface_value_calls_rewrite_interface_payable(config) -> None:
     source = """# @version 0.1.0b4
 contract Exchange():

--- a/tests/rule_groups/test_numeric.py
+++ b/tests/rule_groups/test_numeric.py
@@ -17,6 +17,88 @@ def f(x: uint256) -> uint256:
     assert any(fix.rule == "VY101" for fix in result.fixes)
 
 
+def test_isqrt_math_import_follows_module_docstring(config) -> None:
+    source = '''#pragma version 0.4.3
+"""
+@title Example
+import math
+"""
+
+@external
+def f(x: uint256) -> uint256:
+    return isqrt(x)
+'''
+
+    result = apply_rules(source, config(target_version="0.5.0a1"))
+
+    assert (
+        result.source
+        == '''#pragma version 0.5.0a1
+"""
+@title Example
+import math
+"""
+
+import math
+@external
+def f(x: uint256) -> uint256:
+    return math.isqrt(x)
+'''
+    )
+
+
+def test_isqrt_uses_fresh_math_alias_when_math_is_already_bound(config) -> None:
+    source = '''#pragma version 0.4.3
+"""
+@title Example
+"""
+
+from . import dep_math as math
+
+@external
+def f(x: uint256) -> uint256:
+    return isqrt(x) + math._identity(0)
+'''
+
+    first = apply_rules(source, config(target_version="0.5.0a1"))
+    second = apply_rules(first.source, config(target_version="0.5.0a1"))
+
+    assert "import math as builtin_math\n" in first.source
+    assert "return builtin_math.isqrt(x) + math._identity(0)" in first.source
+    assert first.source == second.source
+
+
+def test_isqrt_reuses_existing_aliased_builtin_math_import(config) -> None:
+    source = """#pragma version 0.4.3
+import math as target_math
+
+@external
+def f(x: uint256) -> uint256:
+    return isqrt(x)
+"""
+
+    result = apply_rules(source, config(target_version="0.5.0a1"))
+
+    assert result.source.count("import math as target_math") == 1
+    assert "return target_math.isqrt(x)" in result.source
+
+
+def test_isqrt_math_alias_suffix_is_deterministic(config) -> None:
+    source = """#pragma version 0.4.3
+from . import dep_math as math
+builtin_math: constant(uint256) = 1
+
+@external
+def f(x: uint256) -> uint256:
+    return isqrt(x) + math._identity(builtin_math)
+"""
+
+    result = apply_rules(source, config(target_version="0.5.0a1"))
+
+    assert "import math as builtin_math_2\n" in result.source
+    assert "return builtin_math_2.isqrt(x) + math._identity(builtin_math)" in result.source
+
+
 def test_isqrt_does_not_rewrite_before_0_5_alpha_target(config) -> None:
     source = """#pragma version 0.4.3
 @external

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -579,6 +579,60 @@ def f(x: uint256) -> uint256:
     assert any(fix["rule"] == "VY101" for fix in file["fixes"])
 
 
+def test_alpha_isqrt_rewrite_avoids_existing_math_binding(tmp_path: Path) -> None:
+    dependency = tmp_path / "dep_math.vy"
+    dependency.write_text(
+        """# pragma version 0.4.1
+
+@internal
+@pure
+def _identity(x: uint256) -> uint256:
+    return x
+""",
+        encoding="utf-8",
+    )
+    contract = tmp_path / "Repro.vy"
+    contract.write_text(
+        '''# pragma version 0.4.1
+"""
+@title Minimal VY101 import collision
+"""
+
+from . import dep_math as math
+
+@external
+@pure
+def sqrt_plus_zero(x: uint256) -> uint256:
+    return isqrt(x) + math._identity(0)
+''',
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(contract),
+            "--check",
+            "--target-version",
+            "0.5.0a3",
+            "--compiler-search-paths",
+            str(tmp_path),
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 1
+    file = json.loads(report.read_text())["files"][0]
+    assert file["validation"]["target_compile"] == "passed"
+    assert file["validation"]["decision"]["status"] == "passed"
+    assert any(
+        fix["after"] == "builtin_math.isqrt"
+        for fix in file["fixes"]
+        if fix["rule"] == "VY101"
+    )
+
+
 def test_standalone_interface_receives_target_validation(tmp_path: Path) -> None:
     interface = tmp_path / "IToken.vyi"
     interface.write_text(

--- a/tests/test_interface_splitting.py
+++ b/tests/test_interface_splitting.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vyupgrade.interfaces import split_interfaces_to_vyi
+
+
+def test_split_interface_import_follows_module_docstring(tmp_path: Path) -> None:
+    source = '''#pragma version 0.4.3
+"""
+@title Example
+"""
+
+interface Token:
+    def balanceOf(owner: address) -> uint256: view
+
+@external
+def f(token: Token, owner: address) -> uint256:
+    return staticcall token.balanceOf(owner)
+'''
+
+    result = split_interfaces_to_vyi(source, tmp_path / "Main.vy")
+
+    assert result.source.startswith(
+        '''#pragma version 0.4.3
+"""
+@title Example
+"""
+
+import Token
+'''
+    )
+    assert result.generated[0].path == tmp_path / "Token.vyi"


### PR DESCRIPTION
Fixes issue #24 by placing generated imports after complete module docstrings, reusing existing builtin math imports, and selecting deterministic aliases when math is already bound. Extends the shared inserter to interface splitting. Validation: full Ruff suite, 840 pytest tests, real Vyper 0.5.0a3 reproduction, and wheel smoke test. Closes #24.