### PR TITLE
chore: prepare 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 - 2026-07-16
 
 - Reject source version specifications that match no compiler supported by the
   current release instead of attempting an unvalidated target migration.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,10 +123,12 @@ two otherwise identical legacy layouts that both omit it remain comparable,
 while their occupied span beyond the compiler-reported start slot is not
 independently provable.
 
-JSON reports use the existing top-level envelope with `schema_version: 1`.
-Within schema 1, fields may be added but existing fields are not renamed,
-removed, or type-changed. A missing version identifies the legacy unversioned
-format; incompatible changes require a new schema version.
+JSON reports use the existing top-level envelope with `schema_version: 2`.
+Schema 2 adds per-file roles and the top-level closure report while preserving
+the schema 1 fields. Within a schema version, fields may be added but existing
+fields are not renamed, removed, or type-changed. A missing version identifies
+the legacy unversioned format; incompatible changes require a new schema
+version.
 
 ## Rule model
 
@@ -296,4 +298,4 @@ Before tagging:
    ```
 
 The PyPI trusted publisher should be configured for repository
-`banteg/vyupgrade`, workflow `publish.yml`, and environment `pypi`.
+`vyperlang/vyupgrade`, workflow `publish.yml`, and environment `pypi`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "vyupgrade"
-version = "0.5.1"
+version = "0.6.0"
 description = "Compiler-backed tool for upgrading Vyper contracts."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,10 +23,10 @@ classifiers = [
 dependencies = ["packaging>=24.0", "rich>=13.0.0", "uv>=0.8.0"]
 
 [project.urls]
-Homepage = "https://github.com/banteg/vyupgrade"
-Repository = "https://github.com/banteg/vyupgrade"
-Issues = "https://github.com/banteg/vyupgrade/issues"
-Changelog = "https://github.com/banteg/vyupgrade/blob/master/CHANGELOG.md"
+Homepage = "https://github.com/vyperlang/vyupgrade"
+Repository = "https://github.com/vyperlang/vyupgrade"
+Issues = "https://github.com/vyperlang/vyupgrade/issues"
+Changelog = "https://github.com/vyperlang/vyupgrade/blob/master/CHANGELOG.md"
 
 [project.scripts]
 vyupgrade = "vyupgrade.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "vyupgrade"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
Prepare the 0.6.0 minor release: finalize the 2026-07-16 changelog, update project and lock versions, point package metadata at vyperlang/vyupgrade, and document report schema 2. Validation: full Ruff suite, 840 pytest tests, wheel smoke test, and distribution-aware release preflight.