### PR TITLE
feat: attest source compiler validation context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Made source validation use the complete declared project environment and
+  attest compiler resolution, dependency context, process start, typed failure
+  origin, and compiler-only output in JSON report schema v3. Removed
+  import-name dependency guessing and retry behavior.
+
 ## 0.6.0 - 2026-07-16
 
 - Reject source version specifications that match no compiler supported by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Unreleased
 
-- Made source validation use the complete declared project environment and
-  attest compiler resolution, dependency context, process start, typed failure
-  origin, and compiler-only output in JSON report schema v3. Removed
-  import-name dependency guessing and retry behavior.
+- Made source validation use the nearest declared project environment and
+  removed source-validation import guessing and retry behavior.
+- Replaced JSON report schema v3 with v4, which records producer identity and
+  distinct source and target attestations: the declared snapshot and compiler
+  declarations, compiler authority and executable/artifact identity, manifest,
+  lock, resolved packages and sources, process completion and exit status,
+  validated sources, exact compile attempt, typed failure origin, and compiler
+  output on failure.
 
 ## 0.6.0 - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ Paths may be files or directories; directories are searched recursively for
 `#pragma version` (or legacy `# @version`) line. Pass `--source-version` to
 override the inference for files that have no pragma.
 
-For broad source pragmas, rule gating uses the oldest satisfying compiler so
-historical migrations still run, while source validation uses the newest
-satisfying compiler no newer than the requested target.
+Rule gating for broad source pragmas uses the oldest satisfying compiler so
+historical migrations still run. Unless `--source-vyper` overrides discovery,
+source-validation authority is the nearest project's declared Vyper resolution
+(including its lock), then an exact pragma, then the newest known compiler that
+satisfies a ranged pragma without exceeding the requested target. Ranged
+selection never inspects source syntax.
 
 ### How it validates
 
@@ -67,12 +70,13 @@ available, and ABI, method identifiers, and storage layout compare equal. This
 write decision is independent of diagnostic selection and rule version gating.
 Standalone `.vyi` inputs are target-compiled through a generated import harness.
 
-Compiler subprocesses run through the bundled `uv`, using
-`uv run --no-project --with vyper==<version>` so each side gets the exact
-compiler it needs instead of inheriting an incompatible interpreter. When a file
-belongs to another project, the nearest `pyproject.toml` is read and any
-declared packages matching its Vyper imports (such as `snekmate`) are added to
-the compiler environment.
+Compiler subprocesses run through the bundled `uv`. Files in a project use the
+complete nearest declared environment via `uv run --isolated --project`,
+including all dependency groups and extras; an existing `uv.lock` is enforced
+with `--frozen`. An unlocked project is mirrored into a temporary root so
+resolution cannot create a lockfile in the source tree. Files without a project
+use an isolated `uv run --no-project --with vyper==<version>` environment.
+Dependencies are never guessed from imports or compiler errors.
 
 For `0.1.0b*` source compilers, `vyupgrade` runs the compiler through a
 `typed-ast` compatibility wrapper so the legacy compiler sees pre-Python-3.8
@@ -98,11 +102,10 @@ Reports distinguish original, validated candidate, and final on-disk hashes. If 
 post-write test command changes a planned file, the run exits nonzero and records the
 drift.
 
-Dependency inference is intentionally conservative. Exact requirements,
-ordinary version ranges, and Git dependencies are supported. Project-specific
-specifier syntaxes that cannot be translated to a compiler environment, such as
-Poetry caret requirements, are skipped; use `--compiler-search-paths`,
-`--source-vyper`, or `--target-vyper` for unusual layouts.
+Source-validation evidence records the declared spec, actual resolved compiler,
+dependency context, whether the compiler started, a typed failure origin, and
+the compiler process output. `compiler_output` contains only compiler stdout and
+stderr; environment-manager or adapter diagnostics remain separate.
 
 ## Options
 
@@ -130,11 +133,13 @@ Poetry caret requirements, are skipped; use `--compiler-search-paths`,
 - `--allow-storage-layout-change` — write despite a storage-layout comparison mismatch.
 - `--config PATH` — read configuration from a specific `pyproject.toml`.
 
-JSON reports include a top-level `schema_version`. Version `2` adds a per-file
-`role` and a top-level `closure` object; version `1` consumers must not assume
-their absence. Consumers should treat a missing version as the legacy
-unversioned format and require a new schema version before relying on renamed,
-removed, or type-changed fields.
+JSON reports include a top-level `schema_version`. Version `3` adds per-file
+source-validation evidence: `declared_spec`, `resolved_compiler`,
+`dependency_context`, `compiler_started`, `failure_origin`, and
+`compiler_output`. Version `2` added a per-file `role` and a top-level `closure`
+object. Consumers should treat a missing version as the legacy unversioned
+format and require a new schema version before relying on renamed, removed, or
+type-changed fields.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -133,13 +133,16 @@ stderr; environment-manager or adapter diagnostics remain separate.
 - `--allow-storage-layout-change` — write despite a storage-layout comparison mismatch.
 - `--config PATH` — read configuration from a specific `pyproject.toml`.
 
-JSON reports include a top-level `schema_version`. Version `3` adds per-file
-source-validation evidence: `declared_spec`, `resolved_compiler`,
-`dependency_context`, `compiler_started`, `failure_origin`, and
-`compiler_output`. Version `2` added a per-file `role` and a top-level `closure`
-object. Consumers should treat a missing version as the legacy unversioned
-format and require a new schema version before relying on renamed, removed, or
-type-changed fields.
+JSON reports include a top-level `schema_version`. Version `4` provides producer
+identity plus separate source and target validation attestations. Each
+attestation records the declared source snapshot and compiler declarations,
+compiler authority and identity, dependency context, process completion and
+exit status, validated sources, the exact compile attempt, typed failure origin,
+and compiler output when validation fails. Version `2` added a per-file `role`
+and a top-level `closure` object; version `3` first introduced source-validation
+evidence and is superseded by version `4`. Consumers should treat a missing
+version as the legacy unversioned format and require a new schema version before
+relying on renamed, removed, or type-changed fields.
 
 ### Configuration
 

--- a/scripts/corpus.py
+++ b/scripts/corpus.py
@@ -23,7 +23,6 @@ from vyupgrade.engine import MigrationRequest, SourceCompileAttempt
 from vyupgrade.models import Config, FileReport
 from vyupgrade.versions import (
     KNOWN_VERSIONS,
-    compiler_version_for_source,
     compiler_version_for_spec,
     infer_pragma,
     is_supported_source_version,
@@ -881,7 +880,8 @@ def _import_vyper_2026_inventory_standard_json(
                 "pragma": source_spec,
                 "source_pragma": infer_pragma(source_text),
                 "source_compiler": compiler_version_for_spec(source_spec),
-                "compiler_version": payload.get("compiler_version") or metadata.get("compiler_version"),
+                "compiler_version": payload.get("compiler_version")
+                or metadata.get("compiler_version"),
                 "sha256": _source_hash(source_text),
                 "compiler_search_paths": [str(path) for path in compiler_search_paths],
                 "standard_json": str(source_path),
@@ -1411,12 +1411,8 @@ def _smoke_one(item: dict[str, Any], target_version: str) -> dict[str, Any]:
             "method_ids_equal": report.method_ids_equal,
             "storage_layout_equal": report.storage_layout_equal,
             "validation_status": validation.status,
-            "validation_blockers": [
-                issue.to_json_obj() for issue in validation.blockers
-            ],
-            "validation_waivers": [
-                issue.to_json_obj() for issue in validation.waivers
-            ],
+            "validation_blockers": [issue.to_json_obj() for issue in validation.blockers],
+            "validation_waivers": [issue.to_json_obj() for issue in validation.waivers],
             **artifact_details,
             "seconds": round(time.time() - started, 3),
         }
@@ -1473,13 +1469,9 @@ def _smoke_summary(
         for code in _validation_issue_codes(item.get("validation_blockers"))
     )
     validation_waivers = Counter(
-        code
-        for item in results
-        for code in _validation_issue_codes(item.get("validation_waivers"))
+        code for item in results for code in _validation_issue_codes(item.get("validation_waivers"))
     )
-    failed_repos = Counter(
-        item["repo"] for item in results if _is_smoke_safety_failure(item)
-    )
+    failed_repos = Counter(item["repo"] for item in results if _is_smoke_safety_failure(item))
     source_errors = Counter(
         item.get("source_error")
         for item in results
@@ -1553,9 +1545,7 @@ def _validation_issue_codes(value: object) -> list[str]:
     return [
         code
         for issue in value
-        if isinstance(issue, dict)
-        and isinstance((code := issue.get("code")), str)
-        and code
+        if isinstance(issue, dict) and isinstance((code := issue.get("code")), str) and code
     ]
 
 
@@ -1654,8 +1644,7 @@ def _load_smoke_checkpoint(
 
 def _result_matches_item(result: dict[str, Any], item: dict[str, Any]) -> bool:
     return all(
-        (result_key := "source_compiler_hint" if key == "source_compiler" else key)
-        in result
+        (result_key := "source_compiler_hint" if key == "source_compiler" else key) in result
         and result[result_key] == value
         for key, value in item.items()
     )
@@ -1667,8 +1656,7 @@ def _write_smoke_checkpoint(
     identity: dict[str, Any],
 ) -> None:
     versioned_results = [
-        {**result, "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION}
-        for result in results
+        {**result, "smoke_schema_version": SMOKE_RESULT_SCHEMA_VERSION} for result in results
     ]
     _atomic_write_json(output_path, versioned_results)
     _atomic_write_json(
@@ -1698,9 +1686,7 @@ def _atomic_write_json(path: Path, value: Any) -> None:
         destination_mode = stat.S_IMODE(path.stat().st_mode)
     except FileNotFoundError:
         destination_mode = None
-    temporary_path = path.with_name(
-        f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
-    )
+    temporary_path = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     descriptor = os.open(
         temporary_path,
         os.O_WRONLY | os.O_CREAT | os.O_EXCL,
@@ -1914,7 +1900,7 @@ def _item_source_version(item: dict[str, Any]) -> str | None:
         source = ""
     pragma = _item_source_spec(item, source)
     if pragma is not None:
-        return compiler_version_for_source(pragma, source)
+        return compiler_version_for_spec(pragma)
     return _normalized_source_compiler(item.get("source_compiler"))
 
 
@@ -1977,12 +1963,15 @@ def _normalized_source_compiler(value: object) -> str | None:
 
 
 def _has_exact_source_compiler(item: dict[str, Any]) -> bool:
-    return bool(item.get("standard_json")) and _normalized_source_compiler(
-        item.get("compiler_version")
-    ) is not None
+    return (
+        bool(item.get("standard_json"))
+        and _normalized_source_compiler(item.get("compiler_version")) is not None
+    )
 
 
-def _standard_json_compiler_search_paths(payload: dict[str, Any], package_root: Path) -> tuple[Path, ...]:
+def _standard_json_compiler_search_paths(
+    payload: dict[str, Any], package_root: Path
+) -> tuple[Path, ...]:
     settings = payload.get("settings")
     if not isinstance(settings, dict):
         return ()

--- a/src/vyupgrade/cli.py
+++ b/src/vyupgrade/cli.py
@@ -65,8 +65,7 @@ def main(argv: list[str] | None = None) -> int:
         format=args.format or pyproject.get("format", "none"),
         allow_unvalidated_source=args.allow_unvalidated_source
         or bool(pyproject.get("allow-unvalidated-source", False)),
-        allow_abi_change=args.allow_abi_change
-        or bool(pyproject.get("allow-abi-change", False)),
+        allow_abi_change=args.allow_abi_change or bool(pyproject.get("allow-abi-change", False)),
         allow_method_id_change=args.allow_method_id_change
         or bool(pyproject.get("allow-method-id-change", False)),
         allow_storage_layout_change=args.allow_storage_layout_change
@@ -94,8 +93,7 @@ def main(argv: list[str] | None = None) -> int:
         and not (config.closure_output or config.closure_archive)
     ):
         print(
-            "--write with --include-dependencies requires "
-            "--closure-output or --closure-archive",
+            "--write with --include-dependencies requires --closure-output or --closure-archive",
             file=sys.stderr,
         )
         return 4
@@ -111,18 +109,14 @@ def main(argv: list[str] | None = None) -> int:
 
     files = discover_files(
         config.paths,
-        excluded_roots=(config.closure_output,)
-        if config.closure_output is not None
-        else (),
+        excluded_roots=(config.closure_output,) if config.closure_output is not None else (),
     )
     human_reporter = None if config.diff else HumanReporter(sys.stdout)
     if human_reporter:
         human_reporter.start(config.source_version, config.target_version)
 
     requests = [
-        engine.bounded_migration_request(
-            path, path.read_bytes().decode("utf-8"), config
-        )
+        engine.bounded_migration_request(path, path.read_bytes().decode("utf-8"), config)
         for path in files
     ]
     archive_entry: Path | None = None
@@ -132,21 +126,15 @@ def main(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             print(str(exc), file=sys.stderr)
             return 4
-    closure_report = (
-        ClosureReport(requested=True) if config.include_dependencies else None
-    )
+    closure_report = ClosureReport(requested=True) if config.include_dependencies else None
     if closure_report is not None and requests:
         dependency_requests, closure = _dependency_requests(requests, config)
         requests += dependency_requests
-        closure_report.dependencies = tuple(
-            str(path) for path in sorted(closure.dependencies)
-        )
+        closure_report.dependencies = tuple(str(path) for path in sorted(closure.dependencies))
     batch = engine.prepare_migrations(requests, config)
     reports, plan, plan_error = _build_migration_plan(batch)
     if plan_error is None:
-        validation_decision = _validate_or_layout_conflict(
-            batch, config, plan.candidate_source
-        )
+        validation_decision = _validate_or_layout_conflict(batch, config, plan.candidate_source)
         if validation_decision is None:
             return 4
     else:
@@ -177,21 +165,14 @@ def main(argv: list[str] | None = None) -> int:
                 run_report.validation_decision = validation_decision
                 if not validation_decision.write_allowed:
                     run_report.write_status = "blocked"
-                    run_report.write_output = (
-                        "formatted candidates did not pass final validation"
-                    )
+                    run_report.write_output = "formatted candidates did not pass final validation"
             else:
                 run_report.write_status = "failed"
                 run_report.write_output = "formatter failed before the write transaction"
-        if (
-            run_report.formatter_status != "failed"
-            and validation_decision.write_allowed
-        ):
+        if run_report.formatter_status != "failed" and validation_decision.write_allowed:
             try:
                 run_report.wrote_changes = plan.commit()
-                run_report.write_status = (
-                    "committed" if run_report.wrote_changes else "no-op"
-                )
+                run_report.write_status = "committed" if run_report.wrote_changes else "no-op"
                 run_report.wrote_changes, _mismatches = plan.refresh_final_state()
             except WriteTransactionError as exc:
                 changed, mismatches = plan.refresh_final_state()
@@ -201,8 +182,9 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 run_report.write_output = str(exc)
                 if mismatches:
-                    run_report.write_output += "; on-disk bytes differ from candidates: " + ", ".join(
-                        str(path) for path in mismatches
+                    run_report.write_output += (
+                        "; on-disk bytes differ from candidates: "
+                        + ", ".join(str(path) for path in mismatches)
                     )
 
     if config.include_dependencies and (
@@ -228,9 +210,7 @@ def main(argv: list[str] | None = None) -> int:
                 _emit_closure_output(config, batch, plan, run_report)
             if config.closure_archive is not None:
                 assert archive_entry is not None
-                _emit_closure_archive(
-                    config, archive_entry, batch, plan, run_report
-                )
+                _emit_closure_archive(config, archive_entry, batch, plan, run_report)
 
     diff_chunks = plan.diff_chunks()
     if config.include_dependencies:
@@ -283,12 +263,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if any(diag.severity == "error" for file in reports for diag in file.diagnostics):
         return 5
-    if (
-        run_report.closure is not None
-        and (
-            run_report.closure.output_status == "blocked"
-            or run_report.closure.archive_status == "blocked"
-        )
+    if run_report.closure is not None and (
+        run_report.closure.output_status == "blocked"
+        or run_report.closure.archive_status == "blocked"
     ):
         return 9
     return 0
@@ -308,9 +285,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--select", default="")
     parser.add_argument("--ignore", default="")
     parser.add_argument("--aggressive", action="store_true")
-    parser.add_argument(
-        "--include-dependencies", "--upgrade-closure", action="store_true"
-    )
+    parser.add_argument("--include-dependencies", "--upgrade-closure", action="store_true")
     parser.add_argument("--test-command")
     parser.add_argument("--source-vyper")
     parser.add_argument("--target-vyper")
@@ -391,10 +366,7 @@ def _dependency_requests(
 def _dependency_diff_chunks(batch: engine.MigrationBatch) -> list[str]:
     chunks: list[str] = []
     for migration in batch.files:
-        if (
-            migration.request.role != "dependency"
-            or migration.original == migration.rewrite.source
-        ):
+        if migration.request.role != "dependency" or migration.original == migration.rewrite.source:
             continue
         chunks.extend(
             difflib.unified_diff(
@@ -447,10 +419,7 @@ def _emit_closure_archive(
 
 
 def _closure_files_validated(reports: list[FileReport]) -> bool:
-    return all(
-        report.validation_decision.status in {"passed", "waived"}
-        for report in reports
-    )
+    return all(report.validation_decision.status in {"passed", "waived"} for report in reports)
 
 
 def _validate_or_layout_conflict(
@@ -587,8 +556,7 @@ def _run_mamushi(plan: MigrationPlan, report: RunReport) -> None:
 
         try:
             formatted = {
-                destination: staged_path.read_bytes()
-                for destination, staged_path in staged.items()
+                destination: staged_path.read_bytes() for destination, staged_path in staged.items()
             }
             for candidate in formatted.values():
                 candidate.decode("utf-8")
@@ -629,9 +597,7 @@ def _run_test_command(command: str, report: RunReport) -> None:
         report.test_output = output or None
     else:
         report.test_output = "\n".join(
-            part
-            for part in (f"test command exited with status {proc.returncode}", output)
-            if part
+            part for part in (f"test command exited with status {proc.returncode}", output) if part
         )
 
 

--- a/src/vyupgrade/closure.py
+++ b/src/vyupgrade/closure.py
@@ -46,9 +46,7 @@ def write_closure_output(
                 (),
                 "refusing to write the closure into a directory that contains migration sources",
             )
-        relative_files = _closure_relative_files(
-            sources, target_version, search_paths
-        )
+        relative_files = _closure_relative_files(sources, target_version, search_paths)
         linked = _linked_output_path(resolved, relative_files)
         if linked is not None:
             return ClosureWriteResult(
@@ -66,9 +64,7 @@ def write_closure_output(
             include_dependencies=True,
         )
         assert overlay is not None
-        return ClosureWriteResult(
-            "written", resolved, tuple(sorted(set(overlay.paths.values())))
-        )
+        return ClosureWriteResult("written", resolved, tuple(sorted(set(overlay.paths.values()))))
     except (compiler.OverlayLayoutConflictError, OSError) as exc:
         return ClosureWriteResult("failed", resolved, (), str(exc))
 
@@ -89,9 +85,7 @@ def write_closure_archive(
                 (),
                 f"archive entry is missing from closure sources: {entry}",
             )
-        members = compiler.resolve_import_closure(
-            sources, config.compiler_search_paths
-        ).files
+        members = compiler.resolve_import_closure(sources, config.compiler_search_paths).files
         if resolved in members:
             return ClosureWriteResult(
                 "failed",
@@ -131,11 +125,7 @@ def _closure_relative_files(
             include_dependencies=True,
         )
         assert overlay is not None
-        return tuple(
-            path.relative_to(root)
-            for path in root.rglob("*")
-            if path.is_file()
-        )
+        return tuple(path.relative_to(root) for path in root.rglob("*") if path.is_file())
 
 
 def _linked_output_path(root: Path, relative_files: tuple[Path, ...]) -> Path | None:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -6,17 +6,19 @@ import re
 import shutil
 import subprocess
 import tempfile
+import sys
 import tomllib
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, replace
 from functools import cache
 from pathlib import Path
+from typing import cast
 from uuid import uuid4
 
 from uv import find_uv_bin
 
-from .models import Config
+from .models import CompilerOutput, Config, DependencyContext, FailureOrigin
 from .source import code_mask
 from .storage_layout import compare_storage_layouts, parse_storage_layout
 from .versions import (
@@ -33,9 +35,6 @@ SOURCE_FORMATS = ("abi", "method_identifiers", "layout", "ast")
 TARGET_FORMATS = (*FORMATS, "ast")
 COMPILE_TIMEOUT_SECONDS = 120
 ARCHIVE_TARGET_FLOOR = "0.4.0"
-COMMON_IMPORT_DEPENDENCIES = {
-    "snekmate": "snekmate",
-}
 OVERLAY_EXCLUDED_PARTS = {
     ".git",
     ".hg",
@@ -57,6 +56,7 @@ VALIDATION_MODULE_ALIASES = {
     "create2": "create2_address",
 }
 
+
 class OverlayLayoutConflictError(ValueError):
     """Two closure members with different content map to one overlay path."""
 
@@ -68,6 +68,24 @@ class CompileResult:
     stderr: str | None = None
     command: list[str] | None = None
     unavailable_formats: tuple[str, ...] = ()
+    resolved_compiler: str | None = None
+    dependency_context: DependencyContext | None = None
+    compiler_started: bool = False
+    failure_origin: FailureOrigin | None = None
+    compiler_output: CompilerOutput | None = None
+
+
+@dataclass(frozen=True)
+class _CompilerProcess:
+    command: list[str]
+    context: DependencyContext
+    returncode: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    resolved_compiler: str | None = None
+    compiler_started: bool = False
+    failure_origin: FailureOrigin | None = None
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -76,6 +94,7 @@ class TargetOverlay:
     paths: Mapping[Path, Path]
     source_roots: tuple[Path, ...]
     search_paths: tuple[Path, ...]
+
 
 @dataclass(frozen=True)
 class ImportClosure:
@@ -103,11 +122,7 @@ def unavailable_validation_artifacts(result: CompileResult) -> list[str]:
         "method_identifiers": _valid_method_identifiers_artifact,
         "layout": _valid_layout_artifact,
     }
-    return [
-        name
-        for name, validator in validators.items()
-        if not validator(artifacts.get(name))
-    ]
+    return [name for name, validator in validators.items() if not validator(artifacts.get(name))]
 
 
 def _valid_abi_artifact(value: object) -> bool:
@@ -171,6 +186,7 @@ def compile_source_file(path: Path, config: Config, source_version: str | None) 
         (),
         suppress_warnings,
         allow_unsupported_formats=True,
+        project_compiler=True,
     )
     if _should_retry_source_with_final_newline(path, result):
         return _compile_source_file_with_final_newline(
@@ -214,6 +230,7 @@ def _compile_source_file_with_final_newline(
             (),
             suppress_warnings,
             allow_unsupported_formats=True,
+            project_compiler=True,
         )
     finally:
         with suppress(OSError):
@@ -257,6 +274,7 @@ def compile_target_source(
                     compile_config,
                     (),
                     suppress_warnings,
+                    environment_path=path,
                 )
             return _run_compile(
                 command,
@@ -264,6 +282,7 @@ def compile_target_source(
                 compile_config,
                 extra_paths=(),
                 suppress_warnings=suppress_warnings,
+                environment_path=path,
             )
     command, suppress_warnings = _prepare_command(
         config.target_vyper, config.target_version, config.target_python
@@ -277,6 +296,7 @@ def compile_target_source(
             compile_config,
             (path.parent,),
             suppress_warnings,
+            environment_path=path,
         )
     try:
         tmp = tempfile.NamedTemporaryFile(
@@ -305,6 +325,7 @@ def compile_target_source(
             compile_config,
             extra_paths=(path.parent,),
             suppress_warnings=suppress_warnings,
+            environment_path=path,
         )
     finally:
         tmp_path.unlink(missing_ok=True)
@@ -317,6 +338,8 @@ def _compile_target_interface(
     config: Config,
     extra_paths: tuple[Path, ...],
     suppress_warnings: bool,
+    *,
+    environment_path: Path,
 ) -> CompileResult:
     try:
         interface_file = tempfile.NamedTemporaryFile(
@@ -350,13 +373,13 @@ def _compile_target_interface(
                 f"#pragma version {config.target_version}\n"
                 f"import {interface_path.stem} as InterfaceUnderTest\n"
             )
-        interface_command = _with_project_import_dependencies(command, interface_path)
         return _run_compile(
-            interface_command,
+            command,
             harness_path,
             config,
             extra_paths=tuple(dict.fromkeys((path.parent, *extra_paths))),
             suppress_warnings=suppress_warnings,
+            environment_path=environment_path,
         )
     except OSError as exc:
         return CompileResult(
@@ -387,15 +410,11 @@ def compile_target_archive(
     compile_config = _target_compile_config(source, config)
     compile_config = replace(
         compile_config,
-        compiler_search_paths=_overlay_search_paths(
-            overlay, compile_config.compiler_search_paths
-        ),
+        compiler_search_paths=_overlay_search_paths(overlay, compile_config.compiler_search_paths),
     )
-    tmp_out = output.with_name(
-        f".{output.name}.vyupgrade-{os.getpid()}-{uuid4().hex}"
-    )
+    tmp_out = output.with_name(f".{output.name}.vyupgrade-{os.getpid()}-{uuid4().hex}")
     full = [
-        *_with_project_import_dependencies(command, staged),
+        *command,
         "-f",
         "archive",
         "-o",
@@ -409,38 +428,36 @@ def compile_target_archive(
     full.append(str(staged.relative_to(overlay.root)))
 
     try:
-        try:
-            proc = subprocess.run(
-                full,
-                cwd=overlay.root,
-                capture_output=True,
-                text=True,
-                timeout=COMPILE_TIMEOUT_SECONDS,
+        process = _run_compiler_process(
+            full,
+            path,
+            project_compiler=False,
+            cwd=overlay.root,
+        )
+        if process.returncode is None:
+            return _failed_compile_result(
+                process,
+                process.error or "compiler process did not return a result",
             )
-        except subprocess.TimeoutExpired:
-            return CompileResult(
-                "failed",
-                stderr=f"compiler timed out after {COMPILE_TIMEOUT_SECONDS} seconds",
-                command=full,
-            )
-        if proc.returncode != 0:
-            return CompileResult(
-                "failed",
-                stderr=proc.stderr.strip() or proc.stdout.strip(),
-                command=full,
+        if process.returncode != 0:
+            return _failed_compile_result(
+                process,
+                process.stderr.strip() or process.stdout.strip(),
             )
         if not tmp_out.is_file():
-            return CompileResult(
-                "failed",
-                stderr="target compiler did not produce archive output",
-                command=full,
+            return _failed_compile_result(
+                replace(process, failure_origin="adapter"),
+                "target compiler did not produce archive output",
             )
         os.replace(tmp_out, output)
         return CompileResult(
             "passed",
             artifacts={"archive": str(output)},
-            stderr=proc.stderr.strip() or None,
-            command=full,
+            stderr=process.stderr.strip() or None,
+            command=process.command,
+            resolved_compiler=process.resolved_compiler,
+            dependency_context=process.context,
+            compiler_started=process.compiler_started,
         )
     finally:
         tmp_out.unlink(missing_ok=True)
@@ -458,9 +475,7 @@ def resolve_import_closure(
     resolved_sources = {path.resolve(): source for path, source in sources.items()}
     if not resolved_sources:
         raise ValueError("resolve_import_closure requires at least one source")
-    source_roots, import_roots, common_root = _overlay_roots(
-        resolved_sources, search_paths
-    )
+    source_roots, import_roots, common_root = _overlay_roots(resolved_sources, search_paths)
     dependencies = [
         path
         for path, _source, _import_root, is_override in _walk_validation_closure(
@@ -537,9 +552,7 @@ def materialize_target_overlay(
                 None,
             )
             overlay_search_paths.update(copied_search_paths)
-        overlay_search_paths.update(
-            _overlay_configured_search_paths(search_paths, common, root)
-        )
+        overlay_search_paths.update(_overlay_configured_search_paths(search_paths, common, root))
         for path, source in resolved_sources.items():
             target = destination(path)
             if target is None:
@@ -549,9 +562,7 @@ def materialize_target_overlay(
             paths[path] = target
             overlay_search_paths.add(target.parent)
     if include_dependencies:
-        configured_search_paths = tuple(
-            search_path.resolve() for search_path in search_paths
-        )
+        configured_search_paths = tuple(search_path.resolve() for search_path in search_paths)
         for source_root in roots:
             if source_root not in configured_search_paths:
                 _copy_project_configs(
@@ -619,9 +630,7 @@ def _overlay_roots(
 ) -> tuple[tuple[Path, ...], tuple[Path, ...], Path]:
     roots = tuple(
         dict.fromkeys(
-            root
-            for path in resolved_sources
-            for root in _validation_roots(path, search_paths)
+            root for path in resolved_sources for root in _validation_roots(path, search_paths)
         )
     )
     import_roots = tuple(
@@ -661,6 +670,7 @@ def _claim_overlay_destination(
     raise OverlayLayoutConflictError(
         f"overlay destination {target} maps both {existing_source} and {source_path}"
     )
+
 
 def _overlay_configured_search_paths(
     search_paths: tuple[Path, ...], common_root: Path, target_root: Path
@@ -729,9 +739,7 @@ def _walk_validation_closure(
     override_paths = set(overrides)
     incoming_overrides: set[Path] = set()
     for path, source in overrides.items():
-        import_source = _standard_json_package_dependency_source(
-            path, source, common_root
-        )
+        import_source = _standard_json_package_dependency_source(path, source, common_root)
         for source_root in _containing_import_roots(path, source_roots):
             relative_path = path.relative_to(source_root)
             incoming_overrides.update(
@@ -782,13 +790,9 @@ def _walk_validation_closure(
             is_override,
         ) = queue.pop(0)
         existing_relative = layouts.get(current)
-        if (
-            existing_relative is not None
-            and existing_relative != current_relative
-        ):
+        if existing_relative is not None and existing_relative != current_relative:
             raise OverlayLayoutConflictError(
-                f"closure member {current} maps to both "
-                f"{existing_relative} and {current_relative}"
+                f"closure member {current} maps to both {existing_relative} and {current_relative}"
             )
         layouts[current] = current_relative
         if current in processed:
@@ -830,9 +834,7 @@ def _walk_validation_closure(
             )
 
 
-def _containing_import_roots(
-    path: Path, import_roots: tuple[Path, ...]
-) -> tuple[Path, ...]:
+def _containing_import_roots(path: Path, import_roots: tuple[Path, ...]) -> tuple[Path, ...]:
     roots = tuple(root for root in import_roots if _is_relative_to(path, root))
     assert roots, f"closure member is outside import roots: {path}"
     return tuple(sorted(roots, key=lambda root: len(root.parts)))
@@ -925,23 +927,17 @@ def _copy_validation_source(
         return
     target.parent.mkdir(parents=True, exist_ok=True)
     if source_path.suffix == ".json":
-        if placed is None or _claim_overlay_destination(
-            placed, target, source_path, source
-        ):
+        if placed is None or _claim_overlay_destination(placed, target, source_path, source):
             target.write_text(source, encoding="utf-8")
         search_paths.add(target.parent)
         return
-    source = _standard_json_package_dependency_source(
-        source_path, source, common_root
-    )
+    source = _standard_json_package_dependency_source(source_path, source, common_root)
     content = _target_validation_source(
         source,
         target_version,
         is_interface=source_path.suffix == ".vyi",
     )
-    if placed is None or _claim_overlay_destination(
-        placed, target, source_path, content
-    ):
+    if placed is None or _claim_overlay_destination(placed, target, source_path, content):
         target.write_text(content, encoding="utf-8")
     search_paths.add(target.parent)
     if source_path.name == "create2_address.vy":
@@ -951,13 +947,13 @@ def _copy_validation_source(
             target_version,
             is_interface=False,
         )
-        if placed is None or _claim_overlay_destination(
-            placed, alias, source_path, alias_content
-        ):
+        if placed is None or _claim_overlay_destination(placed, alias, source_path, alias_content):
             alias.write_text(alias_content, encoding="utf-8")
 
 
-def _standard_json_package_dependency_source(source_path: Path, source: str, common_root: Path) -> str:
+def _standard_json_package_dependency_source(
+    source_path: Path, source: str, common_root: Path
+) -> str:
     source = _local_sibling_import_source(source_path, source)
     if source_path.parent.name != "src":
         return source
@@ -1069,11 +1065,7 @@ def _resolve_validation_import(
     candidates: list[tuple[Path, Path, Path]] = []
     for base, import_root, relative_base in bases:
         module_path = base.joinpath(*module_parts) if module_parts else base
-        relative_module = (
-            relative_base.joinpath(*module_parts)
-            if module_parts
-            else relative_base
-        )
+        relative_module = relative_base.joinpath(*module_parts) if module_parts else relative_base
         if names:
             for name in names:
                 candidates.extend(
@@ -1084,15 +1076,11 @@ def _resolve_validation_import(
                     )
                 )
             candidates.extend(
-                _validation_module_candidate_layouts(
-                    module_path, relative_module, import_root
-                )
+                _validation_module_candidate_layouts(module_path, relative_module, import_root)
             )
         else:
             candidates.extend(
-                _validation_module_candidate_layouts(
-                    module_path, relative_module, import_root
-                )
+                _validation_module_candidate_layouts(module_path, relative_module, import_root)
             )
     resolved: dict[Path, tuple[Path, Path]] = {}
     roots = tuple(root.resolve() for root in (source_root, *import_roots))
@@ -1104,9 +1092,7 @@ def _resolve_validation_import(
         except (OSError, ValueError):
             continue
         if resolved_candidate.exists() and resolved_candidate.suffix in VALIDATION_SOURCE_SUFFIXES:
-            resolved.setdefault(
-                resolved_candidate, (import_root, candidate_relative)
-            )
+            resolved.setdefault(resolved_candidate, (import_root, candidate_relative))
     return tuple(
         _ResolvedValidationImport(path, import_root, candidate_relative)
         for path, (import_root, candidate_relative) in resolved.items()
@@ -1131,11 +1117,8 @@ def _validation_import_bases(
         for base, root, relative_base in bases:
             unique_bases.setdefault(base, (root, relative_base))
         return tuple(
-            (base, root, relative_base)
-            for base, (root, relative_base) in unique_bases.items()
-        ), tuple(
-            part for part in module.split(".") if part
-        )
+            (base, root, relative_base) for base, (root, relative_base) in unique_bases.items()
+        ), tuple(part for part in module.split(".") if part)
     level = len(module) - len(module.lstrip("."))
     base = path.parent
     relative_base = relative_parent
@@ -1160,7 +1143,11 @@ def _validation_module_candidates(path: Path) -> tuple[Path, ...]:
     alias = VALIDATION_MODULE_ALIASES.get(path.name)
     if alias is not None:
         paths.append(path.with_name(alias))
-    return tuple(candidate.with_suffix(suffix) for candidate in paths for suffix in sorted(VALIDATION_SOURCE_SUFFIXES))
+    return tuple(
+        candidate.with_suffix(suffix)
+        for candidate in paths
+        for suffix in sorted(VALIDATION_SOURCE_SUFFIXES)
+    )
 
 
 def _validation_module_candidate_layouts(
@@ -1170,9 +1157,7 @@ def _validation_module_candidate_layouts(
         (
             candidate,
             import_root,
-            relative_path.with_name(candidate.name)
-            if relative_path.name
-            else Path(candidate.name),
+            relative_path.with_name(candidate.name) if relative_path.name else Path(candidate.name),
         )
         for candidate in _validation_module_candidates(path)
     )
@@ -1182,8 +1167,10 @@ def _project_config_paths(
     source_root: Path,
     excluded_roots: tuple[Path, ...],
 ) -> Iterator[Path]:
+    names = ("pyproject.toml", "uv.lock", "uv.toml")
     if not excluded_roots:
-        yield from source_root.rglob("pyproject.toml")
+        for name in names:
+            yield from source_root.rglob(name)
         return
     for directory, directories, files in os.walk(source_root):
         current = Path(directory)
@@ -1195,8 +1182,9 @@ def _project_config_paths(
                 for excluded_root in excluded_roots
             )
         ]
-        if "pyproject.toml" in files:
-            yield current / "pyproject.toml"
+        for name in names:
+            if name in files:
+                yield current / name
 
 
 def _copy_project_configs(
@@ -1206,29 +1194,25 @@ def _copy_project_configs(
     excluded_roots: tuple[Path, ...] = (),
 ) -> None:
     resolved_target = target_root.resolve()
-    for pyproject in _project_config_paths(source_root, excluded_roots):
-        resolved_pyproject = pyproject.resolve()
+    for config_path in _project_config_paths(source_root, excluded_roots):
+        resolved_config = config_path.resolve()
         if (
-            resolved_pyproject == resolved_target
-            or resolved_target in resolved_pyproject.parents
+            resolved_config == resolved_target
+            or resolved_target in resolved_config.parents
             or any(
-                _is_relative_to(resolved_pyproject, excluded_root)
-                for excluded_root in excluded_roots
+                _is_relative_to(resolved_config, excluded_root) for excluded_root in excluded_roots
             )
         ):
             continue
-        if any(
-            part in {".git", ".venv", "venv", "node_modules"}
-            for part in pyproject.parts
-        ):
+        if any(part in {".git", ".venv", "venv", "node_modules"} for part in config_path.parts):
             continue
         try:
-            relative = pyproject.relative_to(source_root)
+            relative = config_path.relative_to(source_root)
         except ValueError:
             continue
         target = target_root / relative
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(pyproject, target)
+        shutil.copyfile(config_path, target)
 
 
 def compile_source_ast(path: Path, config: Config, source_version: str | None) -> CompileResult:
@@ -1247,6 +1231,7 @@ def compile_source_ast(path: Path, config: Config, source_version: str | None) -
         (),
         suppress_warnings,
         allow_unsupported_formats=True,
+        project_compiler=True,
     )
 
 
@@ -1503,7 +1488,11 @@ def _strip_abi_metadata(value: object) -> object:
             for key, item in sorted(value.items())
             if key not in {"gas", "internalType", "unit"}
             and not (key == "name" and not _is_abi_entry(value))
-            and not (value.get("type") == "constructor" and key == "stateMutability" and item == "nonpayable")
+            and not (
+                value.get("type") == "constructor"
+                and key == "stateMutability"
+                and item == "nonpayable"
+            )
             and key != "constant"
             and key != "payable"
             and not (value.get("type") == "constructor" and key == "outputs")
@@ -1682,9 +1671,7 @@ def _mapping_diff_lines(
     )
     for key in sorted(source.keys() & target.keys()):
         if not (
-            equivalent(key, source[key], target[key])
-            if equivalent
-            else source[key] == target[key]
+            equivalent(key, source[key], target[key]) if equivalent else source[key] == target[key]
         ):
             lines.extend(changed(key, source[key], target[key]))
     return lines
@@ -1794,7 +1781,9 @@ def _target_compile_config(source: str, config: Config) -> Config:
 def _uses_decimal(source: str) -> bool:
     if re.search(r"\bdecimal\b", source):
         return True
-    return bool(re.search(r"^\s*(?:from\s+math\s+import\b|import\s+math(?:\s|,|$))", source, re.MULTILINE))
+    return bool(
+        re.search(r"^\s*(?:from\s+math\s+import\b|import\s+math(?:\s|,|$))", source, re.MULTILINE)
+    )
 
 
 def _run_compile(
@@ -1803,6 +1792,7 @@ def _run_compile(
     config: Config,
     extra_paths: tuple[Path, ...] = (),
     suppress_warnings: bool = False,
+    environment_path: Path | None = None,
 ) -> CompileResult:
     return _run_compile_with_formats(
         command,
@@ -1812,6 +1802,7 @@ def _run_compile(
         extra_paths,
         suppress_warnings,
         optional_formats=frozenset({"ast"}),
+        environment_path=environment_path,
     )
 
 
@@ -1826,45 +1817,54 @@ def _run_compile_with_formats(
     allow_unsupported_formats: bool = False,
     unavailable_formats: tuple[str, ...] = (),
     optional_formats: frozenset[str] = frozenset(),
+    project_compiler: bool = False,
+    environment_path: Path | None = None,
 ) -> CompileResult:
+    environment_path = environment_path or path
     full = [
-        *_with_project_import_dependencies(command, path),
+        *command,
         "-f",
         ",".join(formats),
         *_compiler_search_path_args(command, path, config, extra_paths),
     ]
     if config.enable_decimals:
         full.append("--enable-decimals")
-    if suppress_warnings:
+    if suppress_warnings and not (
+        project_compiler and _project_declares_vyper(_nearest_pyproject(environment_path.parent))
+    ):
         full.extend(["-W", "none"])
     full.append(str(path))
-    try:
-        proc = subprocess.run(full, capture_output=True, text=True, timeout=COMPILE_TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired:
-        return CompileResult(
-            "failed",
-            stderr=f"compiler timed out after {COMPILE_TIMEOUT_SECONDS} seconds",
-            command=full,
+    process = _run_compiler_process(
+        full,
+        environment_path,
+        project_compiler=project_compiler,
+    )
+    if process.returncode is None:
+        return _failed_compile_result(
+            process,
+            process.error or "compiler process did not return a result",
+            unavailable_formats,
         )
-    if proc.returncode != 0:
-        stderr = proc.stderr.strip() or proc.stdout.strip()
+    if process.returncode != 0:
+        stderr = process.stderr.strip() or process.stdout.strip()
         unsupported = _unsupported_output_format(stderr, formats)
         if unsupported is not None:
             unavailable = tuple(dict.fromkeys((*unavailable_formats, unsupported)))
             if not allow_unsupported_formats and unsupported not in optional_formats:
-                return CompileResult(
-                    "failed",
-                    stderr=f"target compiler did not support required output format '{unsupported}': {stderr}",
-                    command=full,
-                    unavailable_formats=unavailable,
+                return _failed_compile_result(
+                    process,
+                    (
+                        "target compiler did not support required output format "
+                        f"'{unsupported}': {stderr}"
+                    ),
+                    unavailable,
                 )
             fallback_formats = tuple(name for name in formats if name != unsupported)
             if not fallback_formats:
-                return CompileResult(
-                    "failed",
-                    stderr="source compiler did not support any requested output formats",
-                    command=full,
-                    unavailable_formats=unavailable,
+                return _failed_compile_result(
+                    process,
+                    "source compiler did not support any requested output formats",
+                    unavailable,
                 )
             return _run_compile_with_formats(
                 command,
@@ -1876,6 +1876,8 @@ def _run_compile_with_formats(
                 allow_unsupported_formats=allow_unsupported_formats,
                 unavailable_formats=unavailable,
                 optional_formats=optional_formats,
+                project_compiler=project_compiler,
+                environment_path=environment_path,
             )
         span_error_format = _legacy_span_error_format(stderr, formats)
         if (
@@ -1885,16 +1887,13 @@ def _run_compile_with_formats(
         ):
             span_error_format = None
         if span_error_format is not None:
-            unavailable = tuple(
-                dict.fromkeys((*unavailable_formats, span_error_format))
-            )
+            unavailable = tuple(dict.fromkeys((*unavailable_formats, span_error_format)))
             fallback_formats = tuple(name for name in formats if name != span_error_format)
             if not fallback_formats:
-                return CompileResult(
-                    "failed",
-                    stderr="source compiler could not produce any requested output formats",
-                    command=full,
-                    unavailable_formats=unavailable,
+                return _failed_compile_result(
+                    process,
+                    "source compiler could not produce any requested output formats",
+                    unavailable,
                 )
             return _run_compile_with_formats(
                 command,
@@ -1906,43 +1905,50 @@ def _run_compile_with_formats(
                 allow_unsupported_formats=allow_unsupported_formats,
                 unavailable_formats=unavailable,
                 optional_formats=optional_formats,
+                project_compiler=project_compiler,
+                environment_path=environment_path,
             )
-        retry_command = _command_with_missing_module_dependency(command, path, stderr)
-        if retry_command is not None:
-            return _run_compile_with_formats(
-                retry_command,
-                path,
-                config,
-                formats,
-                extra_paths,
-                suppress_warnings,
-                allow_unsupported_formats=allow_unsupported_formats,
-                unavailable_formats=unavailable_formats,
-                optional_formats=optional_formats,
-            )
-        return CompileResult(
-            "failed",
-            stderr=proc.stderr.strip() or proc.stdout.strip(),
-            command=full,
-            unavailable_formats=unavailable_formats,
-        )
+        return _failed_compile_result(process, stderr, unavailable_formats)
     try:
-        artifacts = _parse_outputs(proc.stdout, formats)
+        artifacts = _parse_outputs(process.stdout, formats)
     except ValueError as exc:
-        return CompileResult(
-            "failed",
-            stderr=f"could not parse compiler output: {exc}",
-            command=full,
-            unavailable_formats=unavailable_formats,
+        return _failed_compile_result(
+            replace(process, failure_origin="adapter"),
+            f"could not parse compiler output: {exc}",
+            unavailable_formats,
         )
     return CompileResult(
         "degraded"
         if any(name not in optional_formats for name in unavailable_formats)
         else "passed",
         artifacts=artifacts,
-        stderr=proc.stderr.strip() or None,
-        command=full,
+        stderr=process.stderr.strip() or None,
+        command=process.command,
         unavailable_formats=unavailable_formats,
+        resolved_compiler=process.resolved_compiler,
+        dependency_context=process.context,
+        compiler_started=process.compiler_started,
+    )
+
+
+def _failed_compile_result(
+    process: _CompilerProcess,
+    error: str,
+    unavailable_formats: tuple[str, ...] = (),
+) -> CompileResult:
+    compiler_output = (
+        CompilerOutput(process.stdout, process.stderr) if process.compiler_started else None
+    )
+    return CompileResult(
+        "failed",
+        stderr=error,
+        command=process.command,
+        unavailable_formats=unavailable_formats,
+        resolved_compiler=process.resolved_compiler,
+        dependency_context=process.context,
+        compiler_started=process.compiler_started,
+        failure_origin=process.failure_origin or "adapter",
+        compiler_output=compiler_output,
     )
 
 
@@ -1964,11 +1970,7 @@ def _compiler_search_path_args(
         *extra_paths,
         path.parent,
     ]
-    return [
-        argument
-        for search_path in paths
-        for argument in ("-p", str(search_path))
-    ]
+    return [argument for search_path in paths for argument in ("-p", str(search_path))]
 
 
 def _unsupported_output_format(stderr: str, formats: tuple[str, ...]) -> str | None:
@@ -2004,52 +2006,267 @@ def _command_vyper_version(command: list[str]) -> str | None:
     return None
 
 
-def _with_project_import_dependencies(command: list[str], path: Path) -> list[str]:
-    if not _is_uv_run_command(command):
-        return command
-    packages = _project_import_packages(path)
-    if not packages:
-        return command
-    return _uv_command_with_packages(command, packages)
+def _run_compiler_process(
+    command: list[str],
+    path: Path,
+    *,
+    project_compiler: bool,
+    cwd: Path | None = None,
+) -> _CompilerProcess:
+    managed_compiler = _is_uv_run_command(command)
+    with _declared_project_environment(
+        command,
+        path,
+        project_compiler=project_compiler,
+    ) as (full, context):
+        return _run_compiler_adapter(
+            full,
+            context,
+            managed_compiler=managed_compiler,
+            cwd=cwd,
+        )
 
 
-def _command_with_missing_module_dependency(
-    command: list[str], path: Path, stderr: str
-) -> list[str] | None:
-    if not _is_uv_run_command(command):
-        return None
-    missing = _missing_module_name(stderr)
-    if missing is None:
-        return None
-    pyproject = _nearest_pyproject(path.parent)
-    dependencies = _pyproject_dependencies(pyproject) if pyproject is not None else {}
-    root = missing.split(".", 1)[0]
-    package = dependencies.get(root) or COMMON_IMPORT_DEPENDENCIES.get(root)
-    if package is None:
-        return None
-    retry_command = _uv_command_with_packages(command, (package,))
-    return retry_command if retry_command != command else None
-
-
-def _missing_module_name(stderr: str) -> str | None:
-    match = re.search(
-        r"\bModuleNotFound:\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)", stderr
+def _run_compiler_adapter(
+    command: list[str],
+    context: DependencyContext,
+    *,
+    managed_compiler: bool,
+    cwd: Path | None,
+) -> _CompilerProcess:
+    result_file = tempfile.NamedTemporaryFile(
+        prefix="vyupgrade-compiler-result-",
+        suffix=".json",
+        delete=False,
     )
-    return match.group(1) if match else None
+    result_path = Path(result_file.name)
+    result_file.close()
+    result_path.unlink()
+    runner = [
+        *_compiler_runner_prefix(command),
+        str(Path(__file__).with_name("compiler_runner.py")),
+        str(result_path),
+        str(COMPILE_TIMEOUT_SECONDS),
+        "managed" if managed_compiler else "explicit",
+        *_compiler_runner_command(command),
+    ]
+    try:
+        try:
+            process = subprocess.run(
+                runner,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=COMPILE_TIMEOUT_SECONDS + 30,
+            )
+        except subprocess.TimeoutExpired:
+            payload = _compiler_runner_result(result_path)
+            return _CompilerProcess(
+                command=command,
+                context=context,
+                resolved_compiler=_payload_string(payload, "resolved_compiler"),
+                compiler_started=payload is not None,
+                failure_origin="timeout",
+                error=f"compiler timed out after {COMPILE_TIMEOUT_SECONDS} seconds",
+            )
+        except OSError as exc:
+            return _CompilerProcess(
+                command=command,
+                context=context,
+                failure_origin="environment" if _is_uv_run_command(command) else "launch",
+                error=f"compiler environment failed to start: {exc}",
+            )
+
+        payload = _compiler_runner_result(result_path)
+        if payload is None or payload.get("state") != "complete":
+            wrapper_error = process.stderr.strip() or process.stdout.strip()
+            return _CompilerProcess(
+                command=command,
+                context=context,
+                compiler_started=payload is not None,
+                failure_origin=(
+                    "adapter"
+                    if payload is not None or process.returncode == 0
+                    else "environment"
+                    if _is_uv_run_command(command)
+                    else "adapter"
+                ),
+                error=wrapper_error or "compiler adapter returned no result",
+            )
+        return _compiler_process_from_payload(command, context, payload)
+    finally:
+        result_path.unlink(missing_ok=True)
 
 
-def _uv_command_with_packages(command: list[str], packages: tuple[str, ...]) -> list[str]:
-    insert_at = _uv_run_command_index(command)
-    full = command[:insert_at]
-    for package in packages:
-        if _uv_command_has_package(command, package):
+def _compiler_runner_prefix(command: list[str]) -> list[str]:
+    if not _is_uv_run_command(command):
+        return [sys.executable]
+    return [*command[: _uv_run_command_index(command)], "python"]
+
+
+def _compiler_runner_command(command: list[str]) -> list[str]:
+    if not _is_uv_run_command(command):
+        return command
+    return command[_uv_run_command_index(command) :]
+
+
+def _compiler_runner_result(path: Path) -> dict[str, object] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _compiler_process_from_payload(
+    command: list[str],
+    context: DependencyContext,
+    payload: dict[str, object],
+) -> _CompilerProcess:
+    raw_origin = payload.get("failure_origin")
+    origin = (
+        cast(FailureOrigin, raw_origin)
+        if raw_origin in {"compiler", "environment", "launch", "timeout", "adapter"}
+        else None
+    )
+    raw_returncode = payload.get("returncode")
+    returncode = raw_returncode if type(raw_returncode) is int else None
+    return _CompilerProcess(
+        command=command,
+        context=context,
+        returncode=returncode,
+        stdout=_payload_string(payload, "stdout") or "",
+        stderr=_payload_string(payload, "stderr") or "",
+        resolved_compiler=_payload_string(payload, "resolved_compiler"),
+        compiler_started=payload.get("compiler_started") is True,
+        failure_origin=origin,
+        error=_payload_string(payload, "error"),
+    )
+
+
+def _payload_string(payload: dict[str, object] | None, key: str) -> str | None:
+    if payload is None:
+        return None
+    value = payload.get(key)
+    return value if isinstance(value, str) else None
+
+
+@contextmanager
+def _declared_project_environment(
+    command: list[str],
+    path: Path,
+    *,
+    project_compiler: bool,
+) -> Iterator[tuple[list[str], DependencyContext]]:
+    pyproject = _nearest_pyproject(path.parent)
+    if pyproject is None:
+        yield command, DependencyContext(mode="isolated")
+        return
+
+    root = pyproject.parent.resolve()
+    lockfile = root / "uv.lock"
+    context = DependencyContext(
+        mode="project",
+        project_root=str(root),
+        manifest=str(pyproject.resolve()),
+        lockfile=str(lockfile) if lockfile.is_file() else None,
+    )
+    if lockfile.is_file():
+        yield (
+            _project_environment_command(
+                command,
+                root,
+                pyproject,
+                project_compiler=project_compiler,
+                frozen=True,
+            ),
+            context,
+        )
+        return
+
+    with tempfile.TemporaryDirectory(prefix="vyupgrade-project-") as raw_directory:
+        temporary_root = Path(raw_directory)
+        _mirror_project_root(root, temporary_root)
+        yield (
+            _project_environment_command(
+                command,
+                temporary_root,
+                pyproject,
+                project_compiler=project_compiler,
+                frozen=False,
+            ),
+            context,
+        )
+
+
+def _project_environment_command(
+    command: list[str],
+    root: Path,
+    pyproject: Path,
+    *,
+    project_compiler: bool,
+    frozen: bool,
+) -> list[str]:
+    environment = [
+        _uv_bin(),
+        "run",
+        "--isolated",
+        "--project",
+        str(root),
+        *(("--frozen",) if frozen else ()),
+        "--all-extras",
+        "--all-groups",
+    ]
+    if not _is_uv_run_command(command):
+        return [*environment, *command]
+
+    command_index = _uv_run_command_index(command)
+    options = _project_uv_options(
+        command[2:command_index],
+        remove_vyper=project_compiler and _project_declares_vyper(pyproject),
+    )
+    return [*environment, *options, *command[command_index:]]
+
+
+def _mirror_project_root(source: Path, target: Path) -> None:
+    for child in source.iterdir():
+        if child.name in {".venv", "uv.lock"}:
             continue
-        full.extend(["--with", package])
-    full.extend(command[insert_at:])
-    return full
+        destination = target / child.name
+        if child.name in {"pyproject.toml", "uv.toml"}:
+            shutil.copyfile(child, destination)
+        else:
+            destination.symlink_to(child, target_is_directory=child.is_dir())
 
 
-def _uv_run_command_index(command: list[str]) -> int:
+def _project_uv_options(options: Sequence[str], *, remove_vyper: bool) -> list[str]:
+    kept: list[str] = []
+    index = 0
+    while index < len(options):
+        option = options[index]
+        if option == "--no-project":
+            index += 1
+            continue
+        if remove_vyper and option == "--python":
+            index += 2
+            continue
+        if (
+            remove_vyper
+            and option == "--with"
+            and index + 1 < len(options)
+            and options[index + 1].startswith("vyper==")
+        ):
+            index += 2
+            continue
+        kept.append(option)
+        index += 1
+        if option in {"--with", "--with-editable", "--with-requirements", "--env-file"}:
+            kept.append(options[index])
+            index += 1
+    return kept
+
+
+def _uv_run_command_index(command: Sequence[str]) -> int:
     index = 2
     options_with_value = {
         "--python",
@@ -2057,63 +2274,86 @@ def _uv_run_command_index(command: list[str]) -> int:
         "--with-editable",
         "--with-requirements",
         "--env-file",
+        "--project",
     }
     while index < len(command):
-        arg = command[index]
-        if arg == "--":
+        argument = command[index]
+        if argument == "--":
             return index + 1
-        if not arg.startswith("-"):
+        if not argument.startswith("-"):
             return index
         index += 1
-        if arg in options_with_value and index < len(command):
+        if argument in options_with_value and index < len(command):
             index += 1
     return len(command)
 
 
-def _uv_command_has_package(command: list[str], package: str) -> bool:
-    return any(
-        arg == "--with" and index + 1 < len(command) and command[index + 1] == package
-        for index, arg in enumerate(command)
-    )
-
-
-def _is_uv_run_command(command: list[str]) -> bool:
+def _is_uv_run_command(command: Sequence[str]) -> bool:
     return len(command) >= 3 and Path(command[0]).name == "uv" and command[1] == "run"
 
 
-def _project_import_packages(path: Path) -> tuple[str, ...]:
+def _project_declares_vyper(pyproject: Path | None) -> bool:
+    if pyproject is None:
+        return False
     try:
-        source = path.read_text(encoding="utf-8")
-    except OSError:
-        return ()
-    imports = _vyper_import_roots(source)
-    if not imports:
-        return ()
-    pyproject = _nearest_pyproject(path.parent)
-    dependencies = _pyproject_dependencies(pyproject) if pyproject is not None else {}
-    return tuple(
-        package
-        for name in imports
-        if (package := dependencies.get(name) or COMMON_IMPORT_DEPENDENCIES.get(name)) is not None
-    )
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    if any(_dependency_name(spec) == "vyper" for spec in _project_dependency_specs(data)):
+        return True
+    return "vyper" in _poetry_dependency_names(data)
 
 
-def _vyper_import_roots(source: str) -> tuple[str, ...]:
-    roots: set[str] = set()
-    for line in source.splitlines():
-        match = re.match(
-            r"\s*from\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s+import\b", line
-        )
-        if match is None:
-            match = re.match(
-                r"\s*import\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\b", line
-            )
-        if match is None:
-            continue
-        root = match.group(1).split(".", 1)[0]
-        if root != "vyper":
-            roots.add(root)
-    return tuple(sorted(roots))
+def _project_dependency_specs(data: dict[str, object]) -> Iterator[str]:
+    project = data.get("project")
+    if isinstance(project, dict):
+        yield from _string_dependencies(project.get("dependencies"))
+        optional = project.get("optional-dependencies")
+        if isinstance(optional, dict):
+            for dependencies in optional.values():
+                yield from _string_dependencies(dependencies)
+    groups = data.get("dependency-groups")
+    if isinstance(groups, dict):
+        for dependencies in groups.values():
+            yield from _string_dependencies(dependencies)
+    tool = data.get("tool")
+    uv = tool.get("uv") if isinstance(tool, dict) else None
+    if isinstance(uv, dict):
+        yield from _string_dependencies(uv.get("dev-dependencies"))
+
+
+def _string_dependencies(value: object) -> Iterator[str]:
+    if isinstance(value, list):
+        yield from (dependency for dependency in value if isinstance(dependency, str))
+
+
+def _poetry_dependency_names(data: dict[str, object]) -> set[str]:
+    tool = data.get("tool")
+    poetry = tool.get("poetry") if isinstance(tool, dict) else None
+    if not isinstance(poetry, dict):
+        return set()
+    names = _normalized_dependency_keys(poetry.get("dependencies"))
+    groups = poetry.get("group")
+    if isinstance(groups, dict):
+        for group in groups.values():
+            if isinstance(group, dict):
+                names.update(_normalized_dependency_keys(group.get("dependencies")))
+    return names
+
+
+def _normalized_dependency_keys(value: object) -> set[str]:
+    if not isinstance(value, dict):
+        return set()
+    return {_normalized_dependency_name(name) for name in value if name != "python"}
+
+
+def _dependency_name(dependency: str) -> str | None:
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", dependency)
+    return _normalized_dependency_name(match.group(1)) if match else None
+
+
+def _normalized_dependency_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
 
 
 def _nearest_project_root(start: Path) -> Path | None:
@@ -2129,74 +2369,10 @@ def _nearest_pyproject(start: Path) -> Path | None:
     return None
 
 
-def _pyproject_dependencies(path: Path) -> dict[str, str]:
-    try:
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return {}
-    dependencies: dict[str, str] = {}
-    project = data.get("project")
-    if isinstance(project, dict) and isinstance(project.get("dependencies"), list):
-        for dependency in project["dependencies"]:
-            if isinstance(dependency, str):
-                name = _dependency_name(dependency)
-                if name is not None:
-                    dependencies[name] = dependency
-    tool = data.get("tool")
-    poetry = tool.get("poetry") if isinstance(tool, dict) else None
-    poetry_dependencies = poetry.get("dependencies") if isinstance(poetry, dict) else None
-    if isinstance(poetry_dependencies, dict):
-        for name, value in poetry_dependencies.items():
-            if name == "python":
-                continue
-            package = _poetry_dependency_package(name, value)
-            if package is not None:
-                dependencies[name.replace("-", "_")] = package
-    return dependencies
-
-
-def _dependency_name(dependency: str) -> str | None:
-    match = re.match(r"\s*([A-Za-z0-9_.-]+)", dependency)
-    return match.group(1).replace("-", "_") if match else None
-
-
-def _poetry_dependency_package(name: str, value: object) -> str | None:
-    normalized_name = name.replace("-", "_")
-    if isinstance(value, str):
-        return _package_with_version(name, value)
-    if not isinstance(value, dict):
-        return None
-    package_name = str(value.get("package", name))
-    if "git" in value:
-        git = str(value["git"])
-        rev = value.get("rev") or value.get("tag") or value.get("branch")
-        suffix = f"@{rev}" if isinstance(rev, str) and rev else ""
-        return f"{package_name} @ git+{git}{suffix}"
-    version = value.get("version")
-    if isinstance(version, str):
-        return _package_with_version(package_name, version)
-    return package_name or normalized_name
-
-
-def _package_with_version(name: str, version: str) -> str | None:
-    version = version.strip()
-    if version in {"", "*"}:
-        return name
-    if version.startswith("^"):
-        return None
-    if version[0].isdigit():
-        return f"{name}=={version}"
-    if version.startswith(("==", "!=", "<=", ">=", "<", ">", "~=")):
-        return f"{name}{version}"
-    return None
-
-
 def _parse_outputs(stdout: str, formats: tuple[str, ...] = FORMATS) -> dict[str, object]:
     chunks = [line for line in stdout.splitlines() if line.strip()]
     if len(chunks) != len(formats):
-        raise ValueError(
-            f"expected {len(formats)} compiler outputs, received {len(chunks)}"
-        )
+        raise ValueError(f"expected {len(formats)} compiler outputs, received {len(chunks)}")
     artifacts: dict[str, object] = {}
     for name, raw in zip(formats, chunks, strict=True):
         artifacts[name] = json.loads(raw)

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -9,8 +10,8 @@ import tempfile
 import sys
 import tomllib
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from contextlib import contextmanager, suppress
-from dataclasses import dataclass, replace
+from contextlib import contextmanager
+from dataclasses import dataclass, field as dataclass_field, replace
 from functools import cache
 from pathlib import Path
 from typing import cast
@@ -18,7 +19,19 @@ from uuid import uuid4
 
 from uv import find_uv_bin
 
-from .models import CompilerOutput, Config, DependencyContext, FailureOrigin
+from .models import (
+    CompilerAuthority,
+    CompilerDeclaration,
+    CompilerOutput,
+    CompletionStatus,
+    Config,
+    ContentIdentity,
+    DependencyContext,
+    ExitStatus,
+    FailureOrigin,
+    ResolvedCompiler,
+    ResolvedPackage,
+)
 from .source import code_mask
 from .storage_layout import compare_storage_layouts, parse_storage_layout
 from .versions import (
@@ -73,6 +86,12 @@ class CompileResult:
     compiler_started: bool = False
     failure_origin: FailureOrigin | None = None
     compiler_output: CompilerOutput | None = None
+    compiler_identity: ResolvedCompiler | None = None
+    compiler_authority: CompilerAuthority = "default"
+    compiler_declarations: tuple[CompilerDeclaration, ...] = ()
+    completion_status: CompletionStatus = "not-started"
+    exit_status: ExitStatus = dataclass_field(default_factory=lambda: ExitStatus(None))
+    validated_sources: tuple[ContentIdentity, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -86,6 +105,12 @@ class _CompilerProcess:
     compiler_started: bool = False
     failure_origin: FailureOrigin | None = None
     error: str | None = None
+    compiler_identity: ResolvedCompiler | None = None
+    compiler_authority: CompilerAuthority = "default"
+    compiler_declarations: tuple[CompilerDeclaration, ...] = ()
+    completion_status: CompletionStatus = "not-started"
+    exit_status: ExitStatus = dataclass_field(default_factory=lambda: ExitStatus(None))
+    validated_sources: tuple[ContentIdentity, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -178,74 +203,16 @@ def compile_source_file(path: Path, config: Config, source_version: str | None) 
         source_version or infer_pragma(path.read_text()),
         config.source_python,
     )
-    result = _run_compile_with_formats(
+    return _run_compile_with_formats(
         command,
         path,
         config,
         SOURCE_FORMATS,
         (),
         suppress_warnings,
-        allow_unsupported_formats=True,
         project_compiler=True,
+        allow_format_retries=False,
     )
-    if _should_retry_source_with_final_newline(path, result):
-        return _compile_source_file_with_final_newline(
-            command, path, config, suppress_warnings, result
-        )
-    return result
-
-
-def _compile_source_file_with_final_newline(
-    command: list[str],
-    path: Path,
-    config: Config,
-    suppress_warnings: bool,
-    original_result: CompileResult,
-) -> CompileResult:
-    try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return CompileResult("failed", stderr="could not read source for final-newline retry")
-    try:
-        tmp = tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            prefix=f".{path.stem}.vyupgrade.source.",
-            suffix=path.suffix,
-            dir=path.parent,
-            delete=False,
-        )
-    except OSError:
-        return original_result
-    tmp_path = Path(tmp.name)
-    try:
-        with tmp:
-            tmp.write(source)
-            tmp.write("\n")
-        return _run_compile_with_formats(
-            command,
-            tmp_path,
-            config,
-            SOURCE_FORMATS,
-            (),
-            suppress_warnings,
-            allow_unsupported_formats=True,
-            project_compiler=True,
-        )
-    finally:
-        with suppress(OSError):
-            tmp_path.unlink()
-
-
-def _should_retry_source_with_final_newline(path: Path, result: CompileResult) -> bool:
-    if result.status != "failed" or result.stderr is None:
-        return False
-    if not _legacy_span_error(result.stderr):
-        return False
-    try:
-        return not path.read_bytes().endswith(b"\n")
-    except OSError:
-        return False
 
 
 def compile_target_source(
@@ -434,6 +401,11 @@ def compile_target_archive(
             project_compiler=False,
             cwd=overlay.root,
         )
+        if process.compiler_started:
+            process = replace(
+                process,
+                validated_sources=(_content_identity(path, content_path=staged),),
+            )
         if process.returncode is None:
             return _failed_compile_result(
                 process,
@@ -458,6 +430,12 @@ def compile_target_archive(
             resolved_compiler=process.resolved_compiler,
             dependency_context=process.context,
             compiler_started=process.compiler_started,
+            compiler_identity=process.compiler_identity,
+            compiler_authority=process.compiler_authority,
+            compiler_declarations=process.compiler_declarations,
+            completion_status=process.completion_status,
+            exit_status=process.exit_status,
+            validated_sources=process.validated_sources,
         )
     finally:
         tmp_out.unlink(missing_ok=True)
@@ -1815,6 +1793,7 @@ def _run_compile_with_formats(
     suppress_warnings: bool,
     *,
     allow_unsupported_formats: bool = False,
+    allow_format_retries: bool = True,
     unavailable_formats: tuple[str, ...] = (),
     optional_formats: frozenset[str] = frozenset(),
     project_compiler: bool = False,
@@ -1839,6 +1818,11 @@ def _run_compile_with_formats(
         environment_path,
         project_compiler=project_compiler,
     )
+    if process.compiler_started and path.is_file():
+        process = replace(
+            process,
+            validated_sources=(_content_identity(environment_path, content_path=path),),
+        )
     if process.returncode is None:
         return _failed_compile_result(
             process,
@@ -1847,6 +1831,8 @@ def _run_compile_with_formats(
         )
     if process.returncode != 0:
         stderr = process.stderr.strip() or process.stdout.strip()
+        if not allow_format_retries:
+            return _failed_compile_result(process, stderr, unavailable_formats)
         unsupported = _unsupported_output_format(stderr, formats)
         if unsupported is not None:
             unavailable = tuple(dict.fromkeys((*unavailable_formats, unsupported)))
@@ -1874,6 +1860,7 @@ def _run_compile_with_formats(
                 extra_paths,
                 suppress_warnings,
                 allow_unsupported_formats=allow_unsupported_formats,
+                allow_format_retries=allow_format_retries,
                 unavailable_formats=unavailable,
                 optional_formats=optional_formats,
                 project_compiler=project_compiler,
@@ -1903,6 +1890,7 @@ def _run_compile_with_formats(
                 extra_paths,
                 suppress_warnings,
                 allow_unsupported_formats=allow_unsupported_formats,
+                allow_format_retries=allow_format_retries,
                 unavailable_formats=unavailable,
                 optional_formats=optional_formats,
                 project_compiler=project_compiler,
@@ -1928,6 +1916,12 @@ def _run_compile_with_formats(
         resolved_compiler=process.resolved_compiler,
         dependency_context=process.context,
         compiler_started=process.compiler_started,
+        compiler_identity=process.compiler_identity,
+        compiler_authority=process.compiler_authority,
+        compiler_declarations=process.compiler_declarations,
+        completion_status=process.completion_status,
+        exit_status=process.exit_status,
+        validated_sources=process.validated_sources,
     )
 
 
@@ -1949,6 +1943,12 @@ def _failed_compile_result(
         compiler_started=process.compiler_started,
         failure_origin=process.failure_origin or "adapter",
         compiler_output=compiler_output,
+        compiler_identity=process.compiler_identity,
+        compiler_authority=process.compiler_authority,
+        compiler_declarations=process.compiler_declarations,
+        completion_status=process.completion_status,
+        exit_status=process.exit_status,
+        validated_sources=process.validated_sources,
     )
 
 
@@ -2013,16 +2013,29 @@ def _run_compiler_process(
     project_compiler: bool,
     cwd: Path | None = None,
 ) -> _CompilerProcess:
-    managed_compiler = _is_uv_run_command(command)
+    authority = _compiler_authority(command, path, project_compiler=project_compiler)
+    declarations = _compiler_declarations(command, path, project_compiler=project_compiler)
+    coherence_spec = (
+        infer_pragma(path.read_text(encoding="utf-8"))
+        if project_compiler and _project_declares_vyper(_nearest_pyproject(path.parent))
+        else None
+    )
     with _declared_project_environment(
         command,
         path,
         project_compiler=project_compiler,
     ) as (full, context):
+        runner_command = _compiler_runner_command(full)
+        managed_compiler = (
+            _is_uv_run_command(full) and bool(runner_command) and runner_command[0] == "vyper"
+        )
         return _run_compiler_adapter(
             full,
             context,
             managed_compiler=managed_compiler,
+            compiler_authority=authority,
+            compiler_declarations=declarations,
+            coherence_spec=coherence_spec,
             cwd=cwd,
         )
 
@@ -2032,6 +2045,9 @@ def _run_compiler_adapter(
     context: DependencyContext,
     *,
     managed_compiler: bool,
+    compiler_authority: CompilerAuthority,
+    compiler_declarations: tuple[CompilerDeclaration, ...],
+    coherence_spec: str | None,
     cwd: Path | None,
 ) -> _CompilerProcess:
     result_file = tempfile.NamedTemporaryFile(
@@ -2048,6 +2064,7 @@ def _run_compiler_adapter(
         str(result_path),
         str(COMPILE_TIMEOUT_SECONDS),
         "managed" if managed_compiler else "explicit",
+        coherence_spec or "",
         *_compiler_runner_command(command),
     ]
     try:
@@ -2063,11 +2080,15 @@ def _run_compiler_adapter(
             payload = _compiler_runner_result(result_path)
             return _CompilerProcess(
                 command=command,
-                context=context,
+                context=_context_with_resolved_packages(context, payload),
                 resolved_compiler=_payload_string(payload, "resolved_compiler"),
                 compiler_started=payload is not None,
                 failure_origin="timeout",
                 error=f"compiler timed out after {COMPILE_TIMEOUT_SECONDS} seconds",
+                compiler_identity=_payload_compiler_identity(payload),
+                compiler_authority=compiler_authority,
+                compiler_declarations=compiler_declarations,
+                completion_status="timed-out",
             )
         except OSError as exc:
             return _CompilerProcess(
@@ -2075,25 +2096,42 @@ def _run_compiler_adapter(
                 context=context,
                 failure_origin="environment" if _is_uv_run_command(command) else "launch",
                 error=f"compiler environment failed to start: {exc}",
+                compiler_authority=compiler_authority,
+                compiler_declarations=compiler_declarations,
             )
 
         payload = _compiler_runner_result(result_path)
         if payload is None or payload.get("state") != "complete":
             wrapper_error = process.stderr.strip() or process.stdout.strip()
+            signaled = process.returncode < 0
             return _CompilerProcess(
                 command=command,
-                context=context,
+                context=_context_with_resolved_packages(context, payload),
                 compiler_started=payload is not None,
                 failure_origin=(
-                    "adapter"
-                    if payload is not None or process.returncode == 0
+                    "compiler-internal"
+                    if signaled
                     else "environment"
-                    if _is_uv_run_command(command)
+                    if payload is None and _is_uv_run_command(command) and process.returncode != 0
                     else "adapter"
                 ),
                 error=wrapper_error or "compiler adapter returned no result",
+                compiler_identity=_payload_compiler_identity(payload),
+                compiler_authority=compiler_authority,
+                compiler_declarations=compiler_declarations,
+                completion_status="signaled" if signaled else "adapter-failed",
+                exit_status=ExitStatus(
+                    process.returncode,
+                    -process.returncode if signaled else None,
+                ),
             )
-        return _compiler_process_from_payload(command, context, payload)
+        return _compiler_process_from_payload(
+            command,
+            context,
+            payload,
+            compiler_authority=compiler_authority,
+            compiler_declarations=compiler_declarations,
+        )
     finally:
         result_path.unlink(missing_ok=True)
 
@@ -2122,18 +2160,28 @@ def _compiler_process_from_payload(
     command: list[str],
     context: DependencyContext,
     payload: dict[str, object],
+    *,
+    compiler_authority: CompilerAuthority,
+    compiler_declarations: tuple[CompilerDeclaration, ...],
 ) -> _CompilerProcess:
     raw_origin = payload.get("failure_origin")
     origin = (
         cast(FailureOrigin, raw_origin)
-        if raw_origin in {"compiler", "environment", "launch", "timeout", "adapter"}
+        if raw_origin
+        in {"compiler", "compiler-internal", "environment", "launch", "timeout", "adapter"}
         else None
     )
     raw_returncode = payload.get("returncode")
     returncode = raw_returncode if type(raw_returncode) is int else None
+    raw_completion = payload.get("completion_status")
+    completion_status = (
+        cast(CompletionStatus, raw_completion)
+        if raw_completion in {"not-started", "completed", "timed-out", "signaled", "adapter-failed"}
+        else "adapter-failed"
+    )
     return _CompilerProcess(
         command=command,
-        context=context,
+        context=_context_with_resolved_packages(context, payload),
         returncode=returncode,
         stdout=_payload_string(payload, "stdout") or "",
         stderr=_payload_string(payload, "stderr") or "",
@@ -2141,6 +2189,14 @@ def _compiler_process_from_payload(
         compiler_started=payload.get("compiler_started") is True,
         failure_origin=origin,
         error=_payload_string(payload, "error"),
+        compiler_identity=_payload_compiler_identity(payload),
+        compiler_authority=compiler_authority,
+        compiler_declarations=compiler_declarations,
+        completion_status=completion_status,
+        exit_status=ExitStatus(
+            returncode,
+            -returncode if returncode is not None and returncode < 0 else None,
+        ),
     )
 
 
@@ -2149,6 +2205,131 @@ def _payload_string(payload: dict[str, object] | None, key: str) -> str | None:
         return None
     value = payload.get(key)
     return value if isinstance(value, str) else None
+
+
+def _payload_compiler_identity(
+    payload: dict[str, object] | None,
+) -> ResolvedCompiler | None:
+    if payload is None:
+        return None
+    value = payload.get("compiler_identity")
+    if not isinstance(value, dict):
+        return None
+    version = value.get("version")
+    executable = _payload_content_identity(value.get("executable"))
+    artifact = _payload_content_identity(value.get("artifact"))
+    if not isinstance(version, str) or executable is None or artifact is None:
+        return None
+    return ResolvedCompiler(version, executable, artifact)
+
+
+def _payload_content_identity(value: object) -> ContentIdentity | None:
+    if not isinstance(value, dict):
+        return None
+    path = value.get("path")
+    digest = value.get("sha256")
+    if not isinstance(path, str) or not isinstance(digest, str):
+        return None
+    return ContentIdentity(path, digest)
+
+
+def _context_with_resolved_packages(
+    context: DependencyContext,
+    payload: dict[str, object] | None,
+) -> DependencyContext:
+    if payload is None:
+        return context
+    raw_packages = payload.get("resolved_packages")
+    if not isinstance(raw_packages, list):
+        return context
+    packages: list[ResolvedPackage] = []
+    for value in raw_packages:
+        if not isinstance(value, dict):
+            return context
+        name = value.get("name")
+        version = value.get("version")
+        source = value.get("source")
+        artifact_sha256 = value.get("artifact_sha256")
+        if (
+            not isinstance(name, str)
+            or not isinstance(version, str)
+            or (source is not None and not isinstance(source, str))
+            or not isinstance(artifact_sha256, str)
+        ):
+            return context
+        packages.append(ResolvedPackage(name, version, source, artifact_sha256))
+    return replace(context, resolved_packages=tuple(packages))
+
+
+def _content_identity(path: Path, *, content_path: Path | None = None) -> ContentIdentity:
+    content = content_path or path
+    return ContentIdentity(
+        str(path.resolve()),
+        hashlib.sha256(content.read_bytes()).hexdigest(),
+    )
+
+
+def _compiler_authority(
+    command: list[str],
+    path: Path,
+    *,
+    project_compiler: bool,
+) -> CompilerAuthority:
+    pyproject = _nearest_pyproject(path.parent)
+    if project_compiler and _project_declares_vyper(pyproject):
+        assert pyproject is not None
+        return "project-lock" if (pyproject.parent / "uv.lock").is_file() else "project-manifest"
+    if not _is_uv_run_command(command):
+        return "explicit-executable"
+    if not project_compiler:
+        return "fixed-target"
+    source_spec = infer_pragma(path.read_text(encoding="utf-8"))
+    if source_spec is None:
+        return "default"
+    return "source-exact" if parse_version(source_spec) is not None else "source-range"
+
+
+def _compiler_declarations(
+    command: list[str],
+    path: Path,
+    *,
+    project_compiler: bool,
+) -> tuple[CompilerDeclaration, ...]:
+    declarations: list[CompilerDeclaration] = []
+    pyproject = _nearest_pyproject(path.parent)
+    if project_compiler:
+        if pyproject is not None:
+            declarations.extend(
+                CompilerDeclaration("project", spec, str(pyproject.resolve()))
+                for spec in _project_vyper_specs(pyproject)
+            )
+        source_spec = infer_pragma(path.read_text(encoding="utf-8"))
+        if source_spec is not None:
+            declarations.append(
+                CompilerDeclaration("source-pragma", source_spec, str(path.resolve()))
+            )
+    else:
+        target_version = _command_vyper_version(command)
+        if target_version is not None:
+            declarations.append(CompilerDeclaration("target-version", target_version))
+    if not _is_uv_run_command(command):
+        declarations.append(CompilerDeclaration("explicit-executable", command[0]))
+    return tuple(declarations)
+
+
+def _project_vyper_specs(pyproject: Path) -> tuple[str, ...]:
+    data = _project_data(pyproject)
+    specs = [
+        dependency
+        for dependency in _project_dependency_specs(data)
+        if _dependency_name(dependency) == "vyper"
+    ]
+    tool = data.get("tool")
+    poetry = tool.get("poetry") if isinstance(tool, dict) else None
+    dependencies = poetry.get("dependencies") if isinstance(poetry, dict) else None
+    if isinstance(dependencies, dict) and "vyper" in dependencies:
+        specs.append(f"vyper {json.dumps(dependencies['vyper'], sort_keys=True)}")
+    return tuple(specs)
 
 
 @contextmanager
@@ -2165,11 +2346,16 @@ def _declared_project_environment(
 
     root = pyproject.parent.resolve()
     lockfile = root / "uv.lock"
+    data = _project_data(pyproject)
+    project = data.get("project")
+    python_constraint = project.get("requires-python") if isinstance(project, dict) else None
     context = DependencyContext(
         mode="project",
         project_root=str(root),
-        manifest=str(pyproject.resolve()),
-        lockfile=str(lockfile) if lockfile.is_file() else None,
+        manifest=_content_identity(pyproject),
+        lockfile=_content_identity(lockfile) if lockfile.is_file() else None,
+        python_constraint=python_constraint if isinstance(python_constraint, str) else None,
+        declared_sources=_declared_local_source_identities(pyproject, data),
     )
     if lockfile.is_file():
         yield (
@@ -2217,17 +2403,61 @@ def _project_environment_command(
         "--all-extras",
         "--all-groups",
     ]
+    project_declares_vyper = _project_declares_vyper(pyproject)
     if not _is_uv_run_command(command):
+        if project_compiler and project_declares_vyper:
+            return [*environment, "vyper"]
         return [*environment, *command]
 
     command_index = _uv_run_command_index(command)
-    project_declares_vyper = _project_declares_vyper(pyproject)
     options = _project_uv_options(
         command[2:command_index],
         remove_vyper=project_compiler and project_declares_vyper,
         remove_python=not project_compiler or project_declares_vyper,
     )
     return [*environment, *options, *command[command_index:]]
+
+
+def _project_data(pyproject: Path) -> dict[str, object]:
+    try:
+        return tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+
+def _declared_local_source_identities(
+    pyproject: Path,
+    data: dict[str, object],
+) -> tuple[ContentIdentity, ...]:
+    tool = data.get("tool")
+    uv = tool.get("uv") if isinstance(tool, dict) else None
+    sources = uv.get("sources") if isinstance(uv, dict) else None
+    if not isinstance(sources, dict):
+        return ()
+    identities: list[ContentIdentity] = []
+    for source in sources.values():
+        path_value = source.get("path") if isinstance(source, dict) else None
+        if not isinstance(path_value, str):
+            continue
+        path = (pyproject.parent / path_value).resolve()
+        if path.exists():
+            identities.append(_tree_identity(path))
+    return tuple(sorted(identities, key=lambda identity: identity.path))
+
+
+def _tree_identity(path: Path) -> ContentIdentity:
+    if path.is_file():
+        return _content_identity(path)
+    digest = hashlib.sha256()
+    for child in sorted(path.rglob("*")):
+        relative = child.relative_to(path)
+        if not child.is_file() or any(part in OVERLAY_EXCLUDED_PARTS for part in relative.parts):
+            continue
+        digest.update(relative.as_posix().encode())
+        digest.update(b"\0")
+        digest.update(child.read_bytes())
+        digest.update(b"\0")
+    return ContentIdentity(str(path.resolve()), digest.hexdigest())
 
 
 def _mirror_project_root(source: Path, target: Path) -> None:
@@ -2299,10 +2529,7 @@ def _is_uv_run_command(command: Sequence[str]) -> bool:
 def _project_declares_vyper(pyproject: Path | None) -> bool:
     if pyproject is None:
         return False
-    try:
-        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return False
+    data = _project_data(pyproject)
     if any(_dependency_name(spec) == "vyper" for spec in _project_dependency_specs(data)):
         return True
     return "vyper" in _poetry_dependency_names(data)

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -73,9 +73,39 @@ VALIDATION_MODULE_ALIASES = {
     "create2": "create2_address",
 }
 
+_MARKER_ENVIRONMENT_SCRIPT = """
+import json
+import os
+import platform
+import sys
+
+version = sys.implementation.version
+implementation_version = ".".join(str(part) for part in version[:3])
+if version.releaselevel != "final":
+    suffix = {"alpha": "a", "beta": "b", "candidate": "rc"}[version.releaselevel]
+    implementation_version += suffix + str(version.serial)
+print(json.dumps({
+    "implementation_name": sys.implementation.name,
+    "implementation_version": implementation_version,
+    "os_name": os.name,
+    "platform_machine": platform.machine(),
+    "platform_python_implementation": platform.python_implementation(),
+    "platform_release": platform.release(),
+    "platform_system": platform.system(),
+    "platform_version": platform.version(),
+    "python_full_version": platform.python_version(),
+    "python_version": ".".join(platform.python_version_tuple()[:2]),
+    "sys_platform": sys.platform,
+}))
+""".strip()
+
 
 class OverlayLayoutConflictError(ValueError):
     """Two closure members with different content map to one overlay path."""
+
+
+class ProjectEnvironmentError(ValueError):
+    """The selected project interpreter could not satisfy the compile request."""
 
 
 @dataclass
@@ -403,6 +433,7 @@ def compile_target_archive(
             full,
             path,
             project_compiler=False,
+            python_pin=config.target_python,
             cwd=overlay.root,
         )
         if process.compiler_started:
@@ -1821,6 +1852,7 @@ def _run_compile_with_formats(
         full,
         environment_path,
         project_compiler=project_compiler,
+        python_pin=config.source_python if project_compiler else config.target_python,
     )
     if process.compiler_started and path.is_file():
         process = replace(
@@ -2028,18 +2060,57 @@ def _run_compiler_process(
     path: Path,
     *,
     project_compiler: bool,
+    python_pin: str | None = None,
     cwd: Path | None = None,
 ) -> _CompilerProcess:
     pyproject = _nearest_pyproject(path.parent)
-    project_declares_vyper = project_compiler and _project_declares_vyper(pyproject)
+    marker_environment: Mapping[str, str] | None = None
+    if pyproject is not None:
+        try:
+            marker_environment = _project_marker_environment(
+                pyproject,
+                command,
+                python_pin=python_pin,
+                pin_name="source" if project_compiler else "target",
+            )
+        except ProjectEnvironmentError as exc:
+            project = _project_data(pyproject).get("project")
+            constraint = project.get("requires-python") if isinstance(project, dict) else None
+            return _CompilerProcess(
+                command=command,
+                context=DependencyContext(
+                    mode="project",
+                    project_root=str(_owning_uv_workspace(pyproject).parent.resolve()),
+                    python_constraint=constraint if isinstance(constraint, str) else None,
+                ),
+                failure_origin="environment",
+                error=str(exc),
+                compiler_authority="fixed-target" if not project_compiler else "default",
+            )
+    project_declares_vyper = project_compiler and _project_declares_vyper(
+        pyproject,
+        marker_environment,
+    )
     source_spec = infer_pragma(path.read_text(encoding="utf-8"))
-    authority = _compiler_authority(command, path, project_compiler=project_compiler)
-    declarations = _compiler_declarations(command, path, project_compiler=project_compiler)
+    authority = _compiler_authority(
+        command,
+        path,
+        project_compiler=project_compiler,
+        marker_environment=marker_environment,
+    )
+    declarations = _compiler_declarations(
+        command,
+        path,
+        project_compiler=project_compiler,
+        marker_environment=marker_environment,
+    )
     coherence = _compiler_coherence(source_spec) if project_declares_vyper else ""
     with _declared_project_environment(
         command,
         path,
         project_compiler=project_compiler,
+        marker_environment=marker_environment,
+        python_pin=python_pin,
     ) as (full, context):
         runner_command = _compiler_runner_command(full)
         managed_compiler = (
@@ -2290,9 +2361,10 @@ def _compiler_authority(
     path: Path,
     *,
     project_compiler: bool,
+    marker_environment: Mapping[str, str] | None = None,
 ) -> CompilerAuthority:
     pyproject = _nearest_pyproject(path.parent)
-    if project_compiler and _project_declares_vyper(pyproject):
+    if project_compiler and _project_declares_vyper(pyproject, marker_environment):
         assert pyproject is not None
         workspace_manifest = _owning_uv_workspace(pyproject)
         return (
@@ -2315,6 +2387,7 @@ def _compiler_declarations(
     path: Path,
     *,
     project_compiler: bool,
+    marker_environment: Mapping[str, str] | None = None,
 ) -> tuple[CompilerDeclaration, ...]:
     declarations: list[CompilerDeclaration] = []
     pyproject = _nearest_pyproject(path.parent)
@@ -2322,7 +2395,7 @@ def _compiler_declarations(
         if pyproject is not None:
             declarations.extend(
                 CompilerDeclaration("project", spec, str(pyproject.resolve()))
-                for spec in _project_vyper_specs(pyproject)
+                for spec in _project_vyper_specs(pyproject, marker_environment)
             )
         source_spec = infer_pragma(path.read_text(encoding="utf-8"))
         if source_spec is not None:
@@ -2338,10 +2411,16 @@ def _compiler_declarations(
     return tuple(declarations)
 
 
-def _project_vyper_specs(pyproject: Path) -> tuple[str, ...]:
+def _project_vyper_specs(
+    pyproject: Path,
+    marker_environment: Mapping[str, str] | None = None,
+) -> tuple[str, ...]:
     return tuple(
         dependency
-        for dependency in _project_dependency_specs(_project_data(pyproject))
+        for dependency in _project_dependency_specs(
+            _project_data(pyproject),
+            marker_environment,
+        )
         if _dependency_name(dependency) == "vyper"
     )
 
@@ -2394,17 +2473,88 @@ def _workspace_glob_roots(root: Path, value: object) -> tuple[Path, ...]:
     )
 
 
+def _project_marker_environment(
+    pyproject: Path,
+    command: Sequence[str],
+    *,
+    python_pin: str | None,
+    pin_name: str,
+) -> dict[str, str]:
+    requested_python = (
+        None
+        if _use_project_interpreter(command, pyproject, python_pin=python_pin)
+        else python_pin or _uv_option_value(command, "--python")
+    )
+    marker_command = [
+        _uv_bin(),
+        "run",
+        "--isolated",
+        "--project",
+        str(pyproject.parent.resolve()),
+        "--no-sync",
+        *((("--python", requested_python)) if requested_python is not None else ()),
+        "python",
+        "-I",
+        "-c",
+        _MARKER_ENVIRONMENT_SCRIPT,
+    ]
+    try:
+        process = subprocess.run(
+            marker_command,
+            capture_output=True,
+            text=True,
+            timeout=COMPILE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ProjectEnvironmentError(f"could not select project Python: {exc}") from exc
+    if process.returncode != 0:
+        detail = process.stderr.strip() or process.stdout.strip() or "interpreter selection failed"
+        project = _project_data(pyproject).get("project")
+        constraint = project.get("requires-python") if isinstance(project, dict) else None
+        if (
+            python_pin is not None
+            and isinstance(constraint, str)
+            and "incompatible with the project's Python requirement" in detail
+        ):
+            raise ProjectEnvironmentError(
+                f"{pin_name} Python pin {python_pin!r} conflicts with "
+                f"project requires-python {constraint!r}: {detail}"
+            )
+        raise ProjectEnvironmentError(f"could not select project Python: {detail}")
+    try:
+        environment = json.loads(process.stdout)
+    except json.JSONDecodeError as exc:
+        raise ProjectEnvironmentError(
+            "selected project Python returned invalid marker data"
+        ) from exc
+    if not isinstance(environment, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in environment.items()
+    ):
+        raise ProjectEnvironmentError("selected project Python returned invalid marker data")
+    return environment
+
+
 @contextmanager
 def _declared_project_environment(
     command: list[str],
     path: Path,
     *,
     project_compiler: bool,
+    marker_environment: Mapping[str, str] | None = None,
+    python_pin: str | None = None,
 ) -> Iterator[tuple[list[str], DependencyContext]]:
     pyproject = _nearest_pyproject(path.parent)
     if pyproject is None:
         yield command, DependencyContext(mode="isolated")
         return
+
+    if marker_environment is None:
+        marker_environment = _project_marker_environment(
+            pyproject,
+            command,
+            python_pin=python_pin,
+            pin_name="source" if project_compiler else "target",
+        )
 
     workspace_manifest = _owning_uv_workspace(pyproject)
     root = workspace_manifest.parent.resolve()
@@ -2416,16 +2566,22 @@ def _declared_project_environment(
     python_constraint = project.get("requires-python") if isinstance(project, dict) else None
     workspace = _uv_workspace(root_data)
     workspace_members = _uv_workspace_member_roots(root, workspace) if workspace is not None else ()
+    declared_source_paths = _declared_local_source_paths(
+        workspace_manifest,
+        root_data,
+        workspace_members,
+    )
     context = DependencyContext(
         mode="project",
         project_root=str(root),
         manifest=_content_identity(workspace_manifest),
         lockfile=_content_identity(lockfile) if lockfile.is_file() else None,
         python_constraint=python_constraint if isinstance(python_constraint, str) else None,
-        declared_sources=_declared_local_source_identities(
-            workspace_manifest,
-            root_data,
-            workspace_members,
+        declared_sources=tuple(
+            sorted(
+                (_tree_identity(path) for path in declared_source_paths),
+                key=lambda identity: identity.path,
+            )
         ),
     )
     if lockfile.is_file():
@@ -2436,14 +2592,19 @@ def _declared_project_environment(
                 pyproject,
                 project_compiler=project_compiler,
                 frozen=True,
+                marker_environment=marker_environment,
+                python_pin=python_pin,
             ),
             context,
         )
         return
 
     with tempfile.TemporaryDirectory(prefix="vyupgrade-project-") as raw_directory:
-        temporary_root = Path(raw_directory)
-        _mirror_project_root(root, temporary_root)
+        temporary_root = _mirror_declared_project(
+            root,
+            Path(raw_directory),
+            _declared_relative_source_paths(workspace_manifest, root_data),
+        )
         temporary_project = temporary_root / selected_root.relative_to(root)
         yield (
             _project_environment_command(
@@ -2452,6 +2613,8 @@ def _declared_project_environment(
                 pyproject,
                 project_compiler=project_compiler,
                 frozen=False,
+                marker_environment=marker_environment,
+                python_pin=python_pin,
             ),
             context,
         )
@@ -2464,6 +2627,8 @@ def _project_environment_command(
     *,
     project_compiler: bool,
     frozen: bool,
+    marker_environment: Mapping[str, str],
+    python_pin: str | None,
 ) -> list[str]:
     environment = [
         _uv_bin(),
@@ -2475,7 +2640,7 @@ def _project_environment_command(
         "--all-extras",
         "--all-groups",
     ]
-    project_declares_vyper = _project_declares_vyper(pyproject)
+    project_declares_vyper = _project_declares_vyper(pyproject, marker_environment)
     if not _is_uv_run_command(command):
         if project_compiler and project_declares_vyper:
             return [*environment, "vyper"]
@@ -2485,12 +2650,7 @@ def _project_environment_command(
     options = _project_uv_options(
         command[2:command_index],
         remove_vyper=project_compiler and project_declares_vyper,
-        remove_python=_use_project_interpreter(
-            command,
-            pyproject,
-            project_compiler=project_compiler,
-            project_declares_vyper=project_declares_vyper,
-        ),
+        remove_python=_use_project_interpreter(command, pyproject, python_pin=python_pin),
     )
     return [*environment, *options, *command[command_index:]]
 
@@ -2499,13 +2659,14 @@ def _use_project_interpreter(
     command: Sequence[str],
     pyproject: Path,
     *,
-    project_compiler: bool,
-    project_declares_vyper: bool,
+    python_pin: str | None,
 ) -> bool:
-    if not project_compiler or project_declares_vyper:
+    if python_pin is not None:
+        return False
+    if _project_has_vyper_requirement(pyproject):
         return True
-    project = _project_data(pyproject).get("project")
-    constraint = project.get("requires-python") if isinstance(project, dict) else None
+    constraint = _project_data(pyproject).get("project")
+    constraint = constraint.get("requires-python") if isinstance(constraint, dict) else None
     requested = _uv_option_value(command, "--python")
     if not isinstance(constraint, str) or requested is None:
         return False
@@ -2530,17 +2691,17 @@ def _project_data(pyproject: Path) -> dict[str, object]:
         return {}
 
 
-def _declared_local_source_identities(
+def _declared_local_source_paths(
     pyproject: Path,
     data: dict[str, object],
     workspace_members: tuple[Path, ...] = (),
-) -> tuple[ContentIdentity, ...]:
+) -> tuple[Path, ...]:
     tool = data.get("tool")
     uv = tool.get("uv") if isinstance(tool, dict) else None
     sources = uv.get("sources") if isinstance(uv, dict) else None
     if not isinstance(sources, dict):
         return ()
-    identities: list[ContentIdentity] = []
+    paths: list[Path] = []
     for name, source in sources.items():
         if not isinstance(source, dict):
             continue
@@ -2551,8 +2712,31 @@ def _declared_local_source_identities(
             else _workspace_source_path(name, source, workspace_members)
         )
         if path is not None and path.exists():
-            identities.append(_tree_identity(path))
-    return tuple(sorted(identities, key=lambda identity: identity.path))
+            paths.append(path)
+    return tuple(sorted(set(paths)))
+
+
+def _declared_relative_source_paths(
+    pyproject: Path,
+    data: dict[str, object],
+) -> tuple[Path, ...]:
+    tool = data.get("tool")
+    uv = tool.get("uv") if isinstance(tool, dict) else None
+    sources = uv.get("sources") if isinstance(uv, dict) else None
+    if not isinstance(sources, dict):
+        return ()
+    return tuple(
+        sorted(
+            {
+                (pyproject.parent / path_value).resolve()
+                for source in sources.values()
+                if isinstance(source, dict)
+                and isinstance((path_value := source.get("path")), str)
+                and not Path(path_value).is_absolute()
+                and (pyproject.parent / path_value).exists()
+            }
+        )
+    )
 
 
 def _workspace_source_path(
@@ -2590,6 +2774,28 @@ def _tree_identity(path: Path) -> ContentIdentity:
         digest.update(child.read_bytes())
         digest.update(b"\0")
     return ContentIdentity(str(path.resolve()), digest.hexdigest())
+
+
+def _mirror_declared_project(
+    root: Path,
+    target: Path,
+    relative_sources: tuple[Path, ...],
+) -> Path:
+    layout_root = Path(os.path.commonpath((root, *relative_sources)))
+    entries = sorted(
+        {root, *relative_sources},
+        key=lambda path: len(path.relative_to(layout_root).parts),
+        reverse=True,
+    )
+    for source in entries:
+        destination = target / source.relative_to(layout_root)
+        if source.is_dir():
+            _mirror_project_root(source, destination)
+            continue
+        if not destination.exists():
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.symlink_to(source)
+    return target / root.relative_to(layout_root)
 
 
 def _mirror_project_root(source: Path, target: Path) -> None:
@@ -2672,34 +2878,68 @@ def _is_uv_run_command(command: Sequence[str]) -> bool:
     return len(command) >= 3 and Path(command[0]).name == "uv" and command[1] == "run"
 
 
-def _project_declares_vyper(pyproject: Path | None) -> bool:
-    return pyproject is not None and bool(_project_vyper_specs(pyproject))
+def _project_has_vyper_requirement(pyproject: Path) -> bool:
+    return any(
+        _dependency_name(dependency) == "vyper"
+        for dependency in _project_dependency_specs(
+            _project_data(pyproject),
+            evaluate_markers=False,
+        )
+    )
 
 
-def _project_dependency_specs(data: dict[str, object]) -> Iterator[str]:
+def _project_declares_vyper(
+    pyproject: Path | None,
+    marker_environment: Mapping[str, str] | None = None,
+) -> bool:
+    return pyproject is not None and bool(_project_vyper_specs(pyproject, marker_environment))
+
+
+def _project_dependency_specs(
+    data: dict[str, object],
+    marker_environment: Mapping[str, str] | None = None,
+    *,
+    evaluate_markers: bool = True,
+) -> Iterator[str]:
     project = data.get("project")
     if isinstance(project, dict):
-        yield from _active_string_dependencies(project.get("dependencies"))
+        yield from _active_string_dependencies(
+            project.get("dependencies"),
+            marker_environment=marker_environment,
+            evaluate_markers=evaluate_markers,
+        )
         optional = project.get("optional-dependencies")
         if isinstance(optional, dict):
             for extra, dependencies in optional.items():
                 yield from _active_string_dependencies(
                     dependencies,
+                    marker_environment=marker_environment,
+                    evaluate_markers=evaluate_markers,
                     extra=extra if isinstance(extra, str) else None,
                 )
     groups = data.get("dependency-groups")
     if isinstance(groups, dict):
         for dependencies in groups.values():
-            yield from _active_string_dependencies(dependencies)
+            yield from _active_string_dependencies(
+                dependencies,
+                marker_environment=marker_environment,
+                evaluate_markers=evaluate_markers,
+            )
     tool = data.get("tool")
     uv = tool.get("uv") if isinstance(tool, dict) else None
     if isinstance(uv, dict):
-        yield from _active_string_dependencies(uv.get("dev-dependencies"))
+        yield from _active_string_dependencies(
+            uv.get("dev-dependencies"),
+            marker_environment=marker_environment,
+            evaluate_markers=evaluate_markers,
+        )
 
 
 def _active_string_dependencies(
     value: object,
     *,
+    marker_environment: Mapping[str, str] | None = None,
+    evaluate_markers: bool = True,
     extra: str | None = None,
 ) -> Iterator[str]:
     if not isinstance(value, list):
@@ -2711,7 +2951,16 @@ def _active_string_dependencies(
             requirement = Requirement(dependency)
         except InvalidRequirement:
             continue
-        if requirement.marker is None or requirement.marker.evaluate({"extra": extra or ""}):
+        environment = (
+            {**marker_environment, "extra": extra or ""}
+            if marker_environment is not None
+            else {"extra": extra or ""}
+        )
+        if (
+            not evaluate_markers
+            or requirement.marker is None
+            or requirement.marker.evaluate(environment)
+        ):
             yield dependency
 
 

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -17,6 +17,9 @@ from pathlib import Path
 from typing import cast
 from uuid import uuid4
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 from uv import find_uv_bin
 
 from .models import (
@@ -38,6 +41,7 @@ from .versions import (
     VyperVersion,
     compiler_version_for_spec,
     infer_pragma,
+    known_versions_satisfying,
     legacy_prerelease_version,
     parse_version,
 )
@@ -2006,6 +2010,19 @@ def _command_vyper_version(command: list[str]) -> str | None:
     return None
 
 
+def _compiler_coherence(source_spec: str | None) -> str:
+    versions = (
+        [str(version) for version in known_versions_satisfying(source_spec)]
+        if source_spec is not None
+        else []
+    )
+    return json.dumps(
+        {"declaration": source_spec, "versions": versions},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
 def _run_compiler_process(
     command: list[str],
     path: Path,
@@ -2013,13 +2030,12 @@ def _run_compiler_process(
     project_compiler: bool,
     cwd: Path | None = None,
 ) -> _CompilerProcess:
+    pyproject = _nearest_pyproject(path.parent)
+    project_declares_vyper = project_compiler and _project_declares_vyper(pyproject)
+    source_spec = infer_pragma(path.read_text(encoding="utf-8"))
     authority = _compiler_authority(command, path, project_compiler=project_compiler)
     declarations = _compiler_declarations(command, path, project_compiler=project_compiler)
-    coherence_spec = (
-        infer_pragma(path.read_text(encoding="utf-8"))
-        if project_compiler and _project_declares_vyper(_nearest_pyproject(path.parent))
-        else None
-    )
+    coherence = _compiler_coherence(source_spec) if project_declares_vyper else ""
     with _declared_project_environment(
         command,
         path,
@@ -2035,7 +2051,7 @@ def _run_compiler_process(
             managed_compiler=managed_compiler,
             compiler_authority=authority,
             compiler_declarations=declarations,
-            coherence_spec=coherence_spec,
+            coherence_spec=coherence,
             cwd=cwd,
         )
 
@@ -2278,7 +2294,12 @@ def _compiler_authority(
     pyproject = _nearest_pyproject(path.parent)
     if project_compiler and _project_declares_vyper(pyproject):
         assert pyproject is not None
-        return "project-lock" if (pyproject.parent / "uv.lock").is_file() else "project-manifest"
+        workspace_manifest = _owning_uv_workspace(pyproject)
+        return (
+            "project-lock"
+            if (workspace_manifest.parent / "uv.lock").is_file()
+            else "project-manifest"
+        )
     if not _is_uv_run_command(command):
         return "explicit-executable"
     if not project_compiler:
@@ -2318,18 +2339,59 @@ def _compiler_declarations(
 
 
 def _project_vyper_specs(pyproject: Path) -> tuple[str, ...]:
-    data = _project_data(pyproject)
-    specs = [
+    return tuple(
         dependency
-        for dependency in _project_dependency_specs(data)
+        for dependency in _project_dependency_specs(_project_data(pyproject))
         if _dependency_name(dependency) == "vyper"
-    ]
+    )
+
+
+def _owning_uv_workspace(pyproject: Path) -> Path:
+    selected_root = pyproject.parent.resolve()
+    for root in (selected_root, *selected_root.parents):
+        workspace_manifest = root / "pyproject.toml"
+        workspace = _uv_workspace(_project_data(workspace_manifest))
+        if workspace is None:
+            continue
+        if root == selected_root or selected_root in _uv_workspace_member_roots(root, workspace):
+            return workspace_manifest
+    return pyproject
+
+
+def _uv_workspace(data: dict[str, object]) -> dict[str, object] | None:
     tool = data.get("tool")
-    poetry = tool.get("poetry") if isinstance(tool, dict) else None
-    dependencies = poetry.get("dependencies") if isinstance(poetry, dict) else None
-    if isinstance(dependencies, dict) and "vyper" in dependencies:
-        specs.append(f"vyper {json.dumps(dependencies['vyper'], sort_keys=True)}")
-    return tuple(specs)
+    uv = tool.get("uv") if isinstance(tool, dict) else None
+    workspace = uv.get("workspace") if isinstance(uv, dict) else None
+    return workspace if isinstance(workspace, dict) else None
+
+
+def _uv_workspace_member_roots(
+    root: Path,
+    workspace: dict[str, object],
+) -> tuple[Path, ...]:
+    members = _workspace_glob_roots(root, workspace.get("members"))
+    excluded = set(_workspace_glob_roots(root, workspace.get("exclude")))
+    return tuple(
+        member
+        for member in members
+        if member not in excluded and (member / "pyproject.toml").is_file()
+    )
+
+
+def _workspace_glob_roots(root: Path, value: object) -> tuple[Path, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(
+        sorted(
+            {
+                candidate.resolve()
+                for pattern in value
+                if isinstance(pattern, str)
+                for candidate in root.glob(pattern)
+                if candidate.is_dir()
+            }
+        )
+    )
 
 
 @contextmanager
@@ -2344,24 +2406,33 @@ def _declared_project_environment(
         yield command, DependencyContext(mode="isolated")
         return
 
-    root = pyproject.parent.resolve()
+    workspace_manifest = _owning_uv_workspace(pyproject)
+    root = workspace_manifest.parent.resolve()
+    selected_root = pyproject.parent.resolve()
     lockfile = root / "uv.lock"
-    data = _project_data(pyproject)
-    project = data.get("project")
+    selected_data = _project_data(pyproject)
+    root_data = _project_data(workspace_manifest)
+    project = selected_data.get("project")
     python_constraint = project.get("requires-python") if isinstance(project, dict) else None
+    workspace = _uv_workspace(root_data)
+    workspace_members = _uv_workspace_member_roots(root, workspace) if workspace is not None else ()
     context = DependencyContext(
         mode="project",
         project_root=str(root),
-        manifest=_content_identity(pyproject),
+        manifest=_content_identity(workspace_manifest),
         lockfile=_content_identity(lockfile) if lockfile.is_file() else None,
         python_constraint=python_constraint if isinstance(python_constraint, str) else None,
-        declared_sources=_declared_local_source_identities(pyproject, data),
+        declared_sources=_declared_local_source_identities(
+            workspace_manifest,
+            root_data,
+            workspace_members,
+        ),
     )
     if lockfile.is_file():
         yield (
             _project_environment_command(
                 command,
-                root,
+                selected_root,
                 pyproject,
                 project_compiler=project_compiler,
                 frozen=True,
@@ -2373,10 +2444,11 @@ def _declared_project_environment(
     with tempfile.TemporaryDirectory(prefix="vyupgrade-project-") as raw_directory:
         temporary_root = Path(raw_directory)
         _mirror_project_root(root, temporary_root)
+        temporary_project = temporary_root / selected_root.relative_to(root)
         yield (
             _project_environment_command(
                 command,
-                temporary_root,
+                temporary_project,
                 pyproject,
                 project_compiler=project_compiler,
                 frozen=False,
@@ -2413,9 +2485,42 @@ def _project_environment_command(
     options = _project_uv_options(
         command[2:command_index],
         remove_vyper=project_compiler and project_declares_vyper,
-        remove_python=not project_compiler or project_declares_vyper,
+        remove_python=_use_project_interpreter(
+            command,
+            pyproject,
+            project_compiler=project_compiler,
+            project_declares_vyper=project_declares_vyper,
+        ),
     )
     return [*environment, *options, *command[command_index:]]
+
+
+def _use_project_interpreter(
+    command: Sequence[str],
+    pyproject: Path,
+    *,
+    project_compiler: bool,
+    project_declares_vyper: bool,
+) -> bool:
+    if not project_compiler or project_declares_vyper:
+        return True
+    project = _project_data(pyproject).get("project")
+    constraint = project.get("requires-python") if isinstance(project, dict) else None
+    requested = _uv_option_value(command, "--python")
+    if not isinstance(constraint, str) or requested is None:
+        return False
+    try:
+        return not SpecifierSet(constraint).contains(Version(requested), prereleases=True)
+    except (InvalidSpecifier, InvalidVersion):
+        return True
+
+
+def _uv_option_value(command: Sequence[str], option: str) -> str | None:
+    try:
+        index = command.index(option)
+    except ValueError:
+        return None
+    return command[index + 1] if index + 1 < len(command) else None
 
 
 def _project_data(pyproject: Path) -> dict[str, object]:
@@ -2428,6 +2533,7 @@ def _project_data(pyproject: Path) -> dict[str, object]:
 def _declared_local_source_identities(
     pyproject: Path,
     data: dict[str, object],
+    workspace_members: tuple[Path, ...] = (),
 ) -> tuple[ContentIdentity, ...]:
     tool = data.get("tool")
     uv = tool.get("uv") if isinstance(tool, dict) else None
@@ -2435,14 +2541,40 @@ def _declared_local_source_identities(
     if not isinstance(sources, dict):
         return ()
     identities: list[ContentIdentity] = []
-    for source in sources.values():
-        path_value = source.get("path") if isinstance(source, dict) else None
-        if not isinstance(path_value, str):
+    for name, source in sources.items():
+        if not isinstance(source, dict):
             continue
-        path = (pyproject.parent / path_value).resolve()
-        if path.exists():
+        path_value = source.get("path")
+        path = (
+            (pyproject.parent / path_value).resolve()
+            if isinstance(path_value, str)
+            else _workspace_source_path(name, source, workspace_members)
+        )
+        if path is not None and path.exists():
             identities.append(_tree_identity(path))
     return tuple(sorted(identities, key=lambda identity: identity.path))
+
+
+def _workspace_source_path(
+    name: object,
+    source: dict[str, object],
+    workspace_members: tuple[Path, ...],
+) -> Path | None:
+    if not isinstance(name, str) or source.get("workspace") is not True:
+        return None
+    normalized_name = _normalized_dependency_name(name)
+    matching = [
+        member
+        for member in workspace_members
+        if _project_name(member / "pyproject.toml") == normalized_name
+    ]
+    return matching[0] if len(matching) == 1 else None
+
+
+def _project_name(pyproject: Path) -> str | None:
+    project = _project_data(pyproject).get("project")
+    name = project.get("name") if isinstance(project, dict) else None
+    return _normalized_dependency_name(name) if isinstance(name, str) else None
 
 
 def _tree_identity(path: Path) -> ContentIdentity:
@@ -2461,14 +2593,28 @@ def _tree_identity(path: Path) -> ContentIdentity:
 
 
 def _mirror_project_root(source: Path, target: Path) -> None:
+    for config in _project_config_paths(source, ()):
+        relative = config.relative_to(source)
+        if config.name == "uv.lock" or any(
+            part in OVERLAY_EXCLUDED_PARTS for part in relative.parts
+        ):
+            continue
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(config, destination)
+    _mirror_project_entries(source, target)
+
+
+def _mirror_project_entries(source: Path, target: Path) -> None:
     for child in source.iterdir():
-        if child.name in {".venv", "uv.lock"}:
+        if child.name == "uv.lock" or child.name in OVERLAY_EXCLUDED_PARTS:
             continue
         destination = target / child.name
-        if child.name in {"pyproject.toml", "uv.toml"}:
-            shutil.copyfile(child, destination)
-        else:
-            destination.symlink_to(child, target_is_directory=child.is_dir())
+        if destination.exists():
+            if child.is_dir():
+                _mirror_project_entries(child, destination)
+            continue
+        destination.symlink_to(child, target_is_directory=child.is_dir())
 
 
 def _project_uv_options(
@@ -2527,60 +2673,53 @@ def _is_uv_run_command(command: Sequence[str]) -> bool:
 
 
 def _project_declares_vyper(pyproject: Path | None) -> bool:
-    if pyproject is None:
-        return False
-    data = _project_data(pyproject)
-    if any(_dependency_name(spec) == "vyper" for spec in _project_dependency_specs(data)):
-        return True
-    return "vyper" in _poetry_dependency_names(data)
+    return pyproject is not None and bool(_project_vyper_specs(pyproject))
 
 
 def _project_dependency_specs(data: dict[str, object]) -> Iterator[str]:
     project = data.get("project")
     if isinstance(project, dict):
-        yield from _string_dependencies(project.get("dependencies"))
+        yield from _active_string_dependencies(project.get("dependencies"))
         optional = project.get("optional-dependencies")
         if isinstance(optional, dict):
-            for dependencies in optional.values():
-                yield from _string_dependencies(dependencies)
+            for extra, dependencies in optional.items():
+                yield from _active_string_dependencies(
+                    dependencies,
+                    extra=extra if isinstance(extra, str) else None,
+                )
     groups = data.get("dependency-groups")
     if isinstance(groups, dict):
         for dependencies in groups.values():
-            yield from _string_dependencies(dependencies)
+            yield from _active_string_dependencies(dependencies)
     tool = data.get("tool")
     uv = tool.get("uv") if isinstance(tool, dict) else None
     if isinstance(uv, dict):
-        yield from _string_dependencies(uv.get("dev-dependencies"))
+        yield from _active_string_dependencies(uv.get("dev-dependencies"))
 
 
-def _string_dependencies(value: object) -> Iterator[str]:
-    if isinstance(value, list):
-        yield from (dependency for dependency in value if isinstance(dependency, str))
-
-
-def _poetry_dependency_names(data: dict[str, object]) -> set[str]:
-    tool = data.get("tool")
-    poetry = tool.get("poetry") if isinstance(tool, dict) else None
-    if not isinstance(poetry, dict):
-        return set()
-    names = _normalized_dependency_keys(poetry.get("dependencies"))
-    groups = poetry.get("group")
-    if isinstance(groups, dict):
-        for group in groups.values():
-            if isinstance(group, dict):
-                names.update(_normalized_dependency_keys(group.get("dependencies")))
-    return names
-
-
-def _normalized_dependency_keys(value: object) -> set[str]:
-    if not isinstance(value, dict):
-        return set()
-    return {_normalized_dependency_name(name) for name in value if name != "python"}
+def _active_string_dependencies(
+    value: object,
+    *,
+    extra: str | None = None,
+) -> Iterator[str]:
+    if not isinstance(value, list):
+        return
+    for dependency in value:
+        if not isinstance(dependency, str):
+            continue
+        try:
+            requirement = Requirement(dependency)
+        except InvalidRequirement:
+            continue
+        if requirement.marker is None or requirement.marker.evaluate({"extra": extra or ""}):
+            yield dependency
 
 
 def _dependency_name(dependency: str) -> str | None:
-    match = re.match(r"\s*([A-Za-z0-9_.-]+)", dependency)
-    return _normalized_dependency_name(match.group(1)) if match else None
+    try:
+        return _normalized_dependency_name(Requirement(dependency).name)
+    except InvalidRequirement:
+        return None
 
 
 def _normalized_dependency_name(name: str) -> str:

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -2221,9 +2221,11 @@ def _project_environment_command(
         return [*environment, *command]
 
     command_index = _uv_run_command_index(command)
+    project_declares_vyper = _project_declares_vyper(pyproject)
     options = _project_uv_options(
         command[2:command_index],
-        remove_vyper=project_compiler and _project_declares_vyper(pyproject),
+        remove_vyper=project_compiler and project_declares_vyper,
+        remove_python=not project_compiler or project_declares_vyper,
     )
     return [*environment, *options, *command[command_index:]]
 
@@ -2239,7 +2241,9 @@ def _mirror_project_root(source: Path, target: Path) -> None:
             destination.symlink_to(child, target_is_directory=child.is_dir())
 
 
-def _project_uv_options(options: Sequence[str], *, remove_vyper: bool) -> list[str]:
+def _project_uv_options(
+    options: Sequence[str], *, remove_vyper: bool, remove_python: bool
+) -> list[str]:
     kept: list[str] = []
     index = 0
     while index < len(options):
@@ -2247,7 +2251,7 @@ def _project_uv_options(options: Sequence[str], *, remove_vyper: bool) -> list[s
         if option == "--no-project":
             index += 1
             continue
-        if remove_vyper and option == "--python":
+        if remove_python and option == "--python":
             index += 2
             continue
         if (

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -2364,6 +2364,8 @@ def _compiler_authority(
     marker_environment: Mapping[str, str] | None = None,
 ) -> CompilerAuthority:
     pyproject = _nearest_pyproject(path.parent)
+    if not _is_uv_run_command(command):
+        return "explicit-executable"
     if project_compiler and _project_declares_vyper(pyproject, marker_environment):
         assert pyproject is not None
         workspace_manifest = _owning_uv_workspace(pyproject)
@@ -2372,8 +2374,6 @@ def _compiler_authority(
             if (workspace_manifest.parent / "uv.lock").is_file()
             else "project-manifest"
         )
-    if not _is_uv_run_command(command):
-        return "explicit-executable"
     if not project_compiler:
         return "fixed-target"
     source_spec = infer_pragma(path.read_text(encoding="utf-8"))
@@ -2640,11 +2640,9 @@ def _project_environment_command(
         "--all-extras",
         "--all-groups",
     ]
-    project_declares_vyper = _project_declares_vyper(pyproject, marker_environment)
     if not _is_uv_run_command(command):
-        if project_compiler and project_declares_vyper:
-            return [*environment, "vyper"]
         return [*environment, *command]
+    project_declares_vyper = _project_declares_vyper(pyproject, marker_environment)
 
     command_index = _uv_run_command_index(command)
     options = _project_uv_options(

--- a/src/vyupgrade/compiler_runner.py
+++ b/src/vyupgrade/compiler_runner.py
@@ -8,7 +8,6 @@ import json
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
@@ -17,13 +16,13 @@ from pathlib import Path
 
 
 _VERSION_PATTERN = re.compile(r"\b\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)?\b")
-
-
-class _CompilerTimedOut(Exception):
-    pass
+_MANAGED_WORKER_ARGUMENT = "--managed-compiler-worker"
 
 
 def main() -> None:
+    if sys.argv[1:2] == [_MANAGED_WORKER_ARGUMENT]:
+        _managed_compiler_worker(sys.argv[2:])
+        return
     result_path, timeout, managed_value, coherence, *command = sys.argv[1:]
     destination = Path(result_path)
     managed = managed_value == "managed"
@@ -118,36 +117,74 @@ def main() -> None:
 
 
 def _run_managed_compiler(command: list[str], timeout: float) -> dict[str, object]:
-    vyper_compile = importlib.import_module("vyper.cli.vyper_compile")
-    exception_type = importlib.import_module("vyper.exceptions").VyperException
+    process = subprocess.run(
+        [
+            sys.executable,
+            *(("-S",) if sys.flags.no_site else ()),
+            str(Path(__file__).resolve()),
+            _MANAGED_WORKER_ARGUMENT,
+            *command,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if process.returncode != 0:
+        signaled = process.returncode < 0
+        return {
+            "returncode": process.returncode,
+            "failure_origin": "compiler-internal" if signaled else "adapter",
+            "completion_status": "signaled" if signaled else "adapter-failed",
+            "stdout": process.stdout,
+            "stderr": process.stderr,
+        }
+    try:
+        result = json.loads(process.stdout)
+    except json.JSONDecodeError:
+        return {
+            "returncode": 1,
+            "failure_origin": "adapter",
+            "completion_status": "adapter-failed",
+            "stdout": process.stdout,
+            "stderr": process.stderr or "managed compiler worker returned invalid output",
+        }
+    if not isinstance(result, dict):
+        return {
+            "returncode": 1,
+            "failure_origin": "adapter",
+            "completion_status": "adapter-failed",
+            "stdout": process.stdout,
+            "stderr": process.stderr or "managed compiler worker returned invalid output",
+        }
+    return result
+
+
+def _managed_compiler_worker(command: list[str]) -> None:
+    sys.stdout.write(json.dumps(_managed_compiler_result(command)))
+
+
+def _managed_compiler_result(command: list[str]) -> dict[str, object]:
     with (
         tempfile.TemporaryFile("w+", encoding="utf-8") as stdout,
         tempfile.TemporaryFile("w+", encoding="utf-8") as stderr,
     ):
-        previous_handler = signal.signal(signal.SIGALRM, _timeout_handler)
-        signal.setitimer(signal.ITIMER_REAL, timeout)
-        try:
-            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-                try:
-                    vyper_compile._parse_args(command[1:])
-                    returncode = 0
-                    origin = None
-                except exception_type as exc:
-                    traceback.print_exception(exc, file=stderr)
-                    returncode = 1
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            try:
+                vyper_compile = importlib.import_module("vyper.cli.vyper_compile")
+                exception_type = importlib.import_module("vyper.exceptions").VyperException
+                vyper_compile._parse_args(command[1:])
+                returncode = 0
+                origin = None
+            except SystemExit as exc:
+                returncode = exc.code if type(exc.code) is int else 1
+                origin = None if returncode == 0 else "adapter"
+            except BaseException as exc:
+                if "exception_type" in locals() and isinstance(exc, exception_type):
                     origin = "compiler"
-                except _CompilerTimedOut:
-                    raise subprocess.TimeoutExpired(command, timeout) from None
-                except SystemExit as exc:
-                    returncode = exc.code if type(exc.code) is int else 1
-                    origin = None if returncode == 0 else "adapter"
-                except BaseException as exc:
-                    traceback.print_exception(exc, file=stderr)
-                    returncode = 1
+                else:
                     origin = "compiler-internal"
-        finally:
-            signal.setitimer(signal.ITIMER_REAL, 0)
-            signal.signal(signal.SIGALRM, previous_handler)
+                traceback.print_exception(exc, file=stderr)
+                returncode = 1
         stdout.seek(0)
         stderr.seek(0)
         return {
@@ -321,10 +358,6 @@ def _failure_payload(
         "error": error,
         **evidence,
     }
-
-
-def _timeout_handler(_signum: int, _frame: object) -> None:
-    raise _CompilerTimedOut
 
 
 def _timeout_text(value: str | bytes | None) -> str:

--- a/src/vyupgrade/compiler_runner.py
+++ b/src/vyupgrade/compiler_runner.py
@@ -133,7 +133,7 @@ def _run_managed_compiler(command: list[str], timeout: float) -> dict[str, objec
         signaled = process.returncode < 0
         return {
             "returncode": process.returncode,
-            "failure_origin": "compiler-internal" if signaled else "adapter",
+            "failure_origin": "compiler-internal",
             "completion_status": "signaled" if signaled else "adapter-failed",
             "stdout": process.stdout,
             "stderr": process.stderr,

--- a/src/vyupgrade/compiler_runner.py
+++ b/src/vyupgrade/compiler_runner.py
@@ -1,67 +1,109 @@
 from __future__ import annotations
 
+import contextlib
+import hashlib
+import importlib
 import importlib.metadata
 import json
 import os
 import re
+import shutil
+import signal
 import subprocess
 import sys
+import tempfile
+import traceback
 from pathlib import Path
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 
 _VERSION_PATTERN = re.compile(r"\b\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)?\b")
 
 
+class _CompilerTimedOut(Exception):
+    pass
+
+
 def main() -> None:
-    result_path, timeout, managed, *command = sys.argv[1:]
+    result_path, timeout, managed_value, coherence_spec, *command = sys.argv[1:]
     destination = Path(result_path)
+    managed = managed_value == "managed"
     _write_result(destination, {"state": "started"})
     try:
-        resolved_compiler = _resolved_compiler(command, managed == "managed")
-    except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+        resolved_compiler, compiler_identity = _resolved_compiler(command, managed)
+        packages = _resolved_packages()
+    except OSError as exc:
         _write_result(
             destination,
-            {
-                "state": "complete",
-                "compiler_started": False,
-                "failure_origin": "launch",
-                "resolved_compiler": None,
-                "error": f"could not identify compiler: {exc}",
-            },
+            _failure_payload(
+                origin="environment" if managed else "launch",
+                completion_status="not-started",
+                error=f"could not identify compiler: {exc}",
+            ),
+        )
+        return
+    except (RuntimeError, subprocess.TimeoutExpired) as exc:
+        _write_result(
+            destination,
+            _failure_payload(
+                origin="environment" if managed else "adapter",
+                completion_status="not-started",
+                error=f"could not identify compiler: {exc}",
+            ),
+        )
+        return
+
+    evidence = {
+        "resolved_compiler": resolved_compiler,
+        "compiler_identity": compiler_identity,
+        "resolved_packages": packages,
+    }
+    if coherence_spec and not _version_satisfies(resolved_compiler, coherence_spec):
+        _write_result(
+            destination,
+            _failure_payload(
+                origin="environment",
+                completion_status="not-started",
+                error=(
+                    f"resolved project compiler {resolved_compiler} conflicts with "
+                    f"source declaration {coherence_spec}"
+                ),
+                **evidence,
+            ),
         )
         return
 
     try:
-        process = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            timeout=float(timeout),
+        process = (
+            _run_managed_compiler(command, float(timeout))
+            if managed and command and command[0] == "vyper"
+            else _run_explicit_compiler(command, float(timeout))
         )
     except subprocess.TimeoutExpired as exc:
         _write_result(
             destination,
-            {
-                "state": "complete",
-                "compiler_started": True,
-                "failure_origin": "timeout",
-                "resolved_compiler": resolved_compiler,
-                "stdout": _timeout_text(exc.stdout),
-                "stderr": _timeout_text(exc.stderr),
-                "error": f"compiler timed out after {timeout} seconds",
-            },
+            _failure_payload(
+                origin="timeout",
+                completion_status="timed-out",
+                compiler_started=True,
+                stdout=_timeout_text(exc.stdout),
+                stderr=_timeout_text(exc.stderr),
+                error=f"compiler timed out after {timeout} seconds",
+                **evidence,
+            ),
         )
         return
     except OSError as exc:
         _write_result(
             destination,
-            {
-                "state": "complete",
-                "compiler_started": False,
-                "failure_origin": "launch",
-                "resolved_compiler": resolved_compiler,
-                "error": f"compiler failed to start: {exc}",
-            },
+            _failure_payload(
+                origin="launch",
+                completion_status="not-started",
+                error=f"compiler failed to start: {exc}",
+                **evidence,
+            ),
         )
         return
 
@@ -70,32 +112,214 @@ def main() -> None:
         {
             "state": "complete",
             "compiler_started": True,
-            "failure_origin": "compiler" if process.returncode != 0 else None,
-            "resolved_compiler": resolved_compiler,
-            "returncode": process.returncode,
-            "stdout": process.stdout,
-            "stderr": process.stderr,
+            "failure_origin": process["failure_origin"],
+            "completion_status": process["completion_status"],
+            "returncode": process["returncode"],
+            "stdout": process["stdout"],
+            "stderr": process["stderr"],
+            **evidence,
         },
     )
 
 
-def _resolved_compiler(command: list[str], managed: bool) -> str:
-    if managed:
-        return importlib.metadata.version("vyper")
+def _run_managed_compiler(command: list[str], timeout: float) -> dict[str, object]:
+    vyper_compile = importlib.import_module("vyper.cli.vyper_compile")
+    exception_type = importlib.import_module("vyper.exceptions").VyperException
+    with (
+        tempfile.TemporaryFile("w+", encoding="utf-8") as stdout,
+        tempfile.TemporaryFile("w+", encoding="utf-8") as stderr,
+    ):
+        previous_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+        signal.setitimer(signal.ITIMER_REAL, timeout)
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                try:
+                    vyper_compile._parse_args(command[1:])
+                    returncode = 0
+                    origin = None
+                except exception_type as exc:
+                    traceback.print_exception(exc, file=stderr)
+                    returncode = 1
+                    origin = "compiler"
+                except _CompilerTimedOut:
+                    raise subprocess.TimeoutExpired(command, timeout) from None
+                except SystemExit as exc:
+                    returncode = exc.code if type(exc.code) is int else 1
+                    origin = None if returncode == 0 else "adapter"
+                except BaseException as exc:
+                    traceback.print_exception(exc, file=stderr)
+                    returncode = 1
+                    origin = "compiler-internal"
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, previous_handler)
+        stdout.seek(0)
+        stderr.seek(0)
+        return {
+            "returncode": returncode,
+            "failure_origin": origin,
+            "completion_status": "completed",
+            "stdout": stdout.read(),
+            "stderr": stderr.read(),
+        }
+
+
+def _run_explicit_compiler(command: list[str], timeout: float) -> dict[str, object]:
     process = subprocess.run(
-        [command[0], "--version"],
+        command,
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=timeout,
     )
-    if process.returncode != 0:
-        raise RuntimeError(
-            process.stderr.strip() or process.stdout.strip() or "version query failed"
+    signaled = process.returncode < 0
+    return {
+        "returncode": process.returncode,
+        "failure_origin": (
+            "compiler-internal" if signaled else "adapter" if process.returncode != 0 else None
+        ),
+        "completion_status": "signaled" if signaled else "completed",
+        "stdout": process.stdout,
+        "stderr": process.stderr,
+    }
+
+
+def _resolved_compiler(command: list[str], managed: bool) -> tuple[str, dict[str, object]]:
+    if managed:
+        version = importlib.metadata.version("vyper")
+    else:
+        process = subprocess.run(
+            [command[0], "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
-    match = _VERSION_PATTERN.search(process.stdout)
-    if match is None:
-        raise RuntimeError("version query returned no version")
-    return match.group(0)
+        if process.returncode != 0:
+            raise RuntimeError(
+                process.stderr.strip() or process.stdout.strip() or "version query failed"
+            )
+        match = _VERSION_PATTERN.search(process.stdout)
+        if match is None:
+            raise RuntimeError("version query returned no version")
+        version = match.group(0)
+    executable = (
+        _managed_executable_identity(command[0])
+        if managed
+        else _file_identity(_resolved_executable(command[0]))
+    )
+    artifact = _compiler_artifact_identity() if managed else executable
+    return version, {
+        "version": version,
+        "executable": executable,
+        "artifact": artifact,
+    }
+
+
+def _resolved_executable(command: str) -> Path:
+    resolved = shutil.which(command)
+    if resolved is None:
+        return Path(command).resolve(strict=True)
+    return Path(resolved).resolve(strict=True)
+
+
+def _managed_executable_identity(command: str) -> dict[str, str]:
+    path = _resolved_executable(command)
+    lines = path.read_bytes().splitlines(keepends=True)
+    if lines and lines[0].startswith(b"#!"):
+        lines[0] = b"#!python\n"
+    return {
+        "path": command,
+        "sha256": hashlib.sha256(b"".join(lines)).hexdigest(),
+    }
+
+
+def _compiler_artifact_identity() -> dict[str, str]:
+    distribution = importlib.metadata.distribution("vyper")
+    artifact = _distribution_artifact(distribution)
+    if artifact is None:
+        raise RuntimeError("vyper distribution has no RECORD or METADATA artifact")
+    return artifact
+
+
+def _resolved_packages() -> list[dict[str, str | None]]:
+    packages: dict[tuple[str, str, str | None, str], dict[str, str | None]] = {}
+    for distribution in importlib.metadata.distributions():
+        name = distribution.metadata.get("Name")
+        if not name:
+            continue
+        artifact = _distribution_artifact(distribution)
+        if artifact is None:
+            continue
+        source = _canonical_json(distribution.read_text("direct_url.json"))
+        identity = (name.lower(), distribution.version, source, artifact["sha256"])
+        packages[identity] = {
+            "name": name,
+            "version": distribution.version,
+            "source": source,
+            "artifact_sha256": artifact["sha256"],
+        }
+    return [packages[identity] for identity in sorted(packages, key=repr)]
+
+
+def _distribution_artifact(
+    distribution: importlib.metadata.Distribution,
+) -> dict[str, str] | None:
+    files = distribution.files or ()
+    for suffix in (".dist-info/RECORD", ".dist-info/METADATA"):
+        entry = next((file for file in files if str(file).endswith(suffix)), None)
+        if entry is None:
+            continue
+        path = Path(distribution.locate_file(entry)).resolve()
+        if path.is_file():
+            return _file_identity(path)
+    return None
+
+
+def _canonical_json(value: str | None) -> str | None:
+    if value is None:
+        return None
+    try:
+        return json.dumps(json.loads(value), sort_keys=True, separators=(",", ":"))
+    except json.JSONDecodeError:
+        return value
+
+
+def _file_identity(path: Path) -> dict[str, str]:
+    return {"path": str(path), "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+
+
+def _version_satisfies(version: str, declaration: str) -> bool:
+    normalized = declaration.strip()
+    if re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z]+\d+)?", normalized):
+        normalized = f"=={normalized}"
+    elif normalized.startswith("^"):
+        normalized = f"~={normalized[1:]}"
+    try:
+        return SpecifierSet(normalized).contains(Version(version), prereleases=True)
+    except (InvalidSpecifier, InvalidVersion):
+        return False
+
+
+def _failure_payload(
+    *,
+    origin: str,
+    completion_status: str,
+    compiler_started: bool = False,
+    error: str,
+    **evidence: object,
+) -> dict[str, object]:
+    return {
+        "state": "complete",
+        "compiler_started": compiler_started,
+        "failure_origin": origin,
+        "completion_status": completion_status,
+        "returncode": None,
+        "error": error,
+        **evidence,
+    }
+
+
+def _timeout_handler(_signum: int, _frame: object) -> None:
+    raise _CompilerTimedOut
 
 
 def _timeout_text(value: str | bytes | None) -> str:

--- a/src/vyupgrade/compiler_runner.py
+++ b/src/vyupgrade/compiler_runner.py
@@ -15,9 +15,6 @@ import tempfile
 import traceback
 from pathlib import Path
 
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
-from packaging.version import InvalidVersion, Version
-
 
 _VERSION_PATTERN = re.compile(r"\b\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)?\b")
 
@@ -27,7 +24,7 @@ class _CompilerTimedOut(Exception):
 
 
 def main() -> None:
-    result_path, timeout, managed_value, coherence_spec, *command = sys.argv[1:]
+    result_path, timeout, managed_value, coherence, *command = sys.argv[1:]
     destination = Path(result_path)
     managed = managed_value == "managed"
     _write_result(destination, {"state": "started"})
@@ -60,16 +57,14 @@ def main() -> None:
         "compiler_identity": compiler_identity,
         "resolved_packages": packages,
     }
-    if coherence_spec and not _version_satisfies(resolved_compiler, coherence_spec):
+    coherence_error = _compiler_coherence_error(resolved_compiler, coherence)
+    if coherence_error is not None:
         _write_result(
             destination,
             _failure_payload(
                 origin="environment",
                 completion_status="not-started",
-                error=(
-                    f"resolved project compiler {resolved_compiler} conflicts with "
-                    f"source declaration {coherence_spec}"
-                ),
+                error=coherence_error,
                 **evidence,
             ),
         )
@@ -287,16 +282,26 @@ def _file_identity(path: Path) -> dict[str, str]:
     return {"path": str(path), "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
 
 
-def _version_satisfies(version: str, declaration: str) -> bool:
-    normalized = declaration.strip()
-    if re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z]+\d+)?", normalized):
-        normalized = f"=={normalized}"
-    elif normalized.startswith("^"):
-        normalized = f"~={normalized[1:]}"
+def _compiler_coherence_error(version: str, raw_evidence: str) -> str | None:
+    if not raw_evidence:
+        return None
     try:
-        return SpecifierSet(normalized).contains(Version(version), prereleases=True)
-    except (InvalidSpecifier, InvalidVersion):
-        return False
+        evidence = json.loads(raw_evidence)
+    except json.JSONDecodeError:
+        return "compiler coherence evidence is malformed"
+    if not isinstance(evidence, dict):
+        return "compiler coherence evidence is malformed"
+    declaration = evidence.get("declaration")
+    versions = evidence.get("versions")
+    if (
+        not isinstance(declaration, str)
+        or not isinstance(versions, list)
+        or not all(isinstance(candidate, str) for candidate in versions)
+    ):
+        return "compiler coherence evidence is malformed"
+    if version in versions:
+        return None
+    return f"resolved project compiler {version} conflicts with source declaration {declaration}"
 
 
 def _failure_payload(

--- a/src/vyupgrade/compiler_runner.py
+++ b/src/vyupgrade/compiler_runner.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+_VERSION_PATTERN = re.compile(r"\b\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)?\b")
+
+
+def main() -> None:
+    result_path, timeout, managed, *command = sys.argv[1:]
+    destination = Path(result_path)
+    _write_result(destination, {"state": "started"})
+    try:
+        resolved_compiler = _resolved_compiler(command, managed == "managed")
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+        _write_result(
+            destination,
+            {
+                "state": "complete",
+                "compiler_started": False,
+                "failure_origin": "launch",
+                "resolved_compiler": None,
+                "error": f"could not identify compiler: {exc}",
+            },
+        )
+        return
+
+    try:
+        process = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=float(timeout),
+        )
+    except subprocess.TimeoutExpired as exc:
+        _write_result(
+            destination,
+            {
+                "state": "complete",
+                "compiler_started": True,
+                "failure_origin": "timeout",
+                "resolved_compiler": resolved_compiler,
+                "stdout": _timeout_text(exc.stdout),
+                "stderr": _timeout_text(exc.stderr),
+                "error": f"compiler timed out after {timeout} seconds",
+            },
+        )
+        return
+    except OSError as exc:
+        _write_result(
+            destination,
+            {
+                "state": "complete",
+                "compiler_started": False,
+                "failure_origin": "launch",
+                "resolved_compiler": resolved_compiler,
+                "error": f"compiler failed to start: {exc}",
+            },
+        )
+        return
+
+    _write_result(
+        destination,
+        {
+            "state": "complete",
+            "compiler_started": True,
+            "failure_origin": "compiler" if process.returncode != 0 else None,
+            "resolved_compiler": resolved_compiler,
+            "returncode": process.returncode,
+            "stdout": process.stdout,
+            "stderr": process.stderr,
+        },
+    )
+
+
+def _resolved_compiler(command: list[str], managed: bool) -> str:
+    if managed:
+        return importlib.metadata.version("vyper")
+    process = subprocess.run(
+        [command[0], "--version"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(
+            process.stderr.strip() or process.stdout.strip() or "version query failed"
+        )
+    match = _VERSION_PATTERN.search(process.stdout)
+    if match is None:
+        raise RuntimeError("version query returned no version")
+    return match.group(0)
+
+
+def _timeout_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    return value.decode(errors="replace") if isinstance(value, bytes) else value
+
+
+def _write_result(path: Path, result: dict[str, object]) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(result), encoding="utf-8")
+    os.replace(temporary, path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -15,12 +16,19 @@ from .compiler import (
 )
 from .interfaces import split_interfaces_to_vyi
 from .models import (
+    CompileAttempt,
+    CompilerDeclaration,
+    ContentIdentity,
+    DeclaredSpec,
+    DependencyContext,
     Config,
     Diagnostic,
     FileReport,
     GeneratedFile,
     RewriteResult,
     ValidationDecision,
+    TargetFailureOrigin,
+    ValidationAttestation,
 )
 from .rule_registry import is_enabled
 from .rules import RULE_CHANGES, apply_rules
@@ -119,22 +127,24 @@ def bounded_migration_request(
     return MigrationRequest(path, original, source_version, attempts, role=role)
 
 
-def prepare_migrations(
-    requests: Iterable[MigrationRequest], config: Config
-) -> MigrationBatch:
+def prepare_migrations(requests: Iterable[MigrationRequest], config: Config) -> MigrationBatch:
     """Compile and rewrite sources without mutating their destinations."""
-    files: list[MigrationFile] = []
-    for request in requests:
-        attempt, source_compile = _compile_source(request, config)
-        source_version = (
-            attempt.rule_version if attempt is not None else request.source_version
+    request_list = tuple(requests)
+    snapshot_sources = tuple(
+        ContentIdentity(
+            str(request.path.resolve()),
+            hashlib.sha256(request.original.encode()).hexdigest(),
         )
+        for request in request_list
+    )
+    files: list[MigrationFile] = []
+    for request in request_list:
+        attempt, source_compile = _compile_source(request, config)
+        source_version = attempt.rule_version if attempt is not None else request.source_version
         source_compiler = source_compile.resolved_compiler or (
             attempt.compiler_label if attempt is not None else None
         )
-        source_ast = (
-            source_compile.artifacts.get("ast") if source_compile.artifacts else None
-        )
+        source_ast = source_compile.artifacts.get("ast") if source_compile.artifacts else None
         # Config.source_ast remains the compatibility bridge for rules, but this
         # derived config belongs to this file and is never reused by another file.
         file_config = replace(
@@ -169,23 +179,21 @@ def prepare_migrations(
             source_version=source_version,
             source_compiler=source_compiler,
             source_compile=source_compile.status,
-            source_unavailable_formats=list(
-                getattr(source_compile, "unavailable_formats", ())
-            ),
-            source_error=(
-                source_compile.stderr if source_compile.status == "failed" else None
-            ),
-            declared_spec=request.source_version,
-            resolved_compiler=source_compile.resolved_compiler,
-            dependency_context=source_compile.dependency_context,
-            compiler_started=source_compile.compiler_started,
-            failure_origin=source_compile.failure_origin,
-            compiler_output=source_compile.compiler_output,
+            source_unavailable_formats=list(getattr(source_compile, "unavailable_formats", ())),
+            source_error=(source_compile.stderr if source_compile.status == "failed" else None),
+            source_attestation=_validation_attestation(
+                source_compile,
+                _declared_spec(snapshot_sources, source_compile.compiler_declarations),
+                attempt_source=ContentIdentity(
+                    str(request.path.resolve()),
+                    hashlib.sha256(request.original.encode()).hexdigest(),
+                ),
+            )
+            if source_compile.status != "skipped"
+            else None,
         )
         if source_compile.status != "skipped":
-            report.source_unavailable_artifacts = unavailable_validation_artifacts(
-                source_compile
-            )
+            report.source_unavailable_artifacts = unavailable_validation_artifacts(source_compile)
         files.append(
             MigrationFile(
                 request,
@@ -220,6 +228,13 @@ def validate_migrations(
     """Validate one coherent candidate overlay and return its typed decision."""
     resolve_candidate = candidate_source or _unchanged_candidate
     target_sources = candidate_sources(batch, resolve_candidate)
+    target_declared_spec = _declared_spec(
+        tuple(
+            ContentIdentity(str(path.resolve()), hashlib.sha256(source.encode()).hexdigest())
+            for path, source in target_sources.items()
+        ),
+        (CompilerDeclaration("target-version", config.target_version),),
+    )
 
     with target_overlay(
         target_sources,
@@ -228,9 +243,7 @@ def validate_migrations(
         include_dependencies=config.include_dependencies,
     ) as overlay:
         for migration in batch.files:
-            _reset_target_validation(
-                migration.report, migration.validation_diagnostics
-            )
+            _reset_target_validation(migration.report, migration.validation_diagnostics)
             migration.target_compile = None
             source_context = MigrationContext.from_specs(
                 migration.request.source_version, config.target_version
@@ -247,7 +260,11 @@ def validate_migrations(
                 overlay,
             )
             migration.target_compile = target_compile
-            _record_target_compile(migration.report, target_compile)
+            _record_target_compile(
+                migration.report,
+                target_compile,
+                target_declared_spec,
+            )
             (
                 migration.report.abi_equal,
                 migration.report.method_ids_equal,
@@ -268,9 +285,7 @@ def validate_migrations(
             )
 
         for migration in batch.generated:
-            _reset_target_validation(
-                migration.report, migration.validation_diagnostics
-            )
+            _reset_target_validation(migration.report, migration.validation_diagnostics)
             migration.target_compile = None
             target_compile = compile_target_source(
                 migration.file.path,
@@ -279,7 +294,11 @@ def validate_migrations(
                 overlay,
             )
             migration.target_compile = target_compile
-            _record_target_compile(migration.report, target_compile)
+            _record_target_compile(
+                migration.report,
+                target_compile,
+                target_declared_spec,
+            )
 
     return decide_run_validation(batch.reports, config)
 
@@ -293,12 +312,8 @@ def _compile_source(
     first_attempt: SourceCompileAttempt | None = None
     first_result: CompileResult | None = None
     for attempt in request.source_attempts:
-        attempt_config = replace(
-            config, source_version=attempt.rule_version, source_ast=None
-        )
-        result = compile_source_file(
-            request.path, attempt_config, attempt.compile_version
-        )
+        attempt_config = replace(config, source_version=attempt.rule_version, source_ast=None)
+        result = compile_source_file(request.path, attempt_config, attempt.compile_version)
         if first_result is None:
             first_attempt = attempt
             first_result = result
@@ -312,9 +327,7 @@ def _unchanged_candidate(_path: Path, source: str) -> str:
     return source
 
 
-def candidate_sources(
-    batch: MigrationBatch, resolve_candidate: CandidateSource
-) -> dict[Path, str]:
+def candidate_sources(batch: MigrationBatch, resolve_candidate: CandidateSource) -> dict[Path, str]:
     candidates = [
         *(
             (
@@ -375,24 +388,103 @@ def candidate_sources(
     return target_sources
 
 
-def _record_target_compile(report: FileReport, target_compile: CompileResult) -> None:
+def _declared_spec(
+    sources: tuple[ContentIdentity, ...],
+    compiler_declarations: tuple[CompilerDeclaration, ...],
+) -> DeclaredSpec:
+    digest = hashlib.sha256()
+    ordered_sources = tuple(sorted(sources, key=lambda source: source.path))
+    for source in ordered_sources:
+        digest.update(source.path.encode())
+        digest.update(b"\0")
+        digest.update(source.sha256.encode())
+        digest.update(b"\0")
+    return DeclaredSpec(digest.hexdigest(), ordered_sources, compiler_declarations)
+
+
+def _validation_attestation(
+    result: CompileResult,
+    declared_spec: DeclaredSpec,
+    *,
+    attempt_source: ContentIdentity,
+    failure_origin: TargetFailureOrigin | None = None,
+) -> ValidationAttestation:
+    origin = failure_origin if failure_origin is not None else result.failure_origin
+    attempt = CompileAttempt(
+        sequence=1,
+        source=attempt_source,
+        compiler_started=result.compiler_started,
+        completion_status=result.completion_status,
+        exit_status=result.exit_status,
+        failure_origin=origin,
+    )
+    return ValidationAttestation(
+        declared_spec=declared_spec,
+        authority_rule=result.compiler_authority,
+        resolved_compiler=result.compiler_identity,
+        dependency_context=result.dependency_context or DependencyContext(mode="isolated"),
+        compiler_started=result.compiler_started,
+        completion_status=result.completion_status,
+        exit_status=result.exit_status,
+        validated_source_set=result.validated_sources,
+        attempt_sequence=(attempt,),
+        failure_origin=origin,
+        compiler_output=result.compiler_output,
+    )
+
+
+def _target_failure_origin(
+    origin: object,
+    *,
+    role: str,
+) -> TargetFailureOrigin | None:
+    if origin == "compiler":
+        return "fixed-target-dependency" if role == "dependency" else "fixed-target-rewrite"
+    if origin in {
+        "compiler-internal",
+        "environment",
+        "launch",
+        "timeout",
+        "adapter",
+    }:
+        return origin
+    return None
+
+
+def _record_target_compile(
+    report: FileReport,
+    target_compile: CompileResult,
+    declared_spec: DeclaredSpec,
+) -> None:
     report.target_compile = target_compile.status
     report.target_unavailable_artifacts = unavailable_validation_artifacts(target_compile)
-    report.target_unavailable_formats = list(
-        getattr(target_compile, "unavailable_formats", ())
+    report.target_unavailable_formats = list(getattr(target_compile, "unavailable_formats", ()))
+    report.target_error = target_compile.stderr if target_compile.status == "failed" else None
+    report_source = next(
+        (source for source in declared_spec.sources if source.path == str(report.path.resolve())),
+        declared_spec.sources[0],
     )
-    report.target_error = (
-        target_compile.stderr if target_compile.status == "failed" else None
-    )
+    if target_compile.status != "skipped":
+        origin = _target_failure_origin(target_compile.failure_origin, role=report.role)
+        attempt_source = (
+            target_compile.validated_sources[0]
+            if target_compile.validated_sources
+            else report_source
+        )
+        report.target_attestation = _validation_attestation(
+            target_compile,
+            declared_spec,
+            attempt_source=attempt_source,
+            failure_origin=origin,
+        )
 
 
-def _reset_target_validation(
-    report: FileReport, validation_diagnostics: list[Diagnostic]
-) -> None:
+def _reset_target_validation(report: FileReport, validation_diagnostics: list[Diagnostic]) -> None:
     report.target_compile = "skipped"
     report.target_unavailable_artifacts.clear()
     report.target_unavailable_formats.clear()
     report.target_error = None
+    report.target_attestation = None
     report.abi_equal = None
     report.method_ids_equal = None
     report.storage_layout_equal = None
@@ -403,9 +495,7 @@ def _reset_target_validation(
     validation_ids = {id(diagnostic) for diagnostic in validation_diagnostics}
     if validation_ids:
         report.diagnostics = [
-            diagnostic
-            for diagnostic in report.diagnostics
-            if id(diagnostic) not in validation_ids
+            diagnostic for diagnostic in report.diagnostics if id(diagnostic) not in validation_ids
         ]
     validation_diagnostics.clear()
 
@@ -450,9 +540,7 @@ def _rule_enabled(rule: str, source_version: str | None, config: Config) -> bool
     return is_enabled(rule, config, context, RULE_CHANGES)
 
 
-def _evm_default_diagnostic(
-    source_version: str | None, target_version: str
-) -> Diagnostic | None:
+def _evm_default_diagnostic(source_version: str | None, target_version: str) -> Diagnostic | None:
     source_evm = default_evm_version_for_spec(source_version)
     target_evm = default_evm_version_for_spec(target_version)
     if source_evm is not None and target_evm is not None:

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -129,7 +129,9 @@ def prepare_migrations(
         source_version = (
             attempt.rule_version if attempt is not None else request.source_version
         )
-        source_compiler = attempt.compiler_label if attempt is not None else None
+        source_compiler = source_compile.resolved_compiler or (
+            attempt.compiler_label if attempt is not None else None
+        )
         source_ast = (
             source_compile.artifacts.get("ast") if source_compile.artifacts else None
         )
@@ -173,6 +175,12 @@ def prepare_migrations(
             source_error=(
                 source_compile.stderr if source_compile.status == "failed" else None
             ),
+            declared_spec=request.source_version,
+            resolved_compiler=source_compile.resolved_compiler,
+            dependency_context=source_compile.dependency_context,
+            compiler_started=source_compile.compiler_started,
+            failure_origin=source_compile.failure_origin,
+            compiler_output=source_compile.compiler_output,
         )
         if source_compile.status != "skipped":
             report.source_unavailable_artifacts = unavailable_validation_artifacts(

--- a/src/vyupgrade/interfaces.py
+++ b/src/vyupgrade/interfaces.py
@@ -68,7 +68,10 @@ def _top_level_interface_blocks(source: str) -> list[_InterfaceBlock]:
     while index < len(lines):
         line = lines[index]
         start = offsets[index]
-        match = re.match(r"interface[ \t]+([A-Za-z_][A-Za-z0-9_]*)(?:[ \t]*\([^)]*\))?[ \t]*:[ \t]*(?:#.*)?(?:\n)?$", line)
+        match = re.match(
+            r"interface[ \t]+([A-Za-z_][A-Za-z0-9_]*)(?:[ \t]*\([^)]*\))?[ \t]*:[ \t]*(?:#.*)?(?:\n)?$",
+            line,
+        )
         if match is None or not span_is_code(mask, start, start + match.end(1)):
             index += 1
             continue
@@ -140,12 +143,17 @@ def _interface_body_to_vyi(body: str) -> str:
             header_lines.append(lines[index])
             index += 1
         mutability = _interface_def_mutability("".join(header_lines))
-        if mutability is None and index < len(lines) and lines[index].strip() in {
-            "view",
-            "pure",
-            "payable",
-            "nonpayable",
-        }:
+        if (
+            mutability is None
+            and index < len(lines)
+            and lines[index].strip()
+            in {
+                "view",
+                "pure",
+                "payable",
+                "nonpayable",
+            }
+        ):
             mutability = lines[index].strip()
             index += 1
         stub = _interface_def_stub("".join(header_lines), mutability)
@@ -155,11 +163,7 @@ def _interface_body_to_vyi(body: str) -> str:
 
 def _dedent_interface_body(body: str) -> str:
     lines = body.splitlines(keepends=True)
-    indents = [
-        len(line) - len(line.lstrip(" \t"))
-        for line in lines
-        if line.strip()
-    ]
+    indents = [len(line) - len(line.lstrip(" \t")) for line in lines if line.strip()]
     width = min(indents) if indents else 0
     return "".join(line[width:] if len(line) >= width else line for line in lines)
 

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -5,8 +5,40 @@ from pathlib import Path
 from typing import Any, Literal
 
 
+FailureOrigin = Literal[
+    "compiler",
+    "compiler-internal",
+    "environment",
+    "launch",
+    "timeout",
+    "adapter",
+]
+TargetFailureOrigin = Literal[
+    "fixed-target-rewrite",
+    "fixed-target-dependency",
+    "compiler-internal",
+    "environment",
+    "launch",
+    "timeout",
+    "adapter",
+]
+CompilerAuthority = Literal[
+    "project-lock",
+    "project-manifest",
+    "source-exact",
+    "source-range",
+    "explicit-executable",
+    "fixed-target",
+    "default",
+]
+CompletionStatus = Literal[
+    "not-started",
+    "completed",
+    "timed-out",
+    "signaled",
+    "adapter-failed",
+]
 Severity = Literal["info", "warning", "error"]
-FailureOrigin = Literal["compiler", "environment", "launch", "timeout", "adapter"]
 ValidationDecisionStatus = Literal["not-required", "passed", "waived", "blocked"]
 ValidationIssueCode = Literal[
     "target_compile_failed",
@@ -18,7 +50,7 @@ ValidationIssueCode = Literal[
     "method_identifiers_changed",
     "storage_layout_changed",
 ]
-REPORT_SCHEMA_VERSION = 3
+REPORT_SCHEMA_VERSION = 4
 
 
 @dataclass(frozen=True)
@@ -95,18 +127,152 @@ class CompilerOutput:
 
 
 @dataclass(frozen=True)
-class DependencyContext:
-    mode: Literal["isolated", "project"]
-    project_root: str | None = None
-    manifest: str | None = None
-    lockfile: str | None = None
+class ContentIdentity:
+    path: str
+    sha256: str
+
+    def to_json_obj(self) -> dict[str, str]:
+        return {"path": self.path, "sha256": self.sha256}
+
+
+@dataclass(frozen=True)
+class CompilerDeclaration:
+    kind: Literal["project", "source-pragma", "target-version", "explicit-executable"]
+    value: str
+    path: str | None = None
+
+    def to_json_obj(self) -> dict[str, str | None]:
+        return {"kind": self.kind, "value": self.value, "path": self.path}
+
+
+@dataclass(frozen=True)
+class DeclaredSpec:
+    snapshot_sha256: str
+    sources: tuple[ContentIdentity, ...]
+    compiler_declarations: tuple[CompilerDeclaration, ...]
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
+            "snapshot": {"sha256": self.snapshot_sha256},
+            "sources": [source.to_json_obj() for source in self.sources],
+            "compiler_declarations": [
+                declaration.to_json_obj() for declaration in self.compiler_declarations
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedCompiler:
+    version: str
+    executable: ContentIdentity
+    artifact: ContentIdentity
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "executable": self.executable.to_json_obj(),
+            "artifact": self.artifact.to_json_obj(),
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedPackage:
+    name: str
+    version: str
+    source: str | None
+    artifact_sha256: str
 
     def to_json_obj(self) -> dict[str, str | None]:
         return {
+            "name": self.name,
+            "version": self.version,
+            "source": self.source,
+            "artifact_sha256": self.artifact_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class DependencyContext:
+    mode: Literal["isolated", "project"]
+    project_root: str | None = None
+    manifest: ContentIdentity | None = None
+    lockfile: ContentIdentity | None = None
+    python_constraint: str | None = None
+    declared_sources: tuple[ContentIdentity, ...] = ()
+    resolved_packages: tuple[ResolvedPackage, ...] = ()
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
             "mode": self.mode,
             "project_root": self.project_root,
-            "manifest": self.manifest,
-            "lockfile": self.lockfile,
+            "manifest": self.manifest.to_json_obj() if self.manifest is not None else None,
+            "lockfile": self.lockfile.to_json_obj() if self.lockfile is not None else None,
+            "python_constraint": self.python_constraint,
+            "declared_sources": [source.to_json_obj() for source in self.declared_sources],
+            "resolved_packages": [package.to_json_obj() for package in self.resolved_packages],
+        }
+
+
+@dataclass(frozen=True)
+class ExitStatus:
+    code: int | None
+    signal: int | None = None
+
+    def to_json_obj(self) -> dict[str, int | None]:
+        return {"code": self.code, "signal": self.signal}
+
+
+@dataclass(frozen=True)
+class CompileAttempt:
+    sequence: int
+    source: ContentIdentity
+    compiler_started: bool
+    completion_status: CompletionStatus
+    exit_status: ExitStatus
+    failure_origin: FailureOrigin | TargetFailureOrigin | None
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
+            "sequence": self.sequence,
+            "source": self.source.to_json_obj(),
+            "compiler_started": self.compiler_started,
+            "completion_status": self.completion_status,
+            "exit_status": self.exit_status.to_json_obj(),
+            "failure_origin": self.failure_origin,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationAttestation:
+    declared_spec: DeclaredSpec
+    authority_rule: CompilerAuthority
+    resolved_compiler: ResolvedCompiler | None
+    dependency_context: DependencyContext
+    compiler_started: bool
+    completion_status: CompletionStatus
+    exit_status: ExitStatus
+    validated_source_set: tuple[ContentIdentity, ...]
+    attempt_sequence: tuple[CompileAttempt, ...]
+    failure_origin: FailureOrigin | TargetFailureOrigin | None
+    compiler_output: CompilerOutput | None
+
+    def to_json_obj(self) -> dict[str, object]:
+        return {
+            "declared_spec": self.declared_spec.to_json_obj(),
+            "authority_rule": self.authority_rule,
+            "resolved_compiler": (
+                self.resolved_compiler.to_json_obj() if self.resolved_compiler is not None else None
+            ),
+            "dependency_context": self.dependency_context.to_json_obj(),
+            "compiler_started": self.compiler_started,
+            "completion_status": self.completion_status,
+            "exit_status": self.exit_status.to_json_obj(),
+            "validated_source_set": [source.to_json_obj() for source in self.validated_source_set],
+            "attempt_sequence": [attempt.to_json_obj() for attempt in self.attempt_sequence],
+            "failure_origin": self.failure_origin,
+            "compiler_output": (
+                self.compiler_output.to_json_obj() if self.compiler_output is not None else None
+            ),
         }
 
 
@@ -122,12 +288,8 @@ class FileReport:
     source_compile: str = "skipped"
     target_compile: str = "skipped"
     source_error: str | None = None
-    declared_spec: str | None = None
-    resolved_compiler: str | None = None
-    dependency_context: DependencyContext | None = None
-    compiler_started: bool = False
-    failure_origin: FailureOrigin | None = None
-    compiler_output: CompilerOutput | None = None
+    source_attestation: ValidationAttestation | None = None
+    target_attestation: ValidationAttestation | None = None
     target_error: str | None = None
     abi_equal: bool | None = None
     method_ids_equal: bool | None = None
@@ -232,8 +394,11 @@ class RunReport:
         return sum(len(file.diagnostics) for file in self.files)
 
     def to_json_obj(self) -> dict[str, Any]:
+        from . import __version__
+
         return {
             "schema_version": REPORT_SCHEMA_VERSION,
+            "producer": {"name": "vyupgrade", "version": __version__},
             "source_version": self.source_version,
             "target_version": self.target_version,
             "write_requested": self.write_requested,
@@ -256,18 +421,14 @@ class RunReport:
                         "source_version": file.source_version,
                         "source_compiler": file.source_compiler,
                         "source_compile": file.source_compile,
-                        "declared_spec": file.declared_spec,
-                        "resolved_compiler": file.resolved_compiler,
-                        "dependency_context": (
-                            file.dependency_context.to_json_obj()
-                            if file.dependency_context is not None
+                        "source_attestation": (
+                            file.source_attestation.to_json_obj()
+                            if file.source_attestation is not None
                             else None
                         ),
-                        "compiler_started": file.compiler_started,
-                        "failure_origin": file.failure_origin,
-                        "compiler_output": (
-                            file.compiler_output.to_json_obj()
-                            if file.compiler_output is not None
+                        "target_attestation": (
+                            file.target_attestation.to_json_obj()
+                            if file.target_attestation is not None
                             else None
                         ),
                         "target_compile": file.target_compile,

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 
 Severity = Literal["info", "warning", "error"]
+FailureOrigin = Literal["compiler", "environment", "launch", "timeout", "adapter"]
 ValidationDecisionStatus = Literal["not-required", "passed", "waived", "blocked"]
 ValidationIssueCode = Literal[
     "target_compile_failed",
@@ -17,7 +18,7 @@ ValidationIssueCode = Literal[
     "method_identifiers_changed",
     "storage_layout_changed",
 ]
-REPORT_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 3
 
 
 @dataclass(frozen=True)
@@ -84,6 +85,31 @@ class ValidationDecision:
         }
 
 
+@dataclass(frozen=True)
+class CompilerOutput:
+    stdout: str
+    stderr: str
+
+    def to_json_obj(self) -> dict[str, str]:
+        return {"stdout": self.stdout, "stderr": self.stderr}
+
+
+@dataclass(frozen=True)
+class DependencyContext:
+    mode: Literal["isolated", "project"]
+    project_root: str | None = None
+    manifest: str | None = None
+    lockfile: str | None = None
+
+    def to_json_obj(self) -> dict[str, str | None]:
+        return {
+            "mode": self.mode,
+            "project_root": self.project_root,
+            "manifest": self.manifest,
+            "lockfile": self.lockfile,
+        }
+
+
 @dataclass
 class FileReport:
     path: Path
@@ -96,6 +122,12 @@ class FileReport:
     source_compile: str = "skipped"
     target_compile: str = "skipped"
     source_error: str | None = None
+    declared_spec: str | None = None
+    resolved_compiler: str | None = None
+    dependency_context: DependencyContext | None = None
+    compiler_started: bool = False
+    failure_origin: FailureOrigin | None = None
+    compiler_output: CompilerOutput | None = None
     target_error: str | None = None
     abi_equal: bool | None = None
     method_ids_equal: bool | None = None
@@ -112,6 +144,7 @@ class FileReport:
     candidate_sha256: str | None = None
     final_sha256: str | None = None
     final_matches_candidate: bool | None = None
+
 
 @dataclass
 class ClosureReport:
@@ -223,6 +256,20 @@ class RunReport:
                         "source_version": file.source_version,
                         "source_compiler": file.source_compiler,
                         "source_compile": file.source_compile,
+                        "declared_spec": file.declared_spec,
+                        "resolved_compiler": file.resolved_compiler,
+                        "dependency_context": (
+                            file.dependency_context.to_json_obj()
+                            if file.dependency_context is not None
+                            else None
+                        ),
+                        "compiler_started": file.compiler_started,
+                        "failure_origin": file.failure_origin,
+                        "compiler_output": (
+                            file.compiler_output.to_json_obj()
+                            if file.compiler_output is not None
+                            else None
+                        ),
                         "target_compile": file.target_compile,
                         "abi_equal": file.abi_equal,
                         "method_ids_equal": file.method_ids_equal,

--- a/src/vyupgrade/project.py
+++ b/src/vyupgrade/project.py
@@ -7,23 +7,18 @@ DEFAULT_INCLUDE = {".vy", ".vyi"}
 DEFAULT_EXCLUDES = {".git", ".venv", "venv", "build", "dist", "__pycache__"}
 
 
-def discover_files(
-    paths: tuple[Path, ...], *, excluded_roots: tuple[Path, ...] = ()
-) -> list[Path]:
+def discover_files(paths: tuple[Path, ...], *, excluded_roots: tuple[Path, ...] = ()) -> list[Path]:
     files: list[Path] = []
     excluded = tuple(
         dict.fromkeys(
-            candidate
-            for root in excluded_roots
-            for candidate in (root.absolute(), root.resolve())
+            candidate for root in excluded_roots for candidate in (root.absolute(), root.resolve())
         )
     )
 
     def is_excluded(path: Path) -> bool:
         absolute, resolved = path.absolute(), path.resolve()
         return any(
-            absolute.is_relative_to(root) or resolved.is_relative_to(root)
-            for root in excluded
+            absolute.is_relative_to(root) or resolved.is_relative_to(root) for root in excluded
         )
 
     for path in paths:
@@ -45,4 +40,3 @@ def discover_files(
                 files.append(child)
 
     return sorted(dict.fromkeys(file.resolve() for file in files))
-

--- a/src/vyupgrade/reporting.py
+++ b/src/vyupgrade/reporting.py
@@ -132,13 +132,9 @@ def _render_text_file(file: FileReport) -> str:
             lines.append(f"  {error_label}:")
             lines.extend(f"    {line}" for line in error.splitlines())
     if file.source_unavailable_formats:
-        lines.append(
-            "  source unavailable outputs: " + ", ".join(file.source_unavailable_formats)
-        )
+        lines.append("  source unavailable outputs: " + ", ".join(file.source_unavailable_formats))
     if file.target_unavailable_formats:
-        lines.append(
-            "  target unavailable outputs: " + ", ".join(file.target_unavailable_formats)
-        )
+        lines.append("  target unavailable outputs: " + ", ".join(file.target_unavailable_formats))
     for label, equal, diff in _artifact_checks(file):
         if equal is not None:
             lines.append(f"  {label}: {equal}")
@@ -173,24 +169,18 @@ def _render_text_summary(report: RunReport) -> str:
         lines.append(f"dependencies: {len(report.closure.dependencies)} upgraded")
         if report.closure.output_status != "skipped":
             lines.append(
-                "closure output: "
-                f"{report.closure.output_dir} ({report.closure.output_status})"
+                f"closure output: {report.closure.output_dir} ({report.closure.output_status})"
             )
         if report.closure.archive_status != "skipped":
             lines.append(
-                "closure archive: "
-                f"{report.closure.archive} ({report.closure.archive_status})"
+                f"closure archive: {report.closure.archive} ({report.closure.archive_status})"
             )
     waiver_flags = sorted(
         {issue.waiver for issue in report.validation_decision.waivers if issue.waiver}
     )
     if waiver_flags:
         lines.append(f"validation waivers: {', '.join(waiver_flags)}")
-    if (
-        not report.write_requested
-        and report.changed_count
-        and report.closure is None
-    ):
+    if not report.write_requested and report.changed_count and report.closure is None:
         lines.append("run with --write to apply these changes")
     if report.write_status != "skipped":
         lines.append(f"write transaction: {report.write_status}")
@@ -255,11 +245,7 @@ def _render_summary(console: Console, report: RunReport) -> None:
     )
     if waiver_flags:
         console.print(_label_value("validation waivers", ", ".join(waiver_flags), "vy.warning"))
-    if (
-        not report.write_requested
-        and report.changed_count
-        and report.closure is None
-    ):
+    if not report.write_requested and report.changed_count and report.closure is None:
         console.print(Text("run with --write to apply these changes", style="vy.muted"))
     if report.write_status != "skipped":
         console.print(
@@ -325,9 +311,7 @@ def _render_file(console: Console, file: FileReport) -> None:
     if file.final_sha256 is not None:
         console.print(_indented(f"final SHA-256: {file.final_sha256}", "vy.muted"))
     if file.final_matches_candidate is not None:
-        console.print(
-            _bool_line("final bytes match candidate", file.final_matches_candidate)
-        )
+        console.print(_bool_line("final bytes match candidate", file.final_matches_candidate))
     console.print(
         _label_value(
             "  validation decision",
@@ -339,9 +323,7 @@ def _render_file(console: Console, file: FileReport) -> None:
         console.print(_indented(f"validation blocker: {issue.message}", "vy.error"))
     for issue in file.validation_decision.waivers:
         console.print(
-            _indented(
-                f"validation waiver: {issue.waiver} ({issue.message})", "vy.warning"
-            )
+            _indented(f"validation waiver: {issue.waiver} ({issue.message})", "vy.warning")
         )
 
 

--- a/src/vyupgrade/rule_groups/numeric.py
+++ b/src/vyupgrade/rule_groups/numeric.py
@@ -128,9 +128,7 @@ def _math_builtin(
     if math_binding is None:
         math_binding = _fresh_math_binding(source)
         import_line = (
-            "import math\n"
-            if math_binding == "math"
-            else f"import math as {math_binding}\n"
+            "import math\n" if math_binding == "math" else f"import math as {math_binding}\n"
         )
     edits: list[TextEdit] = []
     fixes: list[Fix] = []
@@ -485,7 +483,9 @@ def _replace_shift_builtin(
             elif negative_expr is not None:
                 vars_for_line = facts.vars_at_line(line_number(current, match.start()))
                 negative_amount = negative_expr.group(1).strip()
-                if _local_name_assigned_negative_integer(current, match.start(), negative_amount, vars_for_line):
+                if _local_name_assigned_negative_integer(
+                    current, match.start(), negative_amount, vars_for_line
+                ):
                     replacement = f"({value} << convert(-{negative_amount}, uint256))"
                 else:
                     replacement = (
@@ -498,7 +498,12 @@ def _replace_shift_builtin(
                 amount = constant_values[positive_constant.group(1)]
                 operator = "<<" if amount >= 0 else ">>"
                 replacement = f"({value} {operator} {abs(amount)})"
-            elif _local_name_assigned_negative_integer(current, match.start(), shift_by, facts.vars_at_line(line_number(current, match.start()))):
+            elif _local_name_assigned_negative_integer(
+                current,
+                match.start(),
+                shift_by,
+                facts.vars_at_line(line_number(current, match.start())),
+            ):
                 replacement = f"({value} >> convert(-{shift_by}, uint256))"
             elif convert_constant is not None and convert_constant.group(1) in constant_values:
                 amount = constant_values[convert_constant.group(1)]
@@ -520,7 +525,7 @@ def _replace_shift_builtin(
                             line_number(current, match.start()),
                             "shift() with non-literal amount needs manual << or >> review",
                         )
-                )
+                    )
                 continue
             if not rule_context.is_enabled("VY111"):
                 continue
@@ -572,7 +577,11 @@ def _local_name_assigned_negative_integer(
     if not _is_signed_integer_type(vars_for_line.get(name)):
         return False
     line_start = source.rfind("\n", 0, index) + 1
-    current_line = source[line_start : source.find("\n", line_start) if source.find("\n", line_start) != -1 else len(source)]
+    current_line = source[
+        line_start : source.find("\n", line_start)
+        if source.find("\n", line_start) != -1
+        else len(source)
+    ]
     current_indent = len(current_line) - len(current_line.lstrip(" \t"))
     for line in reversed(source[:line_start].splitlines()):
         stripped = line.strip()
@@ -702,11 +711,12 @@ def _redundant_integer_convert(
             continue
         if target != "uint256" or expr.lstrip().startswith("-") or not re.search(r"[-+*/%]", expr):
             continue
-        if _integerish_expression(expr, vars_for_line) and not _expression_has_signed_integer(
-            expr, vars_for_line
-        ) and not _expression_has_narrow_unsigned_integer(
-            expr, vars_for_line
-        ) and not _target_semantic_convert(expr, target):
+        if (
+            _integerish_expression(expr, vars_for_line)
+            and not _expression_has_signed_integer(expr, vars_for_line)
+            and not _expression_has_narrow_unsigned_integer(expr, vars_for_line)
+            and not _target_semantic_convert(expr, target)
+        ):
             replacement = f"({expr})"
             edits.append(TextEdit(match.start(), close + 1, replacement))
             fixes.append(
@@ -725,10 +735,14 @@ def _target_semantic_convert(expr: str, target: str) -> bool:
     target = normalize_type(target)
     if expr == "block.prevhash" and target == "uint256":
         return True
-    return target == "uint256" and re.search(
-        r"\bconvert\s*\([^()\n]+,\s*int(?:8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)?\s*\)",
-        expr,
-    ) is not None
+    return (
+        target == "uint256"
+        and re.search(
+            r"\bconvert\s*\([^()\n]+,\s*int(?:8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)?\s*\)",
+            expr,
+        )
+        is not None
+    )
 
 
 def _redundant_convert_replacement(expr: str) -> str:
@@ -776,9 +790,12 @@ INTEGER_DIVISION_RULES = (
 )
 
 
-
 REDUNDANT_CONVERT_RULES = (
-    Rule("redundant_integer_convert", runner=_redundant_integer_convert, changes=(crossing("VY051", (0, 4, 0)),)),
+    Rule(
+        "redundant_integer_convert",
+        runner=_redundant_integer_convert,
+        changes=(crossing("VY051", (0, 4, 0)),),
+    ),
 )
 
 LATE_RULES = (

--- a/src/vyupgrade/rule_helpers.py
+++ b/src/vyupgrade/rule_helpers.py
@@ -263,7 +263,9 @@ def lhs_declared_type(line: str) -> str | None:
 
 
 def lhs_assigned_type(line: str, vars_for_line: dict[str, str]) -> str | None:
-    match = re.match(r"\s*(?:self\.)?([A-Za-z_][A-Za-z0-9_]*)(\s*\[[^=]+\])?\s*(?://=|[-+*/%]?=)", line)
+    match = re.match(
+        r"\s*(?:self\.)?([A-Za-z_][A-Za-z0-9_]*)(\s*\[[^=]+\])?\s*(?://=|[-+*/%]?=)", line
+    )
     if not match:
         return None
     type_name = vars_for_line.get(match.group(1))

--- a/src/vyupgrade/versions.py
+++ b/src/vyupgrade/versions.py
@@ -141,24 +141,16 @@ def compiler_version_for_source(spec: str | None, source: str) -> str | None:
 
 
 def compiler_version_for_source_validation(
-    spec: str | None, target_spec: str, source: str
+    spec: str | None, target_spec: str, _source: str
 ) -> str | None:
+    """Select the newest known satisfying release that is no newer than the target."""
     versions = known_versions_satisfying(spec)
     if not versions:
-        return compiler_version_for_source(spec, source)
+        return compiler_version_for_spec(spec)
 
     target = parse_version(compiler_version_for_spec(target_spec)) or parse_version(target_spec)
     candidates = tuple(version for version in versions if target is None or version <= target)
-    if not candidates:
-        return compiler_version_for_source(spec, source)
-
-    hinted = _source_syntax_floor(source)
-    if hinted is not None:
-        hinted_candidates = tuple(version for version in candidates if version >= hinted)
-        if hinted_candidates:
-            candidates = hinted_candidates
-
-    return str(candidates[-1])
+    return str(candidates[-1] if candidates else versions[-1])
 
 
 def _source_syntax_floor(source: str) -> VyperVersion | None:

--- a/src/vyupgrade/versions.py
+++ b/src/vyupgrade/versions.py
@@ -33,11 +33,14 @@ KNOWN_VERSIONS = tuple(
     ]
 )
 
-SUPPORTED_RELEASE_VERSIONS = frozenset(
-    Version(f"0.{minor}.{patch}")
-    for minor, last_patch in ((2, 16), (3, 10), (4, 3))
-    for patch in range(1 if minor == 2 else 0, last_patch + 1)
-) | ALPHA_RELEASES
+SUPPORTED_RELEASE_VERSIONS = (
+    frozenset(
+        Version(f"0.{minor}.{patch}")
+        for minor, last_patch in ((2, 16), (3, 10), (4, 3))
+        for patch in range(1 if minor == 2 else 0, last_patch + 1)
+    )
+    | ALPHA_RELEASES
+)
 
 
 @dataclass(frozen=True)
@@ -126,20 +129,6 @@ def compiler_version_for_spec(spec: str | None) -> str | None:
     return str(version) if version else None
 
 
-def compiler_version_for_source(spec: str | None, source: str) -> str | None:
-    version = parse_version(compiler_version_for_spec(spec))
-    versions = known_versions_satisfying(spec)
-    if version is None or not versions:
-        return str(version) if version else None
-    hinted = _source_syntax_floor(source)
-    if hinted is None or version >= hinted:
-        return str(version)
-    for candidate in versions:
-        if candidate >= hinted:
-            return str(candidate)
-    return str(version)
-
-
 def compiler_version_for_source_validation(
     spec: str | None, target_spec: str, _source: str
 ) -> str | None:
@@ -151,27 +140,6 @@ def compiler_version_for_source_validation(
     target = parse_version(compiler_version_for_spec(target_spec)) or parse_version(target_spec)
     candidates = tuple(version for version in versions if target is None or version <= target)
     return str(candidates[-1] if candidates else versions[-1])
-
-
-def _source_syntax_floor(source: str) -> VyperVersion | None:
-    floors: list[VyperVersion] = []
-    if re.search(r"\buint8\b", source):
-        floors.append(Version("0.3.1"))
-    if re.search(r"\buint(?:16|32|64)\b", source):
-        floors.append(Version("0.3.2"))
-    if re.search(r"\bDynArray\s*\[[^\]]+,\s*[A-Z_][A-Z0-9_]*\s*\]", source):
-        floors.append(Version("0.3.7"))
-    elif re.search(r"\bDynArray\s*\[", source):
-        floors.append(Version("0.3.3"))
-    if re.search(r"(?m)^enum\s+[A-Za-z_][A-Za-z0-9_]*\s*:", source):
-        floors.append(Version("0.3.4"))
-    if re.search(r"\bimmutable\s*\(", source):
-        floors.append(Version("0.3.1"))
-    if re.search(r"\bsend\s*\([^)]*\bgas\s*=", source):
-        floors.append(Version("0.3.8"))
-    if re.search(r"(?m)^\s*error\s+[A-Za-z_][A-Za-z0-9_]*\s*:", source):
-        floors.append(Version("0.5.0a3"))
-    return max(floors) if floors else None
 
 
 def default_evm_version_for_spec(spec: str | None) -> str | None:
@@ -263,7 +231,10 @@ def _parse_clauses(spec: str) -> list[tuple[str, VyperVersion]]:
 def _has_lower_bound(spec: str) -> bool:
     specifiers = _specifier_set(spec)
     if specifiers is not None:
-        return any(_specifier_is_lower_bound(specifier.operator, specifier.version) for specifier in specifiers)
+        return any(
+            _specifier_is_lower_bound(specifier.operator, specifier.version)
+            for specifier in specifiers
+        )
     return any(op in {">=", ">", "=="} for op, _version in _parse_clauses(spec))
 
 

--- a/tests/rule_groups/test_numeric.py
+++ b/tests/rule_groups/test_numeric.py
@@ -354,8 +354,7 @@ def f(pool: address, dy: uint256, rates: uint256[N_COINS]) -> uint256:
 
     assert (
         "staticcall Curve(pool).calc_withdraw_one_coin("
-        "dy * PRECISION // rates[1], convert(0, int128))"
-        in result.source
+        "dy * PRECISION // rates[1], convert(0, int128))" in result.source
     )
 
 
@@ -400,7 +399,10 @@ def f(token: address) -> uint256:
 
     result = apply_rules(source, config())
 
-    assert "return 10**18 * self.get_xcp(self.D) // staticcall CurveToken(token).totalSupply()" in result.source
+    assert (
+        "return 10**18 * self.get_xcp(self.D) // staticcall CurveToken(token).totalSupply()"
+        in result.source
+    )
 
 
 def test_self_balance_integer_division_operand(config) -> None:
@@ -610,7 +612,7 @@ def f() -> uint256:
 
     result = apply_rules(source, config())
 
-    assert "* as_wei_value(1, \"ether\")) // self.total_supply" in result.source
+    assert '* as_wei_value(1, "ether")) // self.total_supply' in result.source
 
 
 def test_tab_indented_return_integer_division_uses_function_return_type(config) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -298,9 +298,7 @@ def test_write_mode_reports_timed_out_mamushi_without_mutation(
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
-    code = main(
-        [str(contract), "--write", "--format", "mamushi", "--report-json", str(report)]
-    )
+    code = main([str(contract), "--write", "--format", "mamushi", "--report-json", str(report)])
 
     assert code == 6
     assert contract.read_text(encoding="utf-8") == original
@@ -395,9 +393,7 @@ def test_formatter_output_that_fails_final_validation_is_not_committed(
     monkeypatch.setattr(engine, "compile_target_source", compile_target_source)
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
-    code = main(
-        [str(contract), "--write", "--format", "mamushi", "--report-json", str(report)]
-    )
+    code = main([str(contract), "--write", "--format", "mamushi", "--report-json", str(report)])
 
     assert code == 2
     assert contract.read_text(encoding="utf-8") == original
@@ -478,9 +474,7 @@ def test_post_write_test_failure_returns_nonzero_and_persists_report(
         ),
     )
 
-    code = main(
-        [str(contract), "--write", "--test-command", "false", "--report-json", str(report)]
-    )
+    code = main([str(contract), "--write", "--test-command", "false", "--report-json", str(report)])
 
     assert code == 8
     assert "#pragma version 0.4.3" in contract.read_text(encoding="utf-8")
@@ -515,9 +509,7 @@ def test_post_write_test_runtime_errors_return_nonzero_and_persist_report(
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
-    code = main(
-        [str(contract), "--write", "--test-command", "tests", "--report-json", str(report)]
-    )
+    code = main([str(contract), "--write", "--test-command", "tests", "--report-json", str(report)])
 
     assert code == 8
     assert "#pragma version 0.4.3" in contract.read_text(encoding="utf-8")
@@ -543,9 +535,7 @@ def test_post_write_test_mutation_is_detected_in_final_hashes(
 
     monkeypatch.setattr(cli.subprocess, "run", mutate_planned_file)
 
-    code = main(
-        [str(contract), "--write", "--test-command", "tests", "--report-json", str(report)]
-    )
+    code = main([str(contract), "--write", "--test-command", "tests", "--report-json", str(report)])
 
     assert code == 8
     data = json.loads(report.read_text())
@@ -656,9 +646,7 @@ def test_allow_unvalidated_source_waives_source_failure(
     data = json.loads(report.read_text())
     assert data["wrote_changes"] is True
     assert data["validation_decision"]["status"] == "waived"
-    assert data["validation_decision"]["waivers"][0]["waiver"] == (
-        "--allow-unvalidated-source"
-    )
+    assert data["validation_decision"]["waivers"][0]["waiver"] == ("--allow-unvalidated-source")
     assert "write validation: waived" in capsys.readouterr().out
 
 
@@ -672,9 +660,7 @@ def test_patch_level_abi_mismatch_blocks_even_when_diagnostic_is_ignored(
     monkeypatch.setattr(
         engine,
         "compile_source_file",
-        lambda *_args: CompileResult(
-            "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
-        ),
+        lambda *_args: CompileResult("passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}),
     )
     monkeypatch.setattr(
         engine,
@@ -747,9 +733,7 @@ def test_artifact_change_waivers_are_narrow_and_reported(
     monkeypatch.setattr(
         engine,
         "compile_source_file",
-        lambda *_args: CompileResult(
-            "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
-        ),
+        lambda *_args: CompileResult("passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}),
     )
     monkeypatch.setattr(
         engine,
@@ -775,9 +759,7 @@ def test_artifact_change_waivers_are_narrow_and_reported(
     ]
 
 
-def test_artifact_waiver_does_not_cover_other_diff_classes(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_artifact_waiver_does_not_cover_other_diff_classes(tmp_path: Path, monkeypatch) -> None:
     contract = tmp_path / "multiple-diffs.vy"
     original = "# @version 0.3.10\n@external\ndef __init__():\n    pass\n"
     contract.write_text(original, encoding="utf-8")
@@ -785,9 +767,7 @@ def test_artifact_waiver_does_not_cover_other_diff_classes(
     monkeypatch.setattr(
         engine,
         "compile_source_file",
-        lambda *_args: CompileResult(
-            "passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}
-        ),
+        lambda *_args: CompileResult("passed", artifacts={**VALIDATION_ARTIFACTS, "ast": {}}),
     )
     monkeypatch.setattr(
         engine,
@@ -886,9 +866,7 @@ def test_missing_target_artifact_is_not_waived_by_source_or_diff_flags(
     monkeypatch.setattr(
         engine,
         "compile_target_source",
-        lambda *_args: CompileResult(
-            "passed", artifacts={"abi": [], "method_identifiers": {}}
-        ),
+        lambda *_args: CompileResult("passed", artifacts={"abi": [], "method_identifiers": {}}),
     )
 
     code = main(
@@ -1037,6 +1015,8 @@ interface Token:
         blocker["path"] == str(tmp_path / "Token.vyi")
         for blocker in data["validation_decision"]["blockers"]
     )
+
+
 def test_split_interfaces_rejects_existing_generated_file_collision(
     tmp_path: Path, passing_compiler
 ) -> None:
@@ -1085,9 +1065,7 @@ interface Token:
         originals[path] = source
     report = tmp_path / "report.json"
 
-    code = main(
-        [str(tmp_path), "--write", "--split-interfaces", "--report-json", str(report)]
-    )
+    code = main([str(tmp_path), "--write", "--split-interfaces", "--report-json", str(report)])
 
     assert code == 9
     assert not (tmp_path / "Token.vyi").exists()
@@ -1135,10 +1113,7 @@ def balanceOf(owner: address) -> uint256: ...
     ]
     assert len(token_reports) == 2
     assert all(item["changed"] is False for item in token_reports)
-    assert all(
-        item["original_sha256"] == item["candidate_sha256"]
-        for item in token_reports
-    )
+    assert all(item["original_sha256"] == item["candidate_sha256"] for item in token_reports)
 
 
 def test_split_interfaces_respects_rule_ignore(tmp_path: Path, passing_compiler) -> None:
@@ -1431,12 +1406,8 @@ def _write_dependency_cli_fixture(
     return project, dependency, search_path, json_dependency
 
 
-def test_include_dependencies_reports_dependency_roles(
-    tmp_path: Path, passing_compiler
-) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+def test_include_dependencies_reports_dependency_roles(tmp_path: Path, passing_compiler) -> None:
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     closure_report = tmp_path / "closure.json"
     project_report = tmp_path / "project.json"
 
@@ -1475,9 +1446,7 @@ def test_include_dependencies_reports_dependency_roles(
 def test_include_dependencies_write_without_destination_exits_4(
     tmp_path: Path, passing_compiler
 ) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     project_original = project.read_bytes()
     dependency_original = dependency.read_bytes()
 
@@ -1499,9 +1468,7 @@ def test_include_dependencies_write_without_destination_exits_4(
 def test_include_dependencies_never_plans_dependency_writes(
     tmp_path: Path, passing_compiler, capsys
 ) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     project_original = project.read_bytes()
     dependency_original = dependency.read_bytes()
     config = Config(
@@ -1509,9 +1476,7 @@ def test_include_dependencies_never_plans_dependency_writes(
         compiler_search_paths=(search_path,),
         include_dependencies=True,
     )
-    project_request = engine.bounded_migration_request(
-        project, project.read_text(), config
-    )
+    project_request = engine.bounded_migration_request(project, project.read_text(), config)
     dependency_requests, _closure = cli._dependency_requests([project_request], config)
     batch = engine.prepare_migrations([project_request, *dependency_requests], config)
 
@@ -1547,9 +1512,7 @@ def test_include_dependencies_never_plans_dependency_writes(
 def test_include_dependencies_check_exits_1_on_dep_only_change(
     tmp_path: Path, passing_compiler
 ) -> None:
-    project, _dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, _dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
 
     code = main(
         [
@@ -1567,9 +1530,7 @@ def test_include_dependencies_check_exits_1_on_dep_only_change(
 def test_include_dependencies_diff_covers_dependencies(
     tmp_path: Path, passing_compiler, capsys
 ) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
 
     code = main(
         [
@@ -1587,12 +1548,8 @@ def test_include_dependencies_diff_covers_dependencies(
     assert f"+++ {dependency.resolve()}" in output
 
 
-def test_upgrade_closure_alias_and_pyproject_key(
-    tmp_path: Path, passing_compiler
-) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+def test_upgrade_closure_alias_and_pyproject_key(tmp_path: Path, passing_compiler) -> None:
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     alias_report = tmp_path / "alias.json"
     config_report = tmp_path / "config.json"
     config_output = tmp_path / "config-output"
@@ -1632,9 +1589,7 @@ def test_upgrade_closure_alias_and_pyproject_key(
 def test_dependency_source_version_inferred_from_dep_pragma(
     tmp_path: Path, passing_compiler
 ) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     report = tmp_path / "report.json"
 
     code = main(
@@ -1655,9 +1610,7 @@ def test_dependency_source_version_inferred_from_dep_pragma(
     assert files[dependency.resolve()]["validation"]["source_version"] == "0.3.10"
 
 
-def test_overlay_layout_conflict_exits_4(
-    tmp_path: Path, passing_compiler, capsys
-) -> None:
+def test_overlay_layout_conflict_exits_4(tmp_path: Path, passing_compiler, capsys) -> None:
     first_root = tmp_path / "first"
     second_root = tmp_path / "second"
     first = first_root / "pkg" / "util.vy"
@@ -1677,9 +1630,9 @@ def test_overlay_layout_conflict_exits_4(
     assert str(second.resolve()) in stderr
 
 
-def test_report_json_schema_v3(tmp_path: Path, passing_compiler) -> None:
-    project, dependency, search_path, json_dependency = (
-        _write_dependency_cli_fixture(tmp_path, include_json=True)
+def test_report_json_schema_v4(tmp_path: Path, passing_compiler) -> None:
+    project, dependency, search_path, json_dependency = _write_dependency_cli_fixture(
+        tmp_path, include_json=True
     )
     assert json_dependency is not None
     project_report = tmp_path / "project.json"
@@ -1709,23 +1662,29 @@ def test_report_json_schema_v3(tmp_path: Path, passing_compiler) -> None:
     assert closure_code == 0
     project_data = json.loads(project_report.read_text())
     closure_data = json.loads(closure_report.read_text())
-    assert project_data["schema_version"] == 3
+    assert project_data["schema_version"] == 4
+    assert project_data["producer"]["name"] == "vyupgrade"
+    assert project_data["producer"]["version"]
     assert project_data["closure"] is None
     assert all(file["role"] == "project" for file in project_data["files"])
+    source_attestation = project_data["files"][0]["validation"]["source_attestation"]
     assert {
         "declared_spec",
+        "authority_rule",
         "resolved_compiler",
         "dependency_context",
         "compiler_started",
+        "completion_status",
+        "exit_status",
+        "validated_source_set",
+        "attempt_sequence",
         "failure_origin",
         "compiler_output",
-    } <= project_data["files"][0]["validation"].keys()
-    assert closure_data["schema_version"] == 3
+    } == source_attestation.keys()
+    assert closure_data["schema_version"] == 4
     assert closure_data["closure"] == {
         "requested": True,
-        "dependencies": sorted(
-            [str(dependency.resolve()), str(json_dependency.resolve())]
-        ),
+        "dependencies": sorted([str(dependency.resolve()), str(json_dependency.resolve())]),
         "output_dir": None,
         "output_status": "skipped",
         "output_error": None,
@@ -1768,9 +1727,7 @@ def test_include_dependencies_empty_project_reports_requested_closure(
     }
 
 
-def test_closure_output_requires_include_dependencies_exit_4(
-    tmp_path: Path, capsys
-) -> None:
+def test_closure_output_requires_include_dependencies_exit_4(tmp_path: Path, capsys) -> None:
     contract = tmp_path / "Contract.vy"
     contract.write_text("#pragma version 0.4.3\n")
 
@@ -1801,16 +1758,9 @@ def test_check_with_closure_output_exit_4(tmp_path: Path, capsys) -> None:
 def test_write_include_dependencies_with_closure_output_commits_both(
     tmp_path: Path, passing_compiler
 ) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     project.write_text(
-        "# @version 0.3.10\n"
-        "from depkg import mod\n"
-        "\n"
-        "@external\n"
-        "def __init__():\n"
-        "    pass\n"
+        "# @version 0.3.10\nfrom depkg import mod\n\n@external\ndef __init__():\n    pass\n"
     )
     dependency_original = dependency.read_bytes()
     output = tmp_path / "output"
@@ -1831,9 +1781,7 @@ def test_write_include_dependencies_with_closure_output_commits_both(
     assert "#pragma version 0.4.3" in project.read_text()
     assert "@deploy\ndef __init__" in project.read_text()
     assert (output / "main.vy").read_bytes() == project.read_bytes()
-    assert "#pragma version 0.4.3" in (
-        output / "depkg" / "mod.vy"
-    ).read_text()
+    assert "#pragma version 0.4.3" in (output / "depkg" / "mod.vy").read_text()
     assert dependency.read_bytes() == dependency_original
     assert not (search_path / "main.vy").exists()
 
@@ -1841,9 +1789,7 @@ def test_write_include_dependencies_with_closure_output_commits_both(
 def test_closure_output_blocked_when_validation_blocks(
     tmp_path: Path, failing_target_compiler
 ) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     output = tmp_path / "output"
     output.mkdir()
     marker = output / "keep.txt"
@@ -1926,12 +1872,8 @@ def test_closure_output_blocks_skipped_hard_boundary_sources(
     )
 
 
-def test_closure_output_failure_exits_9(
-    tmp_path: Path, passing_compiler
-) -> None:
-    project, _dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+def test_closure_output_failure_exits_9(tmp_path: Path, passing_compiler) -> None:
+    project, _dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     output = tmp_path / "not-a-directory"
     output.write_text("existing file")
     report = tmp_path / "report.json"
@@ -1952,18 +1894,12 @@ def test_closure_output_failure_exits_9(
     assert code == 9
     closure_report = json.loads(report.read_text())["closure"]
     assert closure_report["output_status"] == "failed"
-    assert closure_report["output_error"] == (
-        "closure output destination is not a directory"
-    )
+    assert closure_report["output_error"] == ("closure output destination is not a directory")
     assert output.read_text() == "existing file"
 
 
-def test_report_json_closure_output_fields(
-    tmp_path: Path, passing_compiler, capsys
-) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+def test_report_json_closure_output_fields(tmp_path: Path, passing_compiler, capsys) -> None:
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     output = tmp_path / "output"
     report = tmp_path / "report.json"
 
@@ -1986,15 +1922,10 @@ def test_report_json_closure_output_fields(
     assert closure_report["output_status"] == "written"
     assert closure_report["output_error"] is None
     assert (output / "depkg" / "mod.vy").read_text() != dependency.read_text()
-    assert (
-        f"closure output: {output.resolve()} (written)"
-        in capsys.readouterr().out
-    )
+    assert f"closure output: {output.resolve()} (written)" in capsys.readouterr().out
 
 
-def test_closure_output_blocked_when_plan_build_fails(
-    tmp_path: Path, passing_compiler
-) -> None:
+def test_closure_output_blocked_when_plan_build_fails(tmp_path: Path, passing_compiler) -> None:
     contract = tmp_path / "Main.vy"
     contract.write_text(
         "#pragma version 0.4.3\n"
@@ -2057,19 +1988,14 @@ def test_empty_project_closure_output_is_written_without_directory(
     assert closure_report["output_error"] is None
 
 
-def test_closure_archive_requires_include_dependencies_exit_4(
-    tmp_path: Path, capsys
-) -> None:
+def test_closure_archive_requires_include_dependencies_exit_4(tmp_path: Path, capsys) -> None:
     contract = tmp_path / "Contract.vy"
     contract.write_text("#pragma version 0.4.3\n")
 
     code = main([str(contract), "--closure-archive", str(tmp_path / "out.vyz")])
 
     assert code == 4
-    assert (
-        "--closure-archive requires --include-dependencies"
-        in capsys.readouterr().err
-    )
+    assert "--closure-archive requires --include-dependencies" in capsys.readouterr().err
 
 
 def test_check_with_closure_archive_exit_4(tmp_path: Path, capsys) -> None:
@@ -2087,10 +2013,7 @@ def test_check_with_closure_archive_exit_4(tmp_path: Path, capsys) -> None:
     )
 
     assert code == 4
-    assert (
-        "--check cannot be combined with --closure-archive"
-        in capsys.readouterr().err
-    )
+    assert "--check cannot be combined with --closure-archive" in capsys.readouterr().err
 
 
 def test_closure_archive_target_below_floor_exits_4_before_compiling(
@@ -2122,14 +2045,11 @@ def test_closure_archive_target_below_floor_exits_4_before_compiling(
     assert code == 4
     assert compile_calls == 0
     assert (
-        "target 0.3.10 predates Vyper archive output (requires >= 0.4.0)"
-        in capsys.readouterr().err
+        "target 0.3.10 predates Vyper archive output (requires >= 0.4.0)" in capsys.readouterr().err
     )
 
 
-def test_closure_archive_requires_single_entry_exit_4(
-    tmp_path: Path, capsys
-) -> None:
+def test_closure_archive_requires_single_entry_exit_4(tmp_path: Path, capsys) -> None:
     project = tmp_path / "project"
     project.mkdir()
     (project / "first.vy").write_text("#pragma version 0.4.3\n")
@@ -2145,10 +2065,7 @@ def test_closure_archive_requires_single_entry_exit_4(
     )
 
     assert code == 4
-    assert (
-        "--closure-archive requires exactly one entry contract; got 2"
-        in capsys.readouterr().err
-    )
+    assert "--closure-archive requires exactly one entry contract; got 2" in capsys.readouterr().err
 
 
 def test_closure_archive_rejects_entry_destination_without_mutation(
@@ -2162,9 +2079,7 @@ def test_closure_archive_rejects_entry_destination_without_mutation(
     def unexpected_compile(*_args, **_kwargs):
         pytest.fail("entry destination must be rejected before archive compilation")
 
-    monkeypatch.setattr(
-        cli.closure.compiler, "compile_target_archive", unexpected_compile
-    )
+    monkeypatch.setattr(cli.closure.compiler, "compile_target_archive", unexpected_compile)
 
     code = main(
         [
@@ -2186,12 +2101,8 @@ def test_closure_archive_rejects_entry_destination_without_mutation(
     )
 
 
-def test_closure_archive_failure_exits_9(
-    tmp_path: Path, passing_compiler, monkeypatch
-) -> None:
-    project, _dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+def test_closure_archive_failure_exits_9(tmp_path: Path, passing_compiler, monkeypatch) -> None:
+    project, _dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     output = tmp_path / "out.vyz"
     report = tmp_path / "report.json"
 
@@ -2201,9 +2112,7 @@ def test_closure_archive_failure_exits_9(
         _sources: dict[Path, str],
         _config: Config,
     ) -> cli.closure.ClosureWriteResult:
-        return cli.closure.ClosureWriteResult(
-            "failed", output.resolve(), (), "archive failed"
-        )
+        return cli.closure.ClosureWriteResult("failed", output.resolve(), (), "archive failed")
 
     monkeypatch.setattr(cli.closure, "write_closure_archive", fail_archive)
 
@@ -2230,9 +2139,7 @@ def test_closure_archive_failure_exits_9(
 def test_report_json_closure_archive_fields(
     tmp_path: Path, passing_compiler, monkeypatch, capsys
 ) -> None:
-    project, dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     output = tmp_path / "out.vyz"
     report = tmp_path / "report.json"
 
@@ -2245,9 +2152,7 @@ def test_report_json_closure_archive_fields(
         assert entry == project.resolve()
         assert dependency.resolve() in sources
         archive.write_bytes(b"archive")
-        return cli.closure.ClosureWriteResult(
-            "written", archive.resolve(), (archive.resolve(),)
-        )
+        return cli.closure.ClosureWriteResult("written", archive.resolve(), (archive.resolve(),))
 
     monkeypatch.setattr(cli.closure, "write_closure_archive", write_archive)
 
@@ -2269,18 +2174,11 @@ def test_report_json_closure_archive_fields(
     assert closure_report["archive"] == str(output.resolve())
     assert closure_report["archive_status"] == "written"
     assert closure_report["archive_error"] is None
-    assert (
-        f"closure archive: {output.resolve()} (written)"
-        in capsys.readouterr().out
-    )
+    assert f"closure archive: {output.resolve()} (written)" in capsys.readouterr().out
 
 
-def test_closure_output_and_archive_combine(
-    tmp_path: Path, passing_compiler, monkeypatch
-) -> None:
-    project, _dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+def test_closure_output_and_archive_combine(tmp_path: Path, passing_compiler, monkeypatch) -> None:
+    project, _dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     output = tmp_path / "output"
     archive = tmp_path / "out.vyz"
     report = tmp_path / "report.json"
@@ -2321,12 +2219,8 @@ def test_closure_output_and_archive_combine(
     assert closure_report["archive_status"] == "written"
 
 
-def test_closure_archive_pyproject_key(
-    tmp_path: Path, passing_compiler, monkeypatch
-) -> None:
-    project, _dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+def test_closure_archive_pyproject_key(tmp_path: Path, passing_compiler, monkeypatch) -> None:
+    project, _dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     archive = tmp_path / "configured.vyz"
     report = tmp_path / "configured.json"
     pyproject = tmp_path / "pyproject.toml"
@@ -2346,9 +2240,7 @@ def test_closure_archive_pyproject_key(
         _config: Config,
     ) -> cli.closure.ClosureWriteResult:
         output.write_bytes(b"archive")
-        return cli.closure.ClosureWriteResult(
-            "written", output.resolve(), (output.resolve(),)
-        )
+        return cli.closure.ClosureWriteResult("written", output.resolve(), (output.resolve(),))
 
     monkeypatch.setattr(cli.closure, "write_closure_archive", write_archive)
 
@@ -2362,9 +2254,7 @@ def test_closure_archive_pyproject_key(
 def test_closure_archive_blocked_when_validation_blocks(
     tmp_path: Path, failing_target_compiler, monkeypatch
 ) -> None:
-    project, _dependency, search_path, _json_dependency = (
-        _write_dependency_cli_fixture(tmp_path)
-    )
+    project, _dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
     archive = tmp_path / "blocked.vyz"
     report = tmp_path / "blocked.json"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1677,7 +1677,7 @@ def test_overlay_layout_conflict_exits_4(
     assert str(second.resolve()) in stderr
 
 
-def test_report_json_schema_v2(tmp_path: Path, passing_compiler) -> None:
+def test_report_json_schema_v3(tmp_path: Path, passing_compiler) -> None:
     project, dependency, search_path, json_dependency = (
         _write_dependency_cli_fixture(tmp_path, include_json=True)
     )
@@ -1709,10 +1709,18 @@ def test_report_json_schema_v2(tmp_path: Path, passing_compiler) -> None:
     assert closure_code == 0
     project_data = json.loads(project_report.read_text())
     closure_data = json.loads(closure_report.read_text())
-    assert project_data["schema_version"] == 2
+    assert project_data["schema_version"] == 3
     assert project_data["closure"] is None
     assert all(file["role"] == "project" for file in project_data["files"])
-    assert closure_data["schema_version"] == 2
+    assert {
+        "declared_spec",
+        "resolved_compiler",
+        "dependency_context",
+        "compiler_started",
+        "failure_origin",
+        "compiler_output",
+    } <= project_data["files"][0]["validation"].keys()
+    assert closure_data["schema_version"] == 3
     assert closure_data["closure"] == {
         "requested": True,
         "dependencies": sorted(

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1308,6 +1308,26 @@ os.kill(os.getpid(), signal.SIGTERM)
     assert result.exit_status.signal == signal.SIGTERM
 
 
+def test_real_unhandled_explicit_compiler_failure_is_not_rejection(tmp_path: Path) -> None:
+    executable = _write_test_compiler(tmp_path, 'raise RuntimeError("compiler crashed")\n')
+    contract = tmp_path / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3", source_vyper=str(executable)),
+        "0.4.1",
+    )
+
+    assert result.status == "failed"
+    assert result.compiler_started is True
+    assert result.failure_origin == "adapter"
+    assert result.completion_status == "completed"
+    assert result.exit_status.code == 1
+    assert result.compiler_output is not None
+    assert "RuntimeError: compiler crashed" in result.compiler_output.stderr
+
+
 def test_real_source_nonrejection_has_one_attested_attempt(tmp_path: Path) -> None:
     attempt_log = tmp_path / "attempts.log"
     executable = _write_test_compiler(

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -690,7 +690,9 @@ def test_real_compiler_include_dependencies_upgrades_closure(
     dependency = search_path / "depkg" / "mod.vy"
     dependency.parent.mkdir(parents=True)
     project_root.mkdir()
-    (project_root / "pyproject.toml").write_text("[project]\nname='project'\n")
+    (project_root / "pyproject.toml").write_text(
+        "[project]\nname='project'\nversion='0.1.0'\n"
+    )
     (project_root / "depkg").symlink_to(dependency.parent, target_is_directory=True)
     project_source = (
         "# @version 0.3.10\n"
@@ -741,7 +743,9 @@ def test_real_compiler_closure_output_tree_compiles_standalone(
     dependency = search_path / "depkg" / "mod.vy"
     dependency.parent.mkdir(parents=True)
     project_root.mkdir()
-    (project_root / "pyproject.toml").write_text("[project]\nname='project'\n")
+    (project_root / "pyproject.toml").write_text(
+        "[project]\nname='project'\nversion='0.1.0'\n"
+    )
     (project_root / "depkg").symlink_to(
         dependency.parent, target_is_directory=True
     )
@@ -799,7 +803,9 @@ def test_real_compiler_closure_archive_round_trips(tmp_path: Path) -> None:
     dependency = search_path / "depkg" / "mod.vy"
     dependency.parent.mkdir(parents=True)
     project_root.mkdir()
-    (project_root / "pyproject.toml").write_text("[project]\nname='project'\n")
+    (project_root / "pyproject.toml").write_text(
+        "[project]\nname='project'\nversion='0.1.0'\n"
+    )
     (project_root / "depkg").symlink_to(
         dependency.parent, target_is_directory=True
     )
@@ -907,3 +913,305 @@ def test_real_compiler_archive_floor_0_4_0(tmp_path: Path, capsys) -> None:
     assert below_floor_code == 4
     assert "requires >= 0.4.0" in capsys.readouterr().err
     assert contract.read_text(encoding="utf-8") == contract_source
+
+
+def test_real_twocrypto_source_reports_declared_environment(tmp_path: Path) -> None:
+    project = tmp_path / "twocrypto-ng"
+    contract = project / "contracts" / "main" / "lp_token.vy"
+    contract.parent.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "twocrypto-ng"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "vyper==0.4.1",
+    "snekmate==0.1.1",
+]
+""",
+        encoding="utf-8",
+    )
+    contract.write_text(
+        """# pragma version 0.4.1
+
+from ethereum.ercs import IERC20
+from ethereum.ercs import IERC20Detailed
+
+implements: IERC20
+implements: IERC20Detailed
+
+from snekmate.auth import ownable
+initializes: ownable
+
+from snekmate.tokens import erc20
+initializes: erc20[ownable := ownable]
+exports: (
+    erc20.transfer,
+    erc20.transferFrom,
+    erc20.approve,
+    erc20.balanceOf,
+    erc20.allowance,
+    erc20.totalSupply,
+)
+
+DECIMALS: constant(uint8) = 18
+symbol: public(String[32])
+name: public(String[64])
+
+@deploy
+def __init__(name: String[64], symbol: String[32]):
+    ownable.__init__()
+    erc20.__init__("", "", DECIMALS, "", "")
+    self.name = name
+    self.symbol = symbol
+
+@view
+@external
+def decimals() -> uint8:
+    return DECIMALS
+""",
+        encoding="utf-8",
+    )
+    report = tmp_path / "twocrypto-report.json"
+
+    assert (
+        main(
+            [
+                "--target-version",
+                "0.4.1",
+                "--report-json",
+                str(report),
+                str(contract),
+            ]
+        )
+        == 0
+    )
+
+    validation = json.loads(report.read_text(encoding="utf-8"))["files"][0]["validation"]
+    assert validation["declared_spec"] == "0.4.1"
+    assert validation["resolved_compiler"] == "0.4.1"
+    assert validation["dependency_context"] == {
+        "mode": "project",
+        "project_root": str(project.resolve()),
+        "manifest": str((project / "pyproject.toml").resolve()),
+        "lockfile": None,
+    }
+    assert validation["compiler_started"] is True
+    assert validation["failure_origin"] is None
+    assert validation["compiler_output"] is None
+
+
+def test_real_ranged_pragma_prefers_declared_project_compiler(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "range-pin"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["vyper==0.4.1"]
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text(
+        """# pragma version >=0.4.0
+
+value: public(uint256)
+""",
+        encoding="utf-8",
+    )
+    report = tmp_path / "range-report.json"
+
+    assert (
+        main(
+            [
+                "--target-version",
+                "0.4.3",
+                "--report-json",
+                str(report),
+                str(contract),
+            ]
+        )
+        == 0
+    )
+
+    validation = json.loads(report.read_text(encoding="utf-8"))["files"][0]["validation"]
+    assert validation["declared_spec"] == ">=0.4.0"
+    assert validation["resolved_compiler"] == "0.4.1"
+    assert validation["source_compiler"] == "0.4.1"
+    assert validation["compiler_started"] is True
+    assert validation["failure_origin"] is None
+
+
+def test_real_declared_dependency_rejection_is_compiler_origin(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    dependency = project / "dependency"
+    package = dependency / "declared_dependency"
+    package.mkdir(parents=True)
+    (dependency / "pyproject.toml").write_text(
+        """[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "declared-dependency"
+version = "0.1.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["declared_dependency"]
+""",
+        encoding="utf-8",
+    )
+    (package / "broken.vy").write_text(
+        """# pragma version 0.4.1
+VALUE: constant(uint256) = "not a uint"
+""",
+        encoding="utf-8",
+    )
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "dependency-rejection"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["vyper==0.4.1", "declared-dependency"]
+
+[tool.uv.sources]
+declared-dependency = { path = "dependency" }
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text(
+        """# pragma version 0.4.1
+from declared_dependency import broken
+""",
+        encoding="utf-8",
+    )
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3"),
+        "0.4.1",
+    )
+
+    assert result.status == "failed"
+    assert result.resolved_compiler == "0.4.1"
+    assert result.compiler_started is True
+    assert result.failure_origin == "compiler"
+    assert result.compiler_output is not None
+    assert "declared_dependency" in result.compiler_output.stderr
+
+
+def test_real_uv_resolution_failure_is_environment_origin(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "broken-environment"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["vyper==0.4.1", "missing-local-dependency"]
+
+[tool.uv.sources]
+missing-local-dependency = { path = "does-not-exist" }
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3"),
+        "0.4.1",
+    )
+
+    assert result.status == "failed"
+    assert result.compiler_started is False
+    assert result.failure_origin == "environment"
+    assert result.compiler_output is None
+
+
+def test_real_missing_compiler_is_launch_origin(tmp_path: Path) -> None:
+    contract = tmp_path / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(
+            paths=(contract,),
+            target_version="0.4.3",
+            source_vyper=str(tmp_path / "missing-vyper"),
+        ),
+        "0.4.1",
+    )
+
+    assert result.status == "failed"
+    assert result.compiler_started is False
+    assert result.failure_origin == "launch"
+    assert result.compiler_output is None
+
+
+def test_real_compiler_timeout_is_timeout_origin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from vyupgrade import compiler
+
+    executable = _write_test_compiler(
+        tmp_path,
+        """import time
+time.sleep(5)
+""",
+    )
+    contract = tmp_path / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\n", encoding="utf-8")
+    monkeypatch.setattr(compiler, "COMPILE_TIMEOUT_SECONDS", 0.05)
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3", source_vyper=str(executable)),
+        "0.4.1",
+    )
+
+    assert result.status == "failed"
+    assert result.resolved_compiler == "0.4.1"
+    assert result.compiler_started is True
+    assert result.failure_origin == "timeout"
+
+
+def test_real_invalid_compiler_output_is_adapter_origin(tmp_path: Path) -> None:
+    executable = _write_test_compiler(tmp_path, 'print("not-json")\n')
+    contract = tmp_path / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3", source_vyper=str(executable)),
+        "0.4.1",
+    )
+
+    assert result.status == "failed"
+    assert result.resolved_compiler == "0.4.1"
+    assert result.compiler_started is True
+    assert result.failure_origin == "adapter"
+    assert result.compiler_output is not None
+    assert result.compiler_output.stdout == "not-json\n"
+
+
+def _write_test_compiler(tmp_path: Path, compile_body: str) -> Path:
+    executable = tmp_path / "test-vyper"
+    executable.write_text(
+        f"""#!/usr/bin/env python3
+import sys
+
+if "--version" in sys.argv:
+    print("0.4.1")
+    raise SystemExit
+
+{compile_body}
+""",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return executable

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -105,11 +105,7 @@ def owner() -> address:
     assert target_compile.artifacts is not None
     layout = target_compile.artifacts["layout"]
     assert isinstance(layout, dict)
-    assert layout == {
-        "code_layout": {
-            "OWNER": {"type": "address", "length": 32, "offset": 0}
-        }
-    }
+    assert layout == {"code_layout": {"OWNER": {"type": "address", "length": 32, "offset": 0}}}
 
 
 def test_real_legacy_immutable_layout_compares_with_modern_code_only_target(
@@ -128,9 +124,9 @@ def __init__():
 def owner() -> address:
     return OWNER
 """
-    target_source = legacy_source.replace(
-        "# @version 0.3.10", "#pragma version 0.4.3"
-    ).replace("@external\ndef __init__", "@deploy\ndef __init__", 1)
+    target_source = legacy_source.replace("# @version 0.3.10", "#pragma version 0.4.3").replace(
+        "@external\ndef __init__", "@deploy\ndef __init__", 1
+    )
     contract.write_text(legacy_source, encoding="utf-8")
     config = Config(paths=(contract,), target_version="0.4.3")
 
@@ -144,9 +140,7 @@ def owner() -> address:
     assert compare_artifacts(source_compile, target_compile) == (True, True, True)
     assert source_compile.artifacts is not None
     assert source_compile.artifacts["layout"] == {
-        "code_layout": {
-            "OWNER": {"type": "address", "length": 32, "offset": 0}
-        },
+        "code_layout": {"OWNER": {"type": "address", "length": 32, "offset": 0}},
         "storage_layout": {},
     }
 
@@ -160,9 +154,7 @@ blob: Bytes[64]
 label: String[32]
 pools: HashMap[address, uint256]
 """
-    target_source = legacy_source.replace(
-        "# @version 0.3.10", "#pragma version 0.4.3"
-    )
+    target_source = legacy_source.replace("# @version 0.3.10", "#pragma version 0.4.3")
     contract.write_text(legacy_source, encoding="utf-8")
     config = Config(paths=(contract,), target_version="0.4.3")
 
@@ -180,9 +172,7 @@ pools: HashMap[address, uint256]
     storage = layout["storage_layout"]
     assert isinstance(storage, dict)
     assert {
-        name: entry["n_slots"]
-        for name, entry in storage.items()
-        if isinstance(entry, dict)
+        name: entry["n_slots"] for name, entry in storage.items() if isinstance(entry, dict)
     } == {
         "fixed_values": 3,
         "dynamic_values": 4,
@@ -224,9 +214,7 @@ mixed_values: DynArray[DynArray[uint256, 3][3], 3][5]
     assert str(tokens["type"]).endswith("IERC20.vyi[3]")
     assert dynamic_values["type"] == "DynArray[uint256, 3][3]"
     assert {
-        name: entry["n_slots"]
-        for name, entry in storage.items()
-        if isinstance(entry, dict)
+        name: entry["n_slots"] for name, entry in storage.items() if isinstance(entry, dict)
     } == {
         "tokens": 3,
         "dynamic_values": 12,
@@ -544,8 +532,7 @@ def test_legacy_erc4626_interface_getter_stub_compiles_but_width_is_unproven(
     assert file["validation"]["decision"]["status"] == "blocked"
     assert file["validation"]["storage_layout_equal"] is False
     assert file["validation"]["storage_layout_diff"] == [
-        "changed storage: asset slot 0 ERC20 -> 0 interface IERC20 "
-        "(n_slots unknown -> 1)"
+        "changed storage: asset slot 0 ERC20 -> 0 interface IERC20 (n_slots unknown -> 1)"
     ]
 
 
@@ -627,9 +614,7 @@ def sqrt_plus_zero(x: uint256) -> uint256:
     assert file["validation"]["target_compile"] == "passed"
     assert file["validation"]["decision"]["status"] == "passed"
     assert any(
-        fix["after"] == "builtin_math.isqrt"
-        for fix in file["fixes"]
-        if fix["rule"] == "VY101"
+        fix["after"] == "builtin_math.isqrt" for fix in file["fixes"] if fix["rule"] == "VY101"
     )
 
 
@@ -690,9 +675,7 @@ def test_real_compiler_include_dependencies_upgrades_closure(
     dependency = search_path / "depkg" / "mod.vy"
     dependency.parent.mkdir(parents=True)
     project_root.mkdir()
-    (project_root / "pyproject.toml").write_text(
-        "[project]\nname='project'\nversion='0.1.0'\n"
-    )
+    (project_root / "pyproject.toml").write_text("[project]\nname='project'\nversion='0.1.0'\n")
     (project_root / "depkg").symlink_to(dependency.parent, target_is_directory=True)
     project_source = (
         "# @version 0.3.10\n"
@@ -702,10 +685,7 @@ def test_real_compiler_include_dependencies_upgrades_closure(
         "def value() -> uint256:\n"
         "    return 1\n"
     )
-    dependency_source = (
-        "# @version 0.3.10\n"
-        "VALUE: constant(uint256) = 1\n"
-    )
+    dependency_source = "# @version 0.3.10\nVALUE: constant(uint256) = 1\n"
     project.write_text(project_source, encoding="utf-8")
     dependency.write_text(dependency_source, encoding="utf-8")
     report = tmp_path / "report.json"
@@ -734,6 +714,54 @@ def test_real_compiler_include_dependencies_upgrades_closure(
     assert files[dependency.resolve()]["role"] == "dependency"
 
 
+def test_real_fixed_target_dependency_rejection_has_typed_origin(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project = project_root / "main.vy"
+    search_path = tmp_path / "site-packages"
+    dependency = search_path / "depkg" / "mod.vy"
+    dependency.parent.mkdir(parents=True)
+    project_root.mkdir()
+    (project_root / "pyproject.toml").write_text("[project]\nname='project'\nversion='0.1.0'\n")
+    (project_root / "depkg").symlink_to(dependency.parent, target_is_directory=True)
+    project.write_text(
+        "# @version 0.3.10\nfrom depkg import mod\n",
+        encoding="utf-8",
+    )
+    dependency.write_text(
+        "# @version 0.3.10\n@external\ndef __init__():\n    pass\n",
+        encoding="utf-8",
+    )
+    report = tmp_path / "target-origin-report.json"
+
+    code = main(
+        [
+            str(project),
+            "--target-version",
+            "0.4.3",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+            "--select",
+            "VY001",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code != 0
+    files = {Path(file["path"]): file for file in json.loads(report.read_text())["files"]}
+    dependency_report = files[dependency.resolve()]
+    assert dependency_report["role"] == "dependency"
+    assert dependency_report["validation"]["source_compile"] == "passed"
+    assert dependency_report["validation"]["target_compile"] == "failed"
+    target_attestation = dependency_report["validation"]["target_attestation"]
+    assert target_attestation["authority_rule"] == "fixed-target"
+    assert target_attestation["failure_origin"] == "fixed-target-dependency"
+    assert target_attestation["compiler_started"] is True
+    assert target_attestation["exit_status"] == {"code": 1, "signal": None}
+    assert target_attestation["compiler_output"]["stderr"]
+
+
 def test_real_compiler_closure_output_tree_compiles_standalone(
     tmp_path: Path,
 ) -> None:
@@ -743,12 +771,8 @@ def test_real_compiler_closure_output_tree_compiles_standalone(
     dependency = search_path / "depkg" / "mod.vy"
     dependency.parent.mkdir(parents=True)
     project_root.mkdir()
-    (project_root / "pyproject.toml").write_text(
-        "[project]\nname='project'\nversion='0.1.0'\n"
-    )
-    (project_root / "depkg").symlink_to(
-        dependency.parent, target_is_directory=True
-    )
+    (project_root / "pyproject.toml").write_text("[project]\nname='project'\nversion='0.1.0'\n")
+    (project_root / "depkg").symlink_to(dependency.parent, target_is_directory=True)
     project_source = (
         "# @version 0.3.10\n"
         "from depkg import mod\n"
@@ -757,10 +781,7 @@ def test_real_compiler_closure_output_tree_compiles_standalone(
         "def value() -> uint256:\n"
         "    return 1\n"
     )
-    dependency_source = (
-        "# @version 0.3.10\n"
-        "VALUE: constant(uint256) = 1\n"
-    )
+    dependency_source = "# @version 0.3.10\nVALUE: constant(uint256) = 1\n"
     project.write_text(project_source, encoding="utf-8")
     dependency.write_text(dependency_source, encoding="utf-8")
     output = project_root / "output"
@@ -803,12 +824,8 @@ def test_real_compiler_closure_archive_round_trips(tmp_path: Path) -> None:
     dependency = search_path / "depkg" / "mod.vy"
     dependency.parent.mkdir(parents=True)
     project_root.mkdir()
-    (project_root / "pyproject.toml").write_text(
-        "[project]\nname='project'\nversion='0.1.0'\n"
-    )
-    (project_root / "depkg").symlink_to(
-        dependency.parent, target_is_directory=True
-    )
+    (project_root / "pyproject.toml").write_text("[project]\nname='project'\nversion='0.1.0'\n")
+    (project_root / "depkg").symlink_to(dependency.parent, target_is_directory=True)
     project_source = (
         "# @version 0.3.10\n"
         "from depkg import mod\n"
@@ -817,10 +834,7 @@ def test_real_compiler_closure_archive_round_trips(tmp_path: Path) -> None:
         "def value() -> uint256:\n"
         "    return 1\n"
     )
-    dependency_source = (
-        "# @version 0.3.10\n"
-        "VALUE: constant(uint256) = 1\n"
-    )
+    dependency_source = "# @version 0.3.10\nVALUE: constant(uint256) = 1\n"
     project.write_text(project_source, encoding="utf-8")
     dependency.write_text(dependency_source, encoding="utf-8")
     archive = tmp_path / "out.vyz"
@@ -877,13 +891,7 @@ def test_real_compiler_closure_archive_round_trips(tmp_path: Path) -> None:
 
 def test_real_compiler_archive_floor_0_4_0(tmp_path: Path, capsys) -> None:
     contract = tmp_path / "floor.vy"
-    contract_source = (
-        "#pragma version 0.4.0\n"
-        "\n"
-        "@external\n"
-        "def value() -> uint256:\n"
-        "    return 1\n"
-    )
+    contract_source = "#pragma version 0.4.0\n\n@external\ndef value() -> uint256:\n    return 1\n"
     contract.write_text(contract_source, encoding="utf-8")
     archive = tmp_path / "floor.vyz"
 
@@ -972,6 +980,12 @@ def decimals() -> uint8:
 """,
         encoding="utf-8",
     )
+    subprocess.run(
+        [find_uv_bin(), "lock", "--project", str(project)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     report = tmp_path / "twocrypto-report.json"
 
     assert (
@@ -987,18 +1001,55 @@ def decimals() -> uint8:
         == 0
     )
 
-    validation = json.loads(report.read_text(encoding="utf-8"))["files"][0]["validation"]
-    assert validation["declared_spec"] == "0.4.1"
-    assert validation["resolved_compiler"] == "0.4.1"
-    assert validation["dependency_context"] == {
-        "mode": "project",
-        "project_root": str(project.resolve()),
-        "manifest": str((project / "pyproject.toml").resolve()),
-        "lockfile": None,
+    report_data = json.loads(report.read_text(encoding="utf-8"))
+    assert report_data["schema_version"] == 4
+    assert report_data["producer"] == {"name": "vyupgrade", "version": "0.6.0"}
+    validation = report_data["files"][0]["validation"]
+    attestation = validation["source_attestation"]
+    declarations = attestation["declared_spec"]["compiler_declarations"]
+    assert {declaration["value"] for declaration in declarations} == {
+        "vyper==0.4.1",
+        "0.4.1",
     }
-    assert validation["compiler_started"] is True
-    assert validation["failure_origin"] is None
-    assert validation["compiler_output"] is None
+    assert attestation["resolved_compiler"]["version"] == "0.4.1"
+    assert attestation["authority_rule"] == "project-lock"
+    assert attestation["dependency_context"]["mode"] == "project"
+    assert attestation["dependency_context"]["project_root"] == str(project.resolve())
+    assert attestation["dependency_context"]["manifest"]["path"] == str(
+        (project / "pyproject.toml").resolve()
+    )
+    assert len(attestation["dependency_context"]["manifest"]["sha256"]) == 64
+    lock_identity = attestation["dependency_context"]["lockfile"]
+    assert lock_identity["path"] == str((project / "uv.lock").resolve())
+    assert lock_identity["sha256"] == hashlib.sha256((project / "uv.lock").read_bytes()).hexdigest()
+    resolved_packages = attestation["dependency_context"]["resolved_packages"]
+    assert {"vyper", "snekmate"} <= {package["name"].lower() for package in resolved_packages}
+    compiler_identity = attestation["resolved_compiler"]
+    assert compiler_identity["executable"]["path"] == "vyper"
+    assert len(compiler_identity["executable"]["sha256"]) == 64
+    assert len(compiler_identity["artifact"]["sha256"]) == 64
+    source_identity = {
+        "path": str(contract.resolve()),
+        "sha256": hashlib.sha256(contract.read_bytes()).hexdigest(),
+    }
+    assert attestation["declared_spec"]["sources"] == [source_identity]
+    assert len(attestation["declared_spec"]["snapshot"]["sha256"]) == 64
+    assert attestation["validated_source_set"] == [source_identity]
+    assert attestation["attempt_sequence"] == [
+        {
+            "sequence": 1,
+            "source": source_identity,
+            "compiler_started": True,
+            "completion_status": "completed",
+            "exit_status": {"code": 0, "signal": None},
+            "failure_origin": None,
+        }
+    ]
+    assert attestation["compiler_started"] is True
+    assert attestation["completion_status"] == "completed"
+    assert attestation["exit_status"] == {"code": 0, "signal": None}
+    assert attestation["failure_origin"] is None
+    assert attestation["compiler_output"] is None
 
 
 def test_real_ranged_pragma_prefers_declared_project_compiler(tmp_path: Path) -> None:
@@ -1037,11 +1088,61 @@ value: public(uint256)
     )
 
     validation = json.loads(report.read_text(encoding="utf-8"))["files"][0]["validation"]
-    assert validation["declared_spec"] == ">=0.4.0"
-    assert validation["resolved_compiler"] == "0.4.1"
+    attestation = validation["source_attestation"]
+    declarations = attestation["declared_spec"]["compiler_declarations"]
+    assert {declaration["value"] for declaration in declarations} == {
+        "vyper==0.4.1",
+        ">=0.4.0",
+    }
+    assert attestation["resolved_compiler"]["version"] == "0.4.1"
     assert validation["source_compiler"] == "0.4.1"
-    assert validation["compiler_started"] is True
-    assert validation["failure_origin"] is None
+    assert attestation["authority_rule"] == "project-manifest"
+    assert attestation["compiler_started"] is True
+    assert attestation["failure_origin"] is None
+
+
+def test_real_conflicting_project_and_source_declarations_are_environment_origin(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "conflict"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["vyper==0.4.3"]
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\nvalue: public(uint256)\n", encoding="utf-8")
+    report = tmp_path / "conflict-report.json"
+
+    assert (
+        main(
+            [
+                str(contract),
+                "--target-version",
+                "0.4.3",
+                "--report-json",
+                str(report),
+            ]
+        )
+        != 0
+    )
+
+    validation = json.loads(report.read_text())["files"][0]["validation"]
+    attestation = validation["source_attestation"]
+    assert validation["source_compile"] == "failed"
+    assert attestation["authority_rule"] == "project-manifest"
+    assert attestation["resolved_compiler"]["version"] == "0.4.3"
+    assert attestation["compiler_started"] is False
+    assert attestation["completion_status"] == "not-started"
+    assert attestation["exit_status"] == {"code": None, "signal": None}
+    assert attestation["validated_source_set"] == []
+    assert attestation["failure_origin"] == "environment"
+    assert attestation["compiler_output"] is None
 
 
 def test_real_declared_dependency_rejection_is_compiler_origin(tmp_path: Path) -> None:

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1391,16 +1391,9 @@ def _parse_args(_arguments):
     time.sleep(5)
 """,
     )
-    source_root = Path(__file__).parents[1] / "src"
-    python_path = os.pathsep.join(
-        part for part in (str(site), str(source_root), os.environ.get("PYTHONPATH")) if part
-    )
-    process = subprocess.run(
-        [
-            sys.executable,
-            "-S",
-            "-c",
-            """import signal
+    process = _run_managed_compiler_harness(
+        site,
+        """import signal
 import subprocess
 from vyupgrade.compiler_runner import _run_managed_compiler
 
@@ -1413,10 +1406,29 @@ except subprocess.TimeoutExpired:
     raise SystemExit(0)
 raise SystemExit("managed compiler did not time out")
 """,
-        ],
-        capture_output=True,
-        text=True,
-        env={**os.environ, "PYTHONPATH": python_path},
+    )
+
+    assert process.returncode == 0, process.stderr
+
+
+def test_managed_compiler_worker_crash_is_internal(tmp_path: Path) -> None:
+    site, _bin_dir = _write_managed_vyper_environment(
+        tmp_path,
+        """import os
+
+def _parse_args(_arguments):
+    os._exit(17)
+""",
+    )
+
+    process = _run_managed_compiler_harness(
+        site,
+        """from vyupgrade.compiler_runner import _run_managed_compiler
+
+result = _run_managed_compiler(["vyper"], 5)
+assert result["failure_origin"] == "compiler-internal", result
+assert result["returncode"] == 17, result
+""",
     )
 
     assert process.returncode == 0, process.stderr
@@ -1767,6 +1779,22 @@ def test_real_invalid_compiler_output_is_adapter_origin(tmp_path: Path) -> None:
     assert result.failure_origin == "adapter"
     assert result.compiler_output is not None
     assert result.compiler_output.stdout == "not-json\n"
+
+
+def _run_managed_compiler_harness(
+    site: Path,
+    script: str,
+) -> subprocess.CompletedProcess[str]:
+    source_root = Path(__file__).parents[1] / "src"
+    python_path = os.pathsep.join(
+        part for part in (str(site), str(source_root), os.environ.get("PYTHONPATH")) if part
+    )
+    return subprocess.run(
+        [sys.executable, "-S", "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": python_path},
+    )
 
 
 def _write_managed_vyper_environment(

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import signal
 import shutil
 import subprocess
 import zipfile
+import sys
 from pathlib import Path
 
 import pytest
@@ -1051,6 +1053,216 @@ def decimals() -> uint8:
     assert attestation["exit_status"] == {"code": 0, "signal": None}
     assert attestation["failure_origin"] is None
     assert attestation["compiler_output"] is None
+
+
+def test_real_uv_workspace_member_uses_root_lock_and_workspace_sources(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    app = workspace / "packages" / "app"
+    helper = workspace / "packages" / "helper"
+    helper_package = helper / "src" / "vyupgrade_pr33_helper"
+    app.mkdir(parents=True)
+    helper_package.mkdir(parents=True)
+    (workspace / "pyproject.toml").write_text(
+        """[tool.uv.workspace]
+members = ["packages/*"]
+
+[tool.uv.sources]
+vyupgrade-pr33-helper = { workspace = true }
+""",
+        encoding="utf-8",
+    )
+    (app / "pyproject.toml").write_text(
+        """[project]
+name = "workspace-app"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["vyper==0.4.1", "vyupgrade-pr33-helper"]
+""",
+        encoding="utf-8",
+    )
+    (helper / "pyproject.toml").write_text(
+        """[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vyupgrade-pr33-helper"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+    (helper_package / "__init__.py").write_text("", encoding="utf-8")
+    contract = app / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\nvalue: public(uint256)\n", encoding="utf-8")
+    subprocess.run(
+        [find_uv_bin(), "lock", "--project", str(app)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3"),
+        "0.4.1",
+    )
+
+    assert result.status == "passed"
+    assert result.compiler_authority == "project-lock"
+    assert result.dependency_context is not None
+    assert result.dependency_context.project_root == str(workspace.resolve())
+    assert result.dependency_context.manifest is not None
+    assert result.dependency_context.manifest.path == str((workspace / "pyproject.toml").resolve())
+    assert result.dependency_context.lockfile is not None
+    assert result.dependency_context.lockfile.path == str((workspace / "uv.lock").resolve())
+    assert {source.path for source in result.dependency_context.declared_sources} == {
+        str(helper.resolve())
+    }
+    assert "vyupgrade-pr33-helper" in {
+        package.name.lower() for package in result.dependency_context.resolved_packages
+    }
+
+
+def test_real_compiler_overlay_uses_project_interpreter(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "python-constraint"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = []
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text("# pragma version 0.4.3\nvalue: public(uint256)\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3"),
+        "0.4.3",
+    )
+
+    assert result.status == "passed"
+    assert result.compiler_authority == "source-exact"
+    assert result.resolved_compiler == "0.4.3"
+    assert result.dependency_context is not None
+    assert result.dependency_context.python_constraint == ">=3.13"
+
+
+@pytest.mark.parametrize(
+    "ignored_declaration",
+    [
+        """dependencies = ["vyper==0.4.1; sys_platform == 'win32'"]""",
+        """dependencies = []
+
+[tool.poetry.dependencies]
+python = ">=3.11"
+vyper = "0.4.1"
+""",
+    ],
+    ids=["inactive-marker", "poetry-only"],
+)
+def test_real_compiler_overlay_ignores_inactive_uv_and_poetry_declarations(
+    tmp_path: Path,
+    ignored_declaration: str,
+) -> None:
+    if "sys_platform" in ignored_declaration and sys.platform == "win32":
+        pytest.skip("the reviewer's marker is active on Windows")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        f"""[project]
+name = "inactive-authority"
+version = "0.1.0"
+requires-python = ">=3.11"
+{ignored_declaration}
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text("# pragma version 0.4.3\nvalue: public(uint256)\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3"),
+        "0.4.3",
+    )
+
+    assert result.status == "passed"
+    assert result.compiler_authority == "source-exact"
+    assert result.resolved_compiler == "0.4.3"
+    assert {declaration.kind for declaration in result.compiler_declarations} == {"source-pragma"}
+
+
+def test_compiler_runner_writes_evidence_without_site_packages(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    package = site / "vyper"
+    cli = package / "cli"
+    dist_info = site / "vyper-0.4.3.dist-info"
+    bin_dir = tmp_path / "bin"
+    cli.mkdir(parents=True)
+    dist_info.mkdir(parents=True)
+    bin_dir.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "exceptions.py").write_text(
+        "class VyperException(Exception):\n    pass\n",
+        encoding="utf-8",
+    )
+    (cli / "__init__.py").write_text("", encoding="utf-8")
+    (cli / "vyper_compile.py").write_text(
+        """def _parse_args(_arguments):
+    print("[]")
+    print("{}")
+    print("{}")
+    print('{"ast_type": "Module", "body": []}')
+""",
+        encoding="utf-8",
+    )
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: vyper\nVersion: 0.4.3\n",
+        encoding="utf-8",
+    )
+    (dist_info / "RECORD").write_text("vyper-0.4.3.dist-info/METADATA,,\n", encoding="utf-8")
+    executable = bin_dir / "vyper"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    result_path = tmp_path / "result.json"
+    runner = Path(__file__).parents[1] / "src" / "vyupgrade" / "compiler_runner.py"
+    coherence = json.dumps({"declaration": "0.4.3", "versions": ["0.4.3"]})
+
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            str(runner),
+            str(result_path),
+            "5",
+            "managed",
+            coherence,
+            "vyper",
+            "-f",
+            "abi,method_identifiers,layout,ast",
+            "contract.vy",
+        ],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "PYTHONPATH": str(site),
+        },
+    )
+
+    assert process.returncode == 0, process.stderr
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["state"] == "complete"
+    assert payload["compiler_started"] is True
+    assert payload["failure_origin"] is None
+    assert payload["resolved_compiler"] == "0.4.3"
 
 
 def test_real_ranged_pragma_prefers_declared_project_compiler(tmp_path: Path) -> None:

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1125,6 +1125,52 @@ version = "0.1.0"
     }
 
 
+def test_real_unlocked_project_preserves_sibling_path_sources(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    helper = tmp_path / "helper"
+    helper_package = helper / "src" / "vyupgrade_pr33_helper"
+    project.mkdir()
+    helper_package.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "sibling-path-app"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["vyper==0.4.1", "vyupgrade-pr33-helper"]
+
+[tool.uv.sources]
+vyupgrade-pr33-helper = { path = "../helper" }
+""",
+        encoding="utf-8",
+    )
+    (helper / "pyproject.toml").write_text(
+        """[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vyupgrade-pr33-helper"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+    (helper_package / "__init__.py").write_text("", encoding="utf-8")
+    source = "# pragma version 0.4.1\nvalue: public(uint256)\n"
+    contract = project / "contract.vy"
+    contract.write_text(source, encoding="utf-8")
+    config = Config(paths=(contract,), target_version="0.4.1")
+
+    source_result = compile_source_file(contract, config, "0.4.1")
+    target_result = compile_target_source(contract, source, config)
+
+    assert source_result.status == "passed"
+    assert target_result.status == "passed"
+    assert source_result.dependency_context is not None
+    assert {source.path for source in source_result.dependency_context.declared_sources} == {
+        str(helper.resolve())
+    }
+
+
 def test_real_compiler_overlay_uses_project_interpreter(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()
@@ -1151,6 +1197,99 @@ dependencies = []
     assert result.resolved_compiler == "0.4.3"
     assert result.dependency_context is not None
     assert result.dependency_context.python_constraint == ">=3.13"
+
+
+def test_real_project_markers_use_the_selected_python(tmp_path: Path) -> None:
+    if sys.version_info[:2] == (3, 11):
+        python_constraint = ">=3.12,<3.13"
+        marker = "python_version >= '3.12'"
+    else:
+        python_constraint = ">=3.11,<3.12"
+        marker = "python_version < '3.12'"
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        f"""[project]
+name = "selected-python-markers"
+version = "0.1.0"
+requires-python = "{python_constraint}"
+dependencies = ["vyper==0.4.1; {marker}"]
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text("# pragma version >=0.4.0\nvalue: public(uint256)\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3"),
+        "0.4.3",
+    )
+
+    assert result.status == "passed"
+    assert result.compiler_authority == "project-manifest"
+    assert result.resolved_compiler == "0.4.1"
+    assert {declaration.value for declaration in result.compiler_declarations} == {
+        "vyper==0.4.1; " + marker,
+        ">=0.4.0",
+    }
+
+
+def test_real_target_python_pin_is_preserved_when_compatible(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "compatible-target-python"
+version = "0.1.0"
+requires-python = ">=3.11,<3.12"
+dependencies = []
+""",
+        encoding="utf-8",
+    )
+    source = "# pragma version 0.4.3\nvalue: public(uint256)\n"
+    contract = project / "contract.vy"
+    contract.write_text(source, encoding="utf-8")
+
+    result = compile_target_source(
+        contract,
+        source,
+        Config(paths=(contract,), target_version="0.4.3", target_python="3.11"),
+    )
+
+    assert result.status == "passed"
+    assert result.command is not None
+    assert result.command[result.command.index("--python") + 1] == "3.11"
+
+
+def test_real_target_python_pin_conflict_is_an_environment_failure(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "conflicting-target-python"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = []
+""",
+        encoding="utf-8",
+    )
+    source = "# pragma version 0.4.3\nvalue: public(uint256)\n"
+    contract = project / "contract.vy"
+    contract.write_text(source, encoding="utf-8")
+
+    result = compile_target_source(
+        contract,
+        source,
+        Config(paths=(contract,), target_version="0.4.3", target_python="3.12"),
+    )
+
+    assert result.status == "failed"
+    assert result.compiler_started is False
+    assert result.failure_origin == "environment"
+    assert result.stderr is not None
+    assert "target Python pin '3.12'" in result.stderr
+    assert "requires-python '>=3.13'" in result.stderr
 
 
 @pytest.mark.parametrize(
@@ -1199,37 +1338,15 @@ requires-python = ">=3.11"
 
 
 def test_compiler_runner_writes_evidence_without_site_packages(tmp_path: Path) -> None:
-    site = tmp_path / "site"
-    package = site / "vyper"
-    cli = package / "cli"
-    dist_info = site / "vyper-0.4.3.dist-info"
-    bin_dir = tmp_path / "bin"
-    cli.mkdir(parents=True)
-    dist_info.mkdir(parents=True)
-    bin_dir.mkdir()
-    (package / "__init__.py").write_text("", encoding="utf-8")
-    (package / "exceptions.py").write_text(
-        "class VyperException(Exception):\n    pass\n",
-        encoding="utf-8",
-    )
-    (cli / "__init__.py").write_text("", encoding="utf-8")
-    (cli / "vyper_compile.py").write_text(
+    site, bin_dir = _write_managed_vyper_environment(
+        tmp_path,
         """def _parse_args(_arguments):
     print("[]")
     print("{}")
     print("{}")
     print('{"ast_type": "Module", "body": []}')
 """,
-        encoding="utf-8",
     )
-    (dist_info / "METADATA").write_text(
-        "Metadata-Version: 2.1\nName: vyper\nVersion: 0.4.3\n",
-        encoding="utf-8",
-    )
-    (dist_info / "RECORD").write_text("vyper-0.4.3.dist-info/METADATA,,\n", encoding="utf-8")
-    executable = bin_dir / "vyper"
-    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    executable.chmod(0o755)
     result_path = tmp_path / "result.json"
     runner = Path(__file__).parents[1] / "src" / "vyupgrade" / "compiler_runner.py"
     coherence = json.dumps({"declaration": "0.4.3", "versions": ["0.4.3"]})
@@ -1610,6 +1727,39 @@ def test_real_invalid_compiler_output_is_adapter_origin(tmp_path: Path) -> None:
     assert result.failure_origin == "adapter"
     assert result.compiler_output is not None
     assert result.compiler_output.stdout == "not-json\n"
+
+
+def _write_managed_vyper_environment(
+    tmp_path: Path,
+    compiler_module: str,
+) -> tuple[Path, Path]:
+    site = tmp_path / "site"
+    package = site / "vyper"
+    cli = package / "cli"
+    dist_info = site / "vyper-0.4.3.dist-info"
+    bin_dir = tmp_path / "bin"
+    cli.mkdir(parents=True)
+    dist_info.mkdir(parents=True)
+    bin_dir.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "exceptions.py").write_text(
+        "class VyperException(Exception):\n    pass\n",
+        encoding="utf-8",
+    )
+    (cli / "__init__.py").write_text("", encoding="utf-8")
+    (cli / "vyper_compile.py").write_text(compiler_module, encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: vyper\nVersion: 0.4.3\n",
+        encoding="utf-8",
+    )
+    (dist_info / "RECORD").write_text(
+        "vyper-0.4.3.dist-info/METADATA,,\n",
+        encoding="utf-8",
+    )
+    executable = bin_dir / "vyper"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+    return site, bin_dir
 
 
 def _write_test_compiler(tmp_path: Path, compile_body: str) -> Path:

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1382,6 +1382,46 @@ def test_compiler_runner_writes_evidence_without_site_packages(tmp_path: Path) -
     assert payload["resolved_compiler"] == "0.4.3"
 
 
+def test_managed_compiler_timeout_does_not_require_posix_alarms(tmp_path: Path) -> None:
+    site, _bin_dir = _write_managed_vyper_environment(
+        tmp_path,
+        """import time
+
+def _parse_args(_arguments):
+    time.sleep(5)
+""",
+    )
+    source_root = Path(__file__).parents[1] / "src"
+    python_path = os.pathsep.join(
+        part for part in (str(site), str(source_root), os.environ.get("PYTHONPATH")) if part
+    )
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-c",
+            """import signal
+import subprocess
+from vyupgrade.compiler_runner import _run_managed_compiler
+
+for name in ("SIGALRM", "ITIMER_REAL", "setitimer"):
+    if hasattr(signal, name):
+        delattr(signal, name)
+try:
+    _run_managed_compiler(["vyper"], 0.05)
+except subprocess.TimeoutExpired:
+    raise SystemExit(0)
+raise SystemExit("managed compiler did not time out")
+""",
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": python_path},
+    )
+
+    assert process.returncode == 0, process.stderr
+
+
 def test_real_ranged_pragma_prefers_declared_project_compiler(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import signal
 import shutil
 import subprocess
 import zipfile
@@ -1279,6 +1280,85 @@ time.sleep(5)
     assert result.resolved_compiler == "0.4.1"
     assert result.compiler_started is True
     assert result.failure_origin == "timeout"
+
+
+def test_real_signaled_compiler_is_compiler_internal_origin(tmp_path: Path) -> None:
+    executable = _write_test_compiler(
+        tmp_path,
+        """import os
+import signal
+
+os.kill(os.getpid(), signal.SIGTERM)
+""",
+    )
+    contract = tmp_path / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\n", encoding="utf-8")
+
+    result = compile_source_file(
+        contract,
+        Config(paths=(contract,), target_version="0.4.3", source_vyper=str(executable)),
+        "0.4.1",
+    )
+
+    assert result.status == "failed"
+    assert result.compiler_started is True
+    assert result.failure_origin == "compiler-internal"
+    assert result.completion_status == "signaled"
+    assert result.exit_status.code == -signal.SIGTERM
+    assert result.exit_status.signal == signal.SIGTERM
+
+
+def test_real_source_nonrejection_has_one_attested_attempt(tmp_path: Path) -> None:
+    attempt_log = tmp_path / "attempts.log"
+    executable = _write_test_compiler(
+        tmp_path,
+        f"""with open({str(attempt_log)!r}, "a", encoding="utf-8") as log:
+    log.write("compile\\n")
+print("ValueError: Unsupported format type 'ast'", file=sys.stderr)
+raise SystemExit(7)
+""",
+    )
+    contract = tmp_path / "contract.vy"
+    contract.write_text("# pragma version 0.4.1\n", encoding="utf-8")
+    report = tmp_path / "report.json"
+
+    assert (
+        main(
+            [
+                str(contract),
+                "--target-version",
+                "0.4.3",
+                "--source-vyper",
+                str(executable),
+                "--report-json",
+                str(report),
+            ]
+        )
+        != 0
+    )
+
+    assert attempt_log.read_text(encoding="utf-8").splitlines() == ["compile"]
+    attestation = json.loads(report.read_text(encoding="utf-8"))["files"][0]["validation"][
+        "source_attestation"
+    ]
+    source_identity = {
+        "path": str(contract.resolve()),
+        "sha256": hashlib.sha256(contract.read_bytes()).hexdigest(),
+    }
+    assert attestation["failure_origin"] == "adapter"
+    assert attestation["completion_status"] == "completed"
+    assert attestation["exit_status"] == {"code": 7, "signal": None}
+    assert attestation["validated_source_set"] == [source_identity]
+    assert attestation["attempt_sequence"] == [
+        {
+            "sequence": 1,
+            "source": source_identity,
+            "compiler_started": True,
+            "completion_status": "completed",
+            "exit_status": {"code": 7, "signal": None},
+            "failure_origin": "adapter",
+        }
+    ]
 
 
 def test_real_invalid_compiler_output_is_adapter_origin(tmp_path: Path) -> None:

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1171,6 +1171,49 @@ version = "0.1.0"
     }
 
 
+
+def test_real_explicit_source_compiler_overrides_declared_project(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "explicit-source-compiler"
+version = "0.1.0"
+dependencies = ["vyper==0.4.3"]
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text("# pragma version 0.4.3\n", encoding="utf-8")
+    requested_compiler = project / "missing-vyper"
+
+    result = compile_source_file(
+        contract,
+        Config(
+            paths=(contract,),
+            target_version="0.4.3",
+            source_vyper=str(requested_compiler),
+        ),
+        "0.4.3",
+    )
+
+    assert result.status == "failed"
+    assert result.compiler_started is False
+    assert result.failure_origin == "launch"
+    assert result.compiler_authority == "explicit-executable"
+    assert result.command is not None
+    compiler_index = result.command.index(str(requested_compiler))
+    assert result.command[compiler_index:] == [
+        str(requested_compiler),
+        "-f",
+        "abi,method_identifiers,layout,ast",
+        "-p",
+        str(project),
+        "-p",
+        str(project),
+        str(contract),
+    ]
+
 def test_real_compiler_overlay_uses_project_interpreter(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()

--- a/tests/test_closure.py
+++ b/tests/test_closure.py
@@ -22,38 +22,26 @@ def _write_closure_fixture(
     (project_root / "pyproject.toml").write_text(
         '[project]\nname = "closure-project"\n', encoding="utf-8"
     )
-    project.write_text(
-        "# @version 0.3.10\nfrom depkg import util, IUtil\n", encoding="utf-8"
-    )
-    dependency.write_text(
-        "# @version 0.3.10\nVALUE: constant(uint256) = 1\n", encoding="utf-8"
-    )
+    project.write_text("# @version 0.3.10\nfrom depkg import util, IUtil\n", encoding="utf-8")
+    dependency.write_text("# @version 0.3.10\nVALUE: constant(uint256) = 1\n", encoding="utf-8")
     interface.write_text("[]\n", encoding="utf-8")
     candidates = {
         project: "#pragma version 0.4.3\nfrom depkg import util, IUtil\n",
         dependency: (
-            "#pragma version 0.4.3\n"
-            "VALUE: constant(uint256) = 2\n"
-            "# exact dependency candidate\n"
+            "#pragma version 0.4.3\nVALUE: constant(uint256) = 2\n# exact dependency candidate\n"
         ),
     }
     return candidates, (search_root,), (project, dependency, interface)
 
 
 def _tree_bytes(root: Path) -> dict[Path, bytes]:
-    return {
-        path.relative_to(root): path.read_bytes()
-        for path in root.rglob("*")
-        if path.is_file()
-    }
+    return {path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()}
 
 
 def test_write_closure_output_materializes_import_root_relative_tree(
     tmp_path: Path,
 ) -> None:
-    sources, search_paths, (_project, dependency, _interface) = (
-        _write_closure_fixture(tmp_path)
-    )
+    sources, search_paths, (_project, dependency, _interface) = _write_closure_fixture(tmp_path)
     output = tmp_path / "output"
 
     result = write_closure_output(output, sources, "0.4.3", search_paths)
@@ -160,9 +148,7 @@ def test_write_closure_output_never_touches_sources(tmp_path: Path) -> None:
     sources, search_paths, inputs = _write_closure_fixture(tmp_path)
     before = {path: path.read_bytes() for path in inputs}
 
-    result = write_closure_output(
-        tmp_path / "output", sources, "0.4.3", search_paths
-    )
+    result = write_closure_output(tmp_path / "output", sources, "0.4.3", search_paths)
 
     assert result.status == "written"
     assert {path: path.read_bytes() for path in inputs} == before
@@ -216,9 +202,7 @@ def test_write_closure_output_reports_layout_conflict_as_failed(
 def test_write_closure_output_refuses_linked_dependency_destination(
     tmp_path: Path, link_kind: str
 ) -> None:
-    sources, search_paths, (_project, dependency, _interface) = (
-        _write_closure_fixture(tmp_path)
-    )
+    sources, search_paths, (_project, dependency, _interface) = _write_closure_fixture(tmp_path)
     original = dependency.read_bytes()
     output = tmp_path / "output"
     linked = output / "depkg" / "util.vy"
@@ -267,9 +251,7 @@ def test_write_closure_output_deduplicates_identical_destinations(
     second.write_text(source)
     output = tmp_path / "output"
 
-    result = write_closure_output(
-        output, {first: source, second: source}, "0.4.3"
-    )
+    result = write_closure_output(output, {first: source, second: source}, "0.4.3")
 
     assert result.status == "written"
     assert result.files == (output / "pkg" / "util.vy",)
@@ -289,9 +271,7 @@ def test_write_closure_archive_passes_through_compile_result(
     expected_status: str,
     expected_error: str | None,
 ) -> None:
-    sources, search_paths, (entry, _dependency, _interface) = (
-        _write_closure_fixture(tmp_path)
-    )
+    sources, search_paths, (entry, _dependency, _interface) = _write_closure_fixture(tmp_path)
     output = tmp_path / "out.vyz"
     captured: list[tuple[Path, str, Path]] = []
 
@@ -305,9 +285,7 @@ def test_write_closure_archive_passes_through_compile_result(
         captured.append((path, source, archive))
         return compile_result
 
-    monkeypatch.setattr(
-        compiler, "compile_target_archive", fake_compile_target_archive
-    )
+    monkeypatch.setattr(compiler, "compile_target_archive", fake_compile_target_archive)
 
     result = write_closure_archive(
         output,
@@ -327,9 +305,7 @@ def test_write_closure_archive_passes_through_compile_result(
 
 
 def test_write_closure_archive_missing_entry_fails(tmp_path: Path) -> None:
-    sources, search_paths, (entry, _dependency, _interface) = (
-        _write_closure_fixture(tmp_path)
-    )
+    sources, search_paths, (entry, _dependency, _interface) = _write_closure_fixture(tmp_path)
     missing = entry.with_name("missing.vy")
     output = tmp_path / "out.vyz"
 
@@ -355,17 +331,13 @@ def test_write_closure_archive_missing_entry_fails(tmp_path: Path) -> None:
 def test_write_closure_archive_rejects_source_destinations(
     tmp_path: Path, monkeypatch, destination: str
 ) -> None:
-    sources, search_paths, (entry, dependency, interface) = (
-        _write_closure_fixture(tmp_path)
-    )
+    sources, search_paths, (entry, dependency, interface) = _write_closure_fixture(tmp_path)
     if destination == "entry":
         output = entry
     else:
         output = tmp_path / "out.vyz"
         output.symlink_to(dependency)
-    original_bytes = {
-        path: path.read_bytes() for path in (entry, dependency, interface)
-    }
+    original_bytes = {path: path.read_bytes() for path in (entry, dependency, interface)}
 
     def unexpected_compile(*_args, **_kwargs):
         pytest.fail("source destination must be rejected before archive compilation")
@@ -394,12 +366,8 @@ def test_write_closure_archive_rejects_source_destinations(
         assert output.is_symlink()
 
 
-def test_write_closure_archive_uses_closure_mode_overlay(
-    tmp_path: Path, monkeypatch
-) -> None:
-    sources, search_paths, (entry, dependency, _interface) = (
-        _write_closure_fixture(tmp_path)
-    )
+def test_write_closure_archive_uses_closure_mode_overlay(tmp_path: Path, monkeypatch) -> None:
+    sources, search_paths, (entry, dependency, _interface) = _write_closure_fixture(tmp_path)
     captured_relative_paths: dict[Path, Path] = {}
 
     def fake_compile_target_archive(
@@ -417,9 +385,7 @@ def test_write_closure_archive_uses_closure_mode_overlay(
         )
         return compiler.CompileResult("passed")
 
-    monkeypatch.setattr(
-        compiler, "compile_target_archive", fake_compile_target_archive
-    )
+    monkeypatch.setattr(compiler, "compile_target_archive", fake_compile_target_archive)
 
     result = write_closure_archive(
         tmp_path / "out.vyz",

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -10,6 +9,8 @@ from vyupgrade.compiler import (
     CompileResult,
     OverlayLayoutConflictError,
     TargetOverlay,
+    _CompilerProcess,
+    _declared_project_environment,
     _compiler_command,
     _overlay_search_paths,
     _run_compile,
@@ -27,11 +28,33 @@ from vyupgrade.compiler import (
     target_overlay,
     unavailable_validation_artifacts,
 )
-from vyupgrade.models import Config
+from vyupgrade.models import Config, DependencyContext, FailureOrigin
 from vyupgrade.versions import KNOWN_VERSIONS, parse_version
 
 
 TARGET_COMPILER_OUTPUT = '[]\n{}\n{}\n{"ast_type":"Module","body":[]}\n'
+
+
+def _compiler_process(
+    command: list[str],
+    *,
+    returncode: int | None = 0,
+    stdout: str = TARGET_COMPILER_OUTPUT,
+    stderr: str = "",
+    failure_origin: FailureOrigin | None = None,
+    error: str | None = None,
+) -> _CompilerProcess:
+    return _CompilerProcess(
+        command=command,
+        context=DependencyContext(mode="isolated"),
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        resolved_compiler="0.4.3",
+        compiler_started=True,
+        failure_origin=failure_origin or ("compiler" if returncode else None),
+        error=error,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -129,15 +152,19 @@ def test_explicit_compiler_path_skips_uv_wrapper() -> None:
 def test_target_compile_fails_on_unsupported_required_layout(monkeypatch) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
-        return subprocess.CompletedProcess(
-            command, 1, "", "ValueError: Unsupported format type 'layout'"
+        return _compiler_process(
+            command,
+            returncode=1,
+            stderr="ValueError: Unsupported format type 'layout'",
         )
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
-    result = _run_compile(["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),)))
+    result = _run_compile(
+        ["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),))
+    )
 
     assert result.status == "failed"
     assert result.unavailable_formats == ("layout",)
@@ -159,14 +186,14 @@ def test_target_compile_falls_back_when_optional_ast_is_unavailable(
 ) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
         requested = command[command.index("-f") + 1]
         if requested.endswith(",ast"):
-            return subprocess.CompletedProcess(command, 1, "", ast_error)
-        return subprocess.CompletedProcess(command, 0, "[]\n{}\n{}\n", "")
+            return _compiler_process(command, returncode=1, stderr=ast_error)
+        return _compiler_process(command, stdout="[]\n{}\n{}\n")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = _run_compile(
         ["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),))
@@ -194,13 +221,13 @@ def test_target_compile_does_not_drop_required_formats_after_ast_fallback(
 ) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
         requested = command[command.index("-f") + 1]
         error = "KeyError: 'ast'" if requested.endswith(",ast") else required_error
-        return subprocess.CompletedProcess(command, 1, "", error)
+        return _compiler_process(command, returncode=1, stderr=error)
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = _run_compile(
         ["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),))
@@ -243,9 +270,7 @@ def test_target_compile_does_not_drop_required_formats_after_ast_fallback(
         ),
     ],
 )
-def test_validation_artifacts_reject_malformed_nested_schemas(
-    artifacts, unavailable
-) -> None:
+def test_validation_artifacts_reject_malformed_nested_schemas(artifacts, unavailable) -> None:
     from vyupgrade.compiler import unavailable_validation_artifacts
 
     result = CompileResult("passed", artifacts=artifacts)
@@ -256,15 +281,17 @@ def test_validation_artifacts_reject_malformed_nested_schemas(
 def test_source_compile_degrades_on_unsupported_legacy_layout(monkeypatch) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
         if command[command.index("-f") + 1] == "abi,method_identifiers,layout":
-            return subprocess.CompletedProcess(
-                command, 1, "", "ValueError: Unsupported format type 'layout'"
+            return _compiler_process(
+                command,
+                returncode=1,
+                stderr="ValueError: Unsupported format type 'layout'",
             )
-        return subprocess.CompletedProcess(command, 0, "[]\n{}\n", "")
+        return _compiler_process(command, stdout="[]\n{}\n")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = _run_compile_with_formats_for_test(
         ["vyper"], Path("/tmp/contract.vy"), ("abi", "method_identifiers", "layout")
@@ -279,18 +306,20 @@ def test_source_compile_degrades_on_unsupported_legacy_layout(monkeypatch) -> No
 def test_compile_retries_without_legacy_keyerror_format(monkeypatch) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
         requested = command[command.index("-f") + 1]
         if "method_identifiers" in requested:
-            return subprocess.CompletedProcess(command, 1, "", "KeyError: 'method_identifiers'")
+            return _compiler_process(command, returncode=1, stderr="KeyError: 'method_identifiers'")
         if "ast" in requested:
-            return subprocess.CompletedProcess(command, 1, "", "KeyError: 'ast'")
-        return subprocess.CompletedProcess(command, 0, "[]\n", "")
+            return _compiler_process(command, returncode=1, stderr="KeyError: 'ast'")
+        return _compiler_process(command, stdout="[]\n")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
-    result = _run_compile_with_formats_for_test(["vyper"], Path("/tmp/contract.vy"), ("abi", "method_identifiers", "ast"))
+    result = _run_compile_with_formats_for_test(
+        ["vyper"], Path("/tmp/contract.vy"), ("abi", "method_identifiers", "ast")
+    )
 
     assert result.status == "degraded"
     assert result.unavailable_formats == ("method_identifiers", "ast")
@@ -300,7 +329,7 @@ def test_compile_retries_without_legacy_keyerror_format(monkeypatch) -> None:
 def test_compile_retries_without_ast_for_legacy_span_error(monkeypatch) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
         requested = command[command.index("-f") + 1]
         if requested in {
@@ -308,15 +337,14 @@ def test_compile_retries_without_ast_for_legacy_span_error(monkeypatch) -> None:
             "abi,method_identifiers,layout",
             "abi,method_identifiers",
         }:
-            return subprocess.CompletedProcess(
+            return _compiler_process(
                 command,
-                1,
-                "",
-                "ValueError: start (57,7) precedes previous end (58,0)",
+                returncode=1,
+                stderr="ValueError: start (57,7) precedes previous end (58,0)",
             )
-        return subprocess.CompletedProcess(command, 0, "[]\n", "")
+        return _compiler_process(command, stdout="[]\n")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = _run_compile_with_formats_for_test(
         ["vyper"], Path("/tmp/contract.vy"), ("abi", "method_identifiers", "layout", "ast")
@@ -328,7 +356,9 @@ def test_compile_retries_without_ast_for_legacy_span_error(monkeypatch) -> None:
     assert calls[-1][calls[-1].index("-f") + 1] == "abi"
 
 
-def _run_compile_with_formats_for_test(command: list[str], path: Path, formats: tuple[str, ...]) -> CompileResult:
+def _run_compile_with_formats_for_test(
+    command: list[str], path: Path, formats: tuple[str, ...]
+) -> CompileResult:
     from vyupgrade.compiler import _run_compile_with_formats
 
     return _run_compile_with_formats(
@@ -343,65 +373,160 @@ def _run_compile_with_formats_for_test(command: list[str], path: Path, formats: 
 
 
 def test_target_compile_fails_when_compiler_omits_requested_output(monkeypatch) -> None:
-    def fake_run(command, **kwargs):
-        return subprocess.CompletedProcess(command, 0, "[]\n{}\n", "")
+    def fake_run(command, *_args, **_kwargs):
+        return _compiler_process(command, stdout="[]\n{}\n")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = _run_compile(
         ["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),))
     )
 
     assert result.status == "failed"
-    assert result.stderr == "could not parse compiler output: expected 4 compiler outputs, received 2"
+    assert (
+        result.stderr == "could not parse compiler output: expected 4 compiler outputs, received 2"
+    )
 
 
-def test_compile_installs_declared_vyper_import_dependencies(monkeypatch, tmp_path) -> None:
+def test_declared_project_environment_uses_full_project_and_project_compiler(tmp_path) -> None:
     project = tmp_path / "project"
-    contracts = project / "contracts"
-    contracts.mkdir(parents=True)
-    contract = contracts / "AMM.vy"
-    contract.write_text(
-        """#pragma version 0.4.3
-from snekmate.utils import math
+    contract = project / "contracts" / "AMM.vy"
+    contract.parent.mkdir(parents=True)
+    contract.write_text("#pragma version 0.4.1\n", encoding="utf-8")
+    pyproject = project / "pyproject.toml"
+    pyproject.write_text(
+        """[project]
+name = "amm"
+version = "0.1.0"
+dependencies = ["vyper==0.4.1", "snekmate==0.1.1", "requests==2.32.4"]
 """,
         encoding="utf-8",
     )
-    (project / "pyproject.toml").write_text(
-        """[tool.poetry.dependencies]
-python = ">=3.11,<4"
-snekmate = "0.1.2"
-""",
-        encoding="utf-8",
-    )
-    calls: list[list[str]] = []
-
-    def fake_run(command, **kwargs):
-        calls.append(command)
-        return subprocess.CompletedProcess(command, 0, TARGET_COMPILER_OUTPUT, "")
-
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
-
-    result = _run_compile(
-        ["/tmp/uv", "run", "--no-project", "--python", "3.11", "--with", "vyper==0.4.3", "vyper"],
-        contract,
-        Config(paths=(contract,)),
-    )
-
-    assert result.status == "passed"
-    assert calls[0][:9] == [
-        "/tmp/uv",
+    command = [
+        _uv_bin(),
         "run",
         "--no-project",
         "--python",
         "3.11",
         "--with",
-        "vyper==0.4.3",
-        "--with",
-        "snekmate==0.1.2",
+        "vyper==0.4.1",
+        "vyper",
     ]
-    assert calls[0][9] == "vyper"
-    assert ["-p", str(project)] == calls[0][calls[0].index("-p") : calls[0].index("-p") + 2]
+
+    with _declared_project_environment(command, contract, project_compiler=True) as (
+        prepared,
+        context,
+    ):
+        environment_root = Path(prepared[prepared.index("--project") + 1])
+
+        assert prepared[:3] == [_uv_bin(), "run", "--isolated"]
+        assert environment_root != project.resolve()
+        assert (environment_root / "pyproject.toml").is_file()
+        assert "--all-extras" in prepared
+        assert "--all-groups" in prepared
+        assert "--no-project" not in prepared
+        assert "--python" not in prepared
+        assert not any(argument.startswith("vyper==") for argument in prepared)
+        assert prepared[-1] == "vyper"
+        assert context == DependencyContext(
+            mode="project",
+            project_root=str(project.resolve()),
+            manifest=str(pyproject.resolve()),
+        )
+
+
+def test_declared_project_environment_uses_existing_lock_without_mutating_project(
+    tmp_path,
+) -> None:
+    project = tmp_path / "project"
+    contract = project / "contract.vy"
+    project.mkdir()
+    contract.write_text("#pragma version 0.4.1\n", encoding="utf-8")
+    pyproject = project / "pyproject.toml"
+    pyproject.write_text(
+        """[project]
+name = "locked"
+version = "0.1.0"
+dependencies = ["vyper==0.4.1"]
+""",
+        encoding="utf-8",
+    )
+    lockfile = project / "uv.lock"
+    lockfile.write_text("version = 1\n", encoding="utf-8")
+
+    with _declared_project_environment(
+        [_uv_bin(), "run", "--no-project", "--with", "vyper==0.4.1", "vyper"],
+        contract,
+        project_compiler=True,
+    ) as (prepared, context):
+        assert prepared[prepared.index("--project") + 1] == str(project.resolve())
+        assert "--frozen" in prepared
+        assert context == DependencyContext(
+            mode="project",
+            project_root=str(project.resolve()),
+            manifest=str(pyproject.resolve()),
+            lockfile=str(lockfile),
+        )
+
+
+def test_declared_project_environment_keeps_managed_compiler_interpreter(tmp_path) -> None:
+    project = tmp_path / "project"
+    contract = project / "contract.vy"
+    project.mkdir()
+    contract.write_text("#pragma version 0.3.10\n", encoding="utf-8")
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "compiler-overlay"
+version = "0.1.0"
+dependencies = ["requests==2.32.4"]
+""",
+        encoding="utf-8",
+    )
+    command = [
+        _uv_bin(),
+        "run",
+        "--no-project",
+        "--python",
+        "3.11",
+        "--with",
+        "vyper==0.3.10",
+        "vyper",
+    ]
+
+    with _declared_project_environment(command, contract, project_compiler=True) as (
+        prepared,
+        _context,
+    ):
+        assert prepared[prepared.index("--python") : prepared.index("--python") + 2] == [
+            "--python",
+            "3.11",
+        ]
+        assert prepared[prepared.index("--with") : prepared.index("--with") + 2] == [
+            "--with",
+            "vyper==0.3.10",
+        ]
+
+
+def test_declared_project_environment_without_manifest_stays_isolated(tmp_path) -> None:
+    contract = tmp_path / "contract.vy"
+    contract.write_text("#pragma version 0.4.1\n", encoding="utf-8")
+    command = [
+        _uv_bin(),
+        "run",
+        "--no-project",
+        "--python",
+        "3.11",
+        "--with",
+        "vyper==0.4.1",
+        "vyper",
+    ]
+
+    with _declared_project_environment(command, contract, project_compiler=True) as (
+        prepared,
+        context,
+    ):
+        assert prepared == command
+        assert context == DependencyContext(mode="isolated")
 
 
 def test_compile_skips_search_paths_for_legacy_prerelease_cli(monkeypatch, tmp_path) -> None:
@@ -409,11 +534,11 @@ def test_compile_skips_search_paths_for_legacy_prerelease_cli(monkeypatch, tmp_p
     contract.write_text("", encoding="utf-8")
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
-        return subprocess.CompletedProcess(command, 0, TARGET_COMPILER_OUTPUT, "")
+        return _compiler_process(command)
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = _run_compile(
         ["/tmp/uv", "run", "--no-project", "--python", "3.8", "--with", "vyper==0.1.0b4", "vyper"],
@@ -426,56 +551,14 @@ def test_compile_skips_search_paths_for_legacy_prerelease_cli(monkeypatch, tmp_p
     assert "-p" not in calls[0]
 
 
-def test_compile_inserts_import_dependencies_before_legacy_runner(monkeypatch, tmp_path) -> None:
-    contract = tmp_path / "contracts" / "contract.vy"
-    contract.parent.mkdir(parents=True)
-    contract.write_text("from snekmate.utils import math\n", encoding="utf-8")
-    (tmp_path / "pyproject.toml").write_text(
-        """[tool.poetry.dependencies]
-python = ">=3.11,<4"
-snekmate = "0.1.2"
-""",
-        encoding="utf-8",
-    )
-    calls: list[list[str]] = []
-
-    def fake_run(command, **kwargs):
-        calls.append(command)
-        return subprocess.CompletedProcess(command, 0, TARGET_COMPILER_OUTPUT, "")
-
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
-
-    result = _run_compile(
-        [
-            "/tmp/uv",
-            "run",
-            "--no-project",
-            "--python",
-            "3.8",
-            "--with",
-            "vyper==0.1.0b4",
-            "--with",
-            "typed-ast",
-            "python",
-            "/tmp/legacy_vyper.py",
-        ],
-        contract,
-        Config(paths=(contract,)),
-    )
-
-    assert result.status == "passed"
-    assert calls[0][9:11] == ["--with", "snekmate==0.1.2"]
-    assert calls[0][11:13] == ["python", "/tmp/legacy_vyper.py"]
-
-
 def test_compile_can_suppress_modern_vyper_warnings(monkeypatch) -> None:
     calls: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, *_args, **_kwargs):
         calls.append(command)
-        return subprocess.CompletedProcess(command, 0, TARGET_COMPILER_OUTPUT, "")
+        return _compiler_process(command)
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = _run_compile(
         ["vyper"],
@@ -488,79 +571,26 @@ def test_compile_can_suppress_modern_vyper_warnings(monkeypatch) -> None:
     assert calls[0][calls[0].index("-W") + 1] == "none"
 
 
-def test_compile_reports_timeout_as_failure(monkeypatch) -> None:
-    def fake_run(command, **kwargs):
-        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+def test_compile_preserves_typed_timeout_failure(monkeypatch) -> None:
+    def fake_run(command, *_args, **_kwargs):
+        return _compiler_process(
+            command,
+            returncode=None,
+            stdout="",
+            failure_origin="timeout",
+            error="compiler timed out after 120 seconds",
+        )
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
-    result = _run_compile(["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),)))
+    result = _run_compile(
+        ["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),))
+    )
 
     assert result.status == "failed"
     assert result.stderr == "compiler timed out after 120 seconds"
-    assert result.command is not None
-
-
-def test_compile_retries_missing_pyproject_import_dependency(monkeypatch, tmp_path) -> None:
-    contract = tmp_path / "contracts" / "utils" / "contract.vy"
-    contract.parent.mkdir(parents=True)
-    contract.write_text("# @version 0.4.3\nfrom snekmate.utils import math\n", encoding="utf-8")
-    (tmp_path / "pyproject.toml").write_text(
-        """
-[tool.poetry.dependencies]
-python = ">=3.11,<4"
-snekmate = "0.1.2"
-curve-std = {git = "https://github.com/curvefi/curve-std.git", rev = "09ad21756cd573cd6ac7afb32fb299fef32429cc"}
-""",
-        encoding="utf-8",
-    )
-    calls: list[list[str]] = []
-
-    def fake_run(command, **_kwargs):
-        calls.append(command)
-        if len(calls) == 1:
-            return subprocess.CompletedProcess(
-                command,
-                1,
-                stdout="",
-                stderr="vyper.exceptions.ModuleNotFound: curve_std.stableswap.lp_oracle_2",
-            )
-        return subprocess.CompletedProcess(command, 0, stdout=TARGET_COMPILER_OUTPUT, stderr="")
-
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
-
-    result = _run_compile(
-        ["/tmp/uv", "run", "--no-project", "--python", "3.11", "--with", "vyper==0.4.3", "vyper"],
-        contract,
-        Config(paths=(contract,)),
-    )
-
-    assert result.status == "passed"
-    assert len(calls) == 2
-    assert "snekmate==0.1.2" in calls[0]
-    assert "curve-std @ git+https://github.com/curvefi/curve-std.git@09ad21756cd573cd6ac7afb32fb299fef32429cc" in calls[1]
-
-
-def test_compile_installs_common_import_dependency_without_pyproject(monkeypatch, tmp_path) -> None:
-    contract = tmp_path / "contracts" / "contract.vy"
-    contract.parent.mkdir(parents=True)
-    contract.write_text("# @version 0.4.3\nfrom snekmate.tokens import erc721\n", encoding="utf-8")
-    calls: list[list[str]] = []
-
-    def fake_run(command, **_kwargs):
-        calls.append(command)
-        return subprocess.CompletedProcess(command, 0, stdout=TARGET_COMPILER_OUTPUT, stderr="")
-
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
-
-    result = _run_compile(
-        ["/tmp/uv", "run", "--no-project", "--python", "3.11", "--with", "vyper==0.4.3", "vyper"],
-        contract,
-        Config(paths=(contract,)),
-    )
-
-    assert result.status == "passed"
-    assert "snekmate" in calls[0]
+    assert result.failure_origin == "timeout"
+    assert result.compiler_started is True
 
 
 def test_compile_source_ast_requests_ast_format(monkeypatch, tmp_path) -> None:
@@ -568,7 +598,9 @@ def test_compile_source_ast_requests_ast_format(monkeypatch, tmp_path) -> None:
     contract.write_text("# @version 0.4.3\n", encoding="utf-8")
     calls: dict[str, object] = {}
 
-    def fake_compiler_command(explicit: str | None, version: str | None, python: str | None) -> list[str]:
+    def fake_compiler_command(
+        explicit: str | None, version: str | None, python: str | None
+    ) -> list[str]:
         calls["compiler"] = (explicit, version, python)
         return ["vyper"]
 
@@ -585,7 +617,9 @@ def test_compile_source_ast_requests_ast_format(monkeypatch, tmp_path) -> None:
         return CompileResult("passed", artifacts={"ast": {"ast_type": "Module"}})
 
     monkeypatch.setattr("vyupgrade.compiler._compiler_command", fake_compiler_command)
-    monkeypatch.setattr("vyupgrade.compiler._run_compile_with_formats", fake_run_compile_with_formats)
+    monkeypatch.setattr(
+        "vyupgrade.compiler._run_compile_with_formats", fake_run_compile_with_formats
+    )
 
     result = compile_source_ast(contract, Config(paths=(contract,)), None)
 
@@ -599,7 +633,9 @@ def test_compile_source_file_requests_ast_with_validation_outputs(monkeypatch, t
     contract.write_text("# @version 0.4.3\n", encoding="utf-8")
     calls: dict[str, object] = {}
 
-    def fake_compiler_command(explicit: str | None, version: str | None, python: str | None) -> list[str]:
+    def fake_compiler_command(
+        explicit: str | None, version: str | None, python: str | None
+    ) -> list[str]:
         calls["compiler"] = (explicit, version, python)
         return ["vyper"]
 
@@ -616,13 +652,21 @@ def test_compile_source_file_requests_ast_with_validation_outputs(monkeypatch, t
         return CompileResult("passed", artifacts={"ast": {"ast_type": "Module"}})
 
     monkeypatch.setattr("vyupgrade.compiler._compiler_command", fake_compiler_command)
-    monkeypatch.setattr("vyupgrade.compiler._run_compile_with_formats", fake_run_compile_with_formats)
+    monkeypatch.setattr(
+        "vyupgrade.compiler._run_compile_with_formats", fake_run_compile_with_formats
+    )
 
     result = compile_source_file(contract, Config(paths=(contract,)), None)
 
     assert result.status == "passed"
     assert calls["compiler"] == (None, "0.4.3", None)
-    assert calls["run"] == (["vyper"], contract, ("abi", "method_identifiers", "layout", "ast"), (), True)
+    assert calls["run"] == (
+        ["vyper"],
+        contract,
+        ("abi", "method_identifiers", "layout", "ast"),
+        (),
+        True,
+    )
 
 
 def test_compile_source_file_retries_legacy_span_error_with_final_newline(
@@ -650,7 +694,9 @@ def test_compile_source_file_retries_legacy_span_error_with_final_newline(
         return CompileResult("passed", artifacts={"abi": []})
 
     monkeypatch.setattr("vyupgrade.compiler._prepare_command", lambda *args: (["vyper"], False))
-    monkeypatch.setattr("vyupgrade.compiler._run_compile_with_formats", fake_run_compile_with_formats)
+    monkeypatch.setattr(
+        "vyupgrade.compiler._run_compile_with_formats", fake_run_compile_with_formats
+    )
 
     result = compile_source_file(contract, Config(paths=(contract,)), "0.2.8")
 
@@ -668,7 +714,9 @@ def test_compile_target_source_enables_decimals_for_decimal_code(monkeypatch, tm
     contract.write_text("# @version 0.3.10\n", encoding="utf-8")
     calls: dict[str, object] = {}
 
-    def fake_compiler_command(explicit: str | None, version: str | None, python: str | None) -> list[str]:
+    def fake_compiler_command(
+        explicit: str | None, version: str | None, python: str | None
+    ) -> list[str]:
         calls["compiler"] = (explicit, version, python)
         return ["vyper"]
 
@@ -678,6 +726,7 @@ def test_compile_target_source_enables_decimals_for_decimal_code(monkeypatch, tm
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["run"] = (command, config.enable_decimals, extra_paths, suppress_warnings)
         return CompileResult("passed", artifacts={})
@@ -709,6 +758,7 @@ def test_compile_target_source_enables_decimals_for_math_import(monkeypatch, tmp
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["enable_decimals"] = config.enable_decimals
         return CompileResult("passed", artifacts={})
@@ -738,6 +788,7 @@ def test_compile_target_source_compiles_exact_candidate_bytes(monkeypatch, tmp_p
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["source"] = path.read_text(encoding="utf-8")
         return CompileResult("passed", artifacts={})
@@ -768,11 +819,14 @@ def test_compile_target_interface_uses_import_harness(monkeypatch, tmp_path) -> 
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["harness"] = path.read_text(encoding="utf-8")
         module = calls["harness"].split("import ", 1)[1].split(" as ", 1)[0]
         calls["interface"] = (path.parent / f"{module}.vyi").read_text(encoding="utf-8")
-        return CompileResult("passed", artifacts={"abi": [], "method_identifiers": {}, "layout": {}})
+        return CompileResult(
+            "passed", artifacts={"abi": [], "method_identifiers": {}, "layout": {}}
+        )
 
     monkeypatch.setattr("vyupgrade.compiler._run_compile", fake_run_compile)
 
@@ -878,6 +932,7 @@ def test_compile_target_source_uses_source_dir_for_relative_imports(monkeypatch,
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["target_parent"] = path.parent
         return CompileResult("passed", artifacts={})
@@ -888,6 +943,7 @@ def test_compile_target_source_uses_source_dir_for_relative_imports(monkeypatch,
 
     assert result.status == "passed"
     assert calls["target_parent"] == contract.parent
+
 
 def _write_import_closure_fixture(
     tmp_path: Path,
@@ -903,9 +959,7 @@ def _write_import_closure_fixture(
     source = "#pragma version 0.4.3\nfrom . import b\n"
     contract.write_text(source, encoding="utf-8")
     dependency.write_text(
-        "# @version 0.4.0\n"
-        "from .lib import c\n"
-        "from .interfaces import IThing\n",
+        "# @version 0.4.0\nfrom .lib import c\nfrom .interfaces import IThing\n",
         encoding="utf-8",
     )
     transitive.write_text("# @version 0.4.0\nVALUE: constant(uint256) = 1\n", encoding="utf-8")
@@ -932,11 +986,7 @@ def _write_external_import_fixture(
     external_dependency = site_packages / "depkg" / "util.vy"
     contract.parent.mkdir(parents=True)
     external_dependency.parent.mkdir(parents=True)
-    source = (
-        "#pragma version 0.4.3\n"
-        "from . import local\n"
-        "from depkg import util\n"
-    )
+    source = "#pragma version 0.4.3\nfrom . import local\nfrom depkg import util\n"
     contract.write_text(source, encoding="utf-8")
     local_dependency.write_text(
         "# @version 0.3.10\nLOCAL: constant(uint256) = 1\n",
@@ -964,10 +1014,7 @@ def _write_create2_collision_fixture(
     create2 = utils / "create2.vy"
     utils.mkdir(parents=True)
     (project / "pyproject.toml").write_text("[project]\nname='create2'\n")
-    contract_source = (
-        "#pragma version 0.4.3\n"
-        "from snekmate.utils import create2_address, create2\n"
-    )
+    contract_source = "#pragma version 0.4.3\nfrom snekmate.utils import create2_address, create2\n"
     create2_address_source = (
         "# @version 0.3.10\n"
         "def _compute_address(value: uint256) -> address:\n"
@@ -984,9 +1031,7 @@ def _write_create2_collision_fixture(
 
 
 def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
-    contract, sources, search_paths, expected_dependencies = (
-        _write_import_closure_fixture(tmp_path)
-    )
+    contract, sources, search_paths, expected_dependencies = _write_import_closure_fixture(tmp_path)
 
     closure = resolve_import_closure(sources, search_paths)
 
@@ -1023,22 +1068,16 @@ def test_resolve_import_closure_ignores_imports_in_strings(
 
 
 def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> None:
-    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
-        tmp_path
-    )
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(tmp_path)
     closure = resolve_import_closure(sources, search_paths)
 
     with target_overlay(sources, "0.4.3", search_paths) as overlay:
         assert overlay is not None
         copied_files = {
-            path.relative_to(overlay.root)
-            for path in overlay.root.rglob("*")
-            if path.is_file()
+            path.relative_to(overlay.root) for path in overlay.root.rglob("*") if path.is_file()
         }
 
-    override_files = {
-        path.resolve().relative_to(closure.common_root) for path in sources
-    }
+    override_files = {path.resolve().relative_to(closure.common_root) for path in sources}
     config_files = {
         path.relative_to(closure.common_root)
         for path in closure.common_root.rglob("pyproject.toml")
@@ -1046,8 +1085,7 @@ def test_resolve_import_closure_matches_overlay_dependency_copies(tmp_path) -> N
     create2_aliases = {
         path
         for path in copied_files
-        if path.name == "create2.vy"
-        and path.with_name("create2_address.vy") in copied_files
+        if path.name == "create2.vy" and path.with_name("create2_address.vy") in copied_files
     }
     dependency_copies = copied_files - override_files - config_files - create2_aliases
 
@@ -1065,11 +1103,7 @@ def test_resolve_import_closure_search_path_dependency(tmp_path) -> None:
     contract.parent.mkdir(parents=True)
     dependency.parent.mkdir(parents=True)
     escaped.parent.mkdir(parents=True)
-    source = (
-        "#pragma version 0.4.3\n"
-        "from pkg import dep\n"
-        "from ...outside import escape\n"
-    )
+    source = "#pragma version 0.4.3\nfrom pkg import dep\nfrom ...outside import escape\n"
     contract.write_text(source, encoding="utf-8")
     dependency.write_text("# @version 0.4.0\n", encoding="utf-8")
     escaped.write_text("# @version 0.4.0\n", encoding="utf-8")
@@ -1085,11 +1119,7 @@ def test_resolve_import_closure_search_path_dependency(tmp_path) -> None:
         dependency.resolve().relative_to(closure.common_root)
     with target_overlay({contract: source}, "0.4.3", (site_packages, project)) as overlay:
         assert overlay is not None
-        assert not any(
-            path.name == "dep.vy"
-            for path in overlay.root.rglob("*")
-            if path.is_file()
-        )
+        assert not any(path.name == "dep.vy" for path in overlay.root.rglob("*") if path.is_file())
 
 
 def test_resolve_import_closure_create2_alias_resolves_to_real_file(tmp_path) -> None:
@@ -1109,9 +1139,7 @@ def test_resolve_import_closure_create2_alias_resolves_to_real_file(tmp_path) ->
 
 
 def test_resolve_import_closure_is_idempotent(tmp_path) -> None:
-    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
-        tmp_path
-    )
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(tmp_path)
 
     first = resolve_import_closure(sources, search_paths)
     second = resolve_import_closure(sources, search_paths)
@@ -1128,9 +1156,7 @@ def test_resolve_import_closure_empty_sources_raises() -> None:
 
 
 def test_materialize_target_overlay_writes_into_given_root(tmp_path) -> None:
-    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
-        tmp_path
-    )
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(tmp_path)
     with target_overlay(sources, "0.4.3", search_paths) as temporary:
         assert temporary is not None
         expected_files = {
@@ -1147,17 +1173,13 @@ def test_materialize_target_overlay_writes_into_given_root(tmp_path) -> None:
     assert overlay.root == root
     assert all(path.is_relative_to(root) for path in overlay.paths.values())
     assert {
-        path.relative_to(root): path.read_bytes()
-        for path in root.rglob("*")
-        if path.is_file()
+        path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()
     } == expected_files
     assert root.exists()
 
 
 def test_materialize_target_overlay_output_root_under_project_root(tmp_path) -> None:
-    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(
-        tmp_path
-    )
+    _contract, sources, search_paths, _dependencies = _write_import_closure_fixture(tmp_path)
     project = tmp_path / "project"
     root = project / "overlay-output"
 
@@ -1165,9 +1187,7 @@ def test_materialize_target_overlay_output_root_under_project_root(tmp_path) -> 
 
     assert overlay is not None
     assert list(root.rglob("pyproject.toml")) == [root / "pyproject.toml"]
-    assert (root / "pyproject.toml").read_bytes() == (
-        project / "pyproject.toml"
-    ).read_bytes()
+    assert (root / "pyproject.toml").read_bytes() == (project / "pyproject.toml").read_bytes()
 
 
 def test_materialize_target_overlay_empty_sources_returns_none(tmp_path) -> None:
@@ -1179,9 +1199,7 @@ def test_materialize_target_overlay_empty_sources_returns_none(tmp_path) -> None
 def test_closure_overlay_places_external_dep_import_root_relative(
     tmp_path,
 ) -> None:
-    contract, dependency, sources, search_paths = _write_external_import_fixture(
-        tmp_path
-    )
+    contract, dependency, sources, search_paths = _write_external_import_fixture(tmp_path)
     root = tmp_path / "overlay"
 
     overlay = materialize_target_overlay(
@@ -1205,13 +1223,9 @@ def test_closure_overlay_places_external_dep_import_root_relative(
 
 
 def test_closure_overlay_places_external_candidate_bytes(tmp_path) -> None:
-    _contract, dependency, sources, search_paths = _write_external_import_fixture(
-        tmp_path
-    )
+    _contract, dependency, sources, search_paths = _write_external_import_fixture(tmp_path)
     candidate = (
-        "#pragma version 0.4.3\n"
-        "EXTERNAL: constant(uint256) = 99\n"
-        "# candidate bytes stay exact\n"
+        "#pragma version 0.4.3\nEXTERNAL: constant(uint256) = 99\n# candidate bytes stay exact\n"
     )
     sources[dependency] = candidate
     root = tmp_path / "overlay"
@@ -1291,9 +1305,7 @@ def test_closure_overlay_preserves_symlinked_import_path(tmp_path) -> None:
 
 
 def test_closure_overlay_paths_equal_resolved_closure(tmp_path) -> None:
-    _contract, _dependency, sources, search_paths = _write_external_import_fixture(
-        tmp_path
-    )
+    _contract, _dependency, sources, search_paths = _write_external_import_fixture(tmp_path)
     closure = resolve_import_closure(sources, search_paths)
     root = tmp_path / "overlay"
 
@@ -1402,9 +1414,7 @@ def test_closure_overlay_identical_content_collisions_dedupe(tmp_path) -> None:
 def test_closure_overlay_drops_external_search_paths_from_compile_paths(
     tmp_path,
 ) -> None:
-    _contract, _dependency, sources, search_paths = _write_external_import_fixture(
-        tmp_path
-    )
+    _contract, _dependency, sources, search_paths = _write_external_import_fixture(tmp_path)
 
     with target_overlay(
         sources,
@@ -1428,9 +1438,7 @@ def test_closure_overlay_create2_alias_beside_override(tmp_path) -> None:
     create2_address = project / "snekmate" / "utils" / "create2_address.vy"
     create2_address.parent.mkdir(parents=True)
     (project / "pyproject.toml").write_text("[project]\nname='create2'\n")
-    contract_source = (
-        "#pragma version 0.4.3\nfrom snekmate.utils import create2\n"
-    )
+    contract_source = "#pragma version 0.4.3\nfrom snekmate.utils import create2\n"
     candidate = (
         "#pragma version 0.4.3\n"
         "def _compute_address(value: uint256) -> address:\n"
@@ -1453,13 +1461,8 @@ def test_closure_overlay_create2_alias_beside_override(tmp_path) -> None:
     assert closure is not None
     assert default is not None
     alias = closure_root / "snekmate" / "utils" / "create2.vy"
-    assert (
-        alias.read_text()
-        == candidate.replace("_compute_address", "_compute_create2_address")
-    )
-    assert (
-        closure_root / "snekmate" / "utils" / "create2_address.vy"
-    ).read_text() == candidate
+    assert alias.read_text() == candidate.replace("_compute_address", "_compute_create2_address")
+    assert (closure_root / "snekmate" / "utils" / "create2_address.vy").read_text() == candidate
     assert alias not in closure.paths.values()
     assert not (default_root / "snekmate" / "utils" / "create2.vy").exists()
 
@@ -1467,13 +1470,8 @@ def test_closure_overlay_create2_alias_beside_override(tmp_path) -> None:
 def test_default_overlay_create2_alias_collision_preserves_last_write(
     tmp_path,
 ) -> None:
-    create2_source = (
-        "# @version 0.3.10\n"
-        "REAL_CREATE2: constant(uint256) = 2\n"
-    )
-    _create2_address, _create2, sources = _write_create2_collision_fixture(
-        tmp_path, create2_source
-    )
+    create2_source = "# @version 0.3.10\nREAL_CREATE2: constant(uint256) = 2\n"
+    _create2_address, _create2, sources = _write_create2_collision_fixture(tmp_path, create2_source)
     root = tmp_path / "overlay"
 
     overlay = materialize_target_overlay(sources, "0.4.3", root)
@@ -1485,13 +1483,8 @@ def test_default_overlay_create2_alias_collision_preserves_last_write(
 
 
 def test_closure_overlay_create2_alias_collision_raises(tmp_path) -> None:
-    create2_source = (
-        "# @version 0.3.10\n"
-        "REAL_CREATE2: constant(uint256) = 2\n"
-    )
-    create2_address, create2, sources = _write_create2_collision_fixture(
-        tmp_path, create2_source
-    )
+    create2_source = "# @version 0.3.10\nREAL_CREATE2: constant(uint256) = 2\n"
+    create2_address, create2, sources = _write_create2_collision_fixture(tmp_path, create2_source)
 
     with pytest.raises(OverlayLayoutConflictError) as exc_info:
         materialize_target_overlay(
@@ -1509,9 +1502,7 @@ def test_closure_overlay_create2_alias_collision_raises(tmp_path) -> None:
 def test_closure_overlay_create2_alias_identical_content_dedupes(
     tmp_path,
 ) -> None:
-    _create2_address, create2, sources = _write_create2_collision_fixture(
-        tmp_path, None
-    )
+    _create2_address, create2, sources = _write_create2_collision_fixture(tmp_path, None)
     root = tmp_path / "overlay"
 
     overlay = materialize_target_overlay(
@@ -1523,16 +1514,12 @@ def test_closure_overlay_create2_alias_identical_content_dedupes(
 
     assert overlay is not None
     target = root / "snekmate" / "utils" / "create2.vy"
-    assert target.read_text() == _target_validation_source(
-        create2.read_text(), "0.4.3"
-    )
+    assert target.read_text() == _target_validation_source(create2.read_text(), "0.4.3")
     assert overlay.paths[create2.resolve()] == target
 
 
 def test_closure_overlay_copies_project_pyproject_only(tmp_path) -> None:
-    _contract, dependency, sources, search_paths = _write_external_import_fixture(
-        tmp_path
-    )
+    _contract, dependency, sources, search_paths = _write_external_import_fixture(tmp_path)
     project_pyproject = tmp_path / "project" / "pyproject.toml"
     site_pyproject = search_paths[0] / "pyproject.toml"
     site_pyproject.write_text("[project]\nname='site-packages'\n")
@@ -1550,8 +1537,7 @@ def test_closure_overlay_copies_project_pyproject_only(tmp_path) -> None:
     assert overlay is not None
     assert (root / "pyproject.toml").read_bytes() == project_pyproject.read_bytes()
     assert site_pyproject.read_bytes() not in {
-        path.read_bytes()
-        for path in root.rglob("pyproject.toml")
+        path.read_bytes() for path in root.rglob("pyproject.toml")
     }
 
 
@@ -1584,31 +1570,20 @@ def test_closure_overlay_excludes_nested_search_path_pyprojects(
     assert overlay is not None
     assert (root / "pyproject.toml").read_bytes() == project_pyproject.read_bytes()
     assert overlay.paths[dependency.resolve()] == root / "depkg" / "util.vy"
-    assert not (
-        root
-        / "vendor"
-        / "site-packages"
-        / "depkg"
-        / "pyproject.toml"
-    ).exists()
+    assert not (root / "vendor" / "site-packages" / "depkg" / "pyproject.toml").exists()
     assert dependency_pyproject.read_bytes() not in {
-        path.read_bytes()
-        for path in root.rglob("pyproject.toml")
+        path.read_bytes() for path in root.rglob("pyproject.toml")
     }
 
 
 def test_materialize_default_mode_ignores_external_deps(tmp_path) -> None:
-    contract, dependency, sources, search_paths = _write_external_import_fixture(
-        tmp_path
-    )
+    contract, dependency, sources, search_paths = _write_external_import_fixture(tmp_path)
     project = contract.parents[1]
     local_dependency = contract.with_name("local.vy")
     implicit_root = tmp_path / "implicit"
     explicit_root = tmp_path / "explicit"
 
-    implicit = materialize_target_overlay(
-        sources, "0.4.3", implicit_root, search_paths
-    )
+    implicit = materialize_target_overlay(sources, "0.4.3", implicit_root, search_paths)
     explicit = materialize_target_overlay(
         sources,
         "0.4.3",
@@ -1622,9 +1597,7 @@ def test_materialize_default_mode_ignores_external_deps(tmp_path) -> None:
 
     def tree(root: Path) -> dict[Path, bytes]:
         return {
-            path.relative_to(root): path.read_bytes()
-            for path in root.rglob("*")
-            if path.is_file()
+            path.relative_to(root): path.read_bytes() for path in root.rglob("*") if path.is_file()
         }
 
     expected_tree = {
@@ -1637,16 +1610,13 @@ def test_materialize_default_mode_ignores_external_deps(tmp_path) -> None:
     assert tree(implicit_root) == expected_tree
     assert tree(explicit_root) == expected_tree
     assert dependency.resolve() not in implicit.paths
-    assert {
-        path: target.relative_to(implicit_root)
-        for path, target in implicit.paths.items()
-    } == {contract.resolve(): Path("src/main.vy")}
-    assert {
-        path: target.relative_to(explicit_root)
-        for path, target in explicit.paths.items()
-    } == {contract.resolve(): Path("src/main.vy")}
+    assert {path: target.relative_to(implicit_root) for path, target in implicit.paths.items()} == {
+        contract.resolve(): Path("src/main.vy")
+    }
+    assert {path: target.relative_to(explicit_root) for path, target in explicit.paths.items()} == {
+        contract.resolve(): Path("src/main.vy")
+    }
     assert implicit.source_roots == explicit.source_roots == (project.resolve(),)
-
 
 
 def test_target_overlay_rewrites_imported_vyper_pragmas(monkeypatch, tmp_path) -> None:
@@ -1673,6 +1643,7 @@ def test_target_overlay_rewrites_imported_vyper_pragmas(monkeypatch, tmp_path) -
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["path"] = path
         calls["search_paths"] = config.compiler_search_paths
@@ -1730,6 +1701,7 @@ def test_target_overlay_rewrites_imported_dependency_modules(monkeypatch, tmp_pa
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         imported_overlay = path.parent / "modules" / "lp_shared.vy"
         calls["imported_source"] = imported_overlay.read_text(encoding="utf-8")
@@ -1751,9 +1723,7 @@ def test_target_overlay_rewrites_imported_dependency_modules(monkeypatch, tmp_pa
 
     assert result.status == "passed"
     assert "from snekmate.utils import create2" in calls["imported_source"]
-    assert "create2._compute_create2_address(salt, init_hash, factory)" in calls[
-        "imported_source"
-    ]
+    assert "create2._compute_create2_address(salt, init_hash, factory)" in calls["imported_source"]
 
 
 def test_target_overlay_skips_unrelated_sibling_sources(tmp_path) -> None:
@@ -1785,7 +1755,9 @@ def test_target_overlay_preserves_shallow_absolute_import_roots(tmp_path) -> Non
     contract.parent.mkdir(parents=True)
     dependency.parent.mkdir(parents=True)
     contract.write_text("# @version 0.4.0\nfrom src.modules import constants\n", encoding="utf-8")
-    dependency.write_text("# @version 0.4.0\nMAX_BPS: constant(uint256) = 10_000\n", encoding="utf-8")
+    dependency.write_text(
+        "# @version 0.4.0\nMAX_BPS: constant(uint256) = 10_000\n", encoding="utf-8"
+    )
 
     with target_overlay(
         {contract: "#pragma version 0.4.3\nfrom src.modules import constants\n"},
@@ -1805,7 +1777,9 @@ def test_target_overlay_copies_json_interfaces(tmp_path) -> None:
     interface = project / "src" / "interfaces" / "IValidator.json"
     contract.parent.mkdir(parents=True)
     interface.parent.mkdir(parents=True)
-    contract.write_text("# @version 0.4.3\nfrom src.interfaces import IValidator\n", encoding="utf-8")
+    contract.write_text(
+        "# @version 0.4.3\nfrom src.interfaces import IValidator\n", encoding="utf-8"
+    )
     interface.write_text("[]\n", encoding="utf-8")
 
     with target_overlay(
@@ -1825,7 +1799,9 @@ def test_target_overlay_copies_create2_address_under_rewritten_name(tmp_path) ->
     dependency = project / "snekmate" / "utils" / "create2_address.vy"
     contract.parent.mkdir(parents=True)
     dependency.parent.mkdir(parents=True)
-    contract.write_text("# @version 0.4.0\nfrom snekmate.utils import create2_address\n", encoding="utf-8")
+    contract.write_text(
+        "# @version 0.4.0\nfrom snekmate.utils import create2_address\n", encoding="utf-8"
+    )
     dependency.write_text(
         "# @version 0.4.0\n"
         "def _compute_address(salt: bytes32, init_hash: bytes32, factory: address) -> address:\n"
@@ -1841,9 +1817,9 @@ def test_target_overlay_copies_create2_address_under_rewritten_name(tmp_path) ->
         assert overlay is not None
         overlay_contract = overlay.paths[contract.resolve()]
         overlay_project = overlay_contract.parents[1]
-        alias_source = (
-            overlay_project / "snekmate" / "utils" / "create2.vy"
-        ).read_text(encoding="utf-8")
+        alias_source = (overlay_project / "snekmate" / "utils" / "create2.vy").read_text(
+            encoding="utf-8"
+        )
 
     assert "def _compute_create2_address(" in alias_source
     assert "def _compute_address(" not in alias_source
@@ -1899,8 +1875,7 @@ def test_target_overlay_preserves_nested_package_search_roots(tmp_path) -> None:
     contract.parent.mkdir(parents=True)
     ownable.parent.mkdir(parents=True)
     contract.write_text(
-        "# @version 0.4.3\n"
-        "from pcaversaccio.snekmate.src.snekmate.auth import ownable\n",
+        "# @version 0.4.3\nfrom pcaversaccio.snekmate.src.snekmate.auth import ownable\n",
         encoding="utf-8",
     )
     ownable.write_text("# @version 0.4.3\nOWNER: public(address)\n", encoding="utf-8")
@@ -1946,8 +1921,12 @@ def test_target_overlay_copies_imported_site_package_sources(tmp_path) -> None:
         (project, site_packages),
     ) as overlay:
         assert overlay is not None
-        assert (overlay.root / "venv" / "lib" / "python3.10" / "site-packages" / "curve_std" / "ema.vy").exists()
-        assert overlay.root / "venv" / "lib" / "python3.10" / "site-packages" in overlay.search_paths
+        assert (
+            overlay.root / "venv" / "lib" / "python3.10" / "site-packages" / "curve_std" / "ema.vy"
+        ).exists()
+        assert (
+            overlay.root / "venv" / "lib" / "python3.10" / "site-packages" in overlay.search_paths
+        )
 
 
 def test_target_overlay_resolves_relative_dependency_imports(tmp_path) -> None:
@@ -2007,7 +1986,10 @@ def test_target_overlay_preserves_exact_override_bytes(tmp_path) -> None:
     math = package / "math.vy"
     package.mkdir()
     contract.write_text("# @version 0.4.0\nimport math\n", encoding="utf-8")
-    math.write_text("# @version 0.4.0\n@internal\ndef mul(x: uint256, y: uint256) -> uint256:\n    return x * y\n", encoding="utf-8")
+    math.write_text(
+        "# @version 0.4.0\n@internal\ndef mul(x: uint256, y: uint256) -> uint256:\n    return x * y\n",
+        encoding="utf-8",
+    )
 
     with target_overlay(
         {contract: "#pragma version 0.4.3\nimport math\n"},
@@ -2022,7 +2004,9 @@ def test_target_overlay_preserves_exact_override_bytes(tmp_path) -> None:
         assert (overlay.root / "math.vy").exists()
 
 
-def test_compile_target_source_keeps_decimal_flag_off_without_decimal(monkeypatch, tmp_path) -> None:
+def test_compile_target_source_keeps_decimal_flag_off_without_decimal(
+    monkeypatch, tmp_path
+) -> None:
     contract = tmp_path / "contract.vy"
     contract.write_text("# @version 0.3.10\n", encoding="utf-8")
     calls: dict[str, object] = {}
@@ -2035,6 +2019,7 @@ def test_compile_target_source_keeps_decimal_flag_off_without_decimal(monkeypatc
         config: Config,
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
+        **_kwargs,
     ) -> CompileResult:
         calls["enable_decimals"] = config.enable_decimals
         return CompileResult("passed", artifacts={})
@@ -2063,7 +2048,12 @@ def test_compare_artifacts_canonicalizes_abi_constructor_and_gas() -> None:
         "passed",
         artifacts={
             "abi": [
-                {"type": "constructor", "stateMutability": "nonpayable", "inputs": [], "outputs": []},
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": [],
+                },
                 {
                     "type": "function",
                     "name": "f",
@@ -2073,7 +2063,10 @@ def test_compare_artifacts_canonicalizes_abi_constructor_and_gas() -> None:
                     "gas": 1234,
                 },
             ],
-            "method_identifiers": {"__init__(string,string,uint256)": "0xdeadbeef", "f()": "0x26121ff0"},
+            "method_identifiers": {
+                "__init__(string,string,uint256)": "0xdeadbeef",
+                "f()": "0x26121ff0",
+            },
         },
     )
     target = CompileResult(
@@ -2087,7 +2080,12 @@ def test_compare_artifacts_canonicalizes_abi_constructor_and_gas() -> None:
                     "inputs": [],
                     "outputs": [{"type": "uint256", "name": ""}],
                 },
-                {"type": "constructor", "stateMutability": "nonpayable", "inputs": [], "outputs": []},
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": [],
+                },
             ],
             "method_identifiers": {"f()": "0x26121ff0"},
         },
@@ -2588,15 +2586,11 @@ def test_compare_artifacts_preserves_matching_non_interface_paths_as_unknown(
 ) -> None:
     source = CompileResult(
         "passed",
-        artifacts={
-            "layout": {"storage_layout": {"pool": {"slot": 4, "type": type_name}}}
-        },
+        artifacts={"layout": {"storage_layout": {"pool": {"slot": 4, "type": type_name}}}},
     )
     target = CompileResult(
         "passed",
-        artifacts={
-            "layout": {"storage_layout": {"pool": {"slot": 4, "type": type_name}}}
-        },
+        artifacts={"layout": {"storage_layout": {"pool": {"slot": 4, "type": type_name}}}},
     )
 
     assert unavailable_validation_artifacts(source) == ["abi", "method_identifiers"]
@@ -2617,20 +2611,12 @@ def test_compare_artifacts_preserves_ambiguous_path_delimiters_fail_closed(
     source = CompileResult(
         "passed",
         artifacts={
-            "layout": {
-                "storage_layout": {
-                    "pools": {"slot": 4, "type": "DynArray[IPool, 8]"}
-                }
-            }
+            "layout": {"storage_layout": {"pools": {"slot": 4, "type": "DynArray[IPool, 8]"}}}
         },
     )
     target = CompileResult(
         "passed",
-        artifacts={
-            "layout": {
-                "storage_layout": {"pools": {"slot": 4, "type": target_type}}
-            }
-        },
+        artifacts={"layout": {"storage_layout": {"pools": {"slot": 4, "type": target_type}}}},
     )
 
     assert unavailable_validation_artifacts(target) == [
@@ -2688,9 +2674,7 @@ def test_compare_artifacts_normalizes_nested_module_layouts() -> None:
                         }
                     },
                 },
-                "code_layout": {
-                    "ignored": {"offset": 0, "type": "uint256", "length": 32}
-                },
+                "code_layout": {"ignored": {"offset": 0, "type": "uint256", "length": 32}},
             }
         },
     )
@@ -2706,9 +2690,7 @@ def test_layout_artifact_accepts_code_only_immutables_as_empty_storage() -> None
             "layout": {
                 "code_layout": {
                     "OWNER": {"offset": 0, "type": "address", "length": 32},
-                    "module": {
-                        "LIMIT": {"offset": 32, "type": "uint256", "length": 32}
-                    },
+                    "module": {"LIMIT": {"offset": 32, "type": "uint256", "length": 32}},
                 }
             }
         },
@@ -2728,15 +2710,11 @@ def test_layout_artifact_accepts_all_known_top_level_wrappers() -> None:
         "passed",
         artifacts={
             "layout": {
-                "storage_layout": {
-                    "owner": {"slot": 0, "type": "address", "n_slots": 1}
-                },
+                "storage_layout": {"owner": {"slot": 0, "type": "address", "n_slots": 1}},
                 "transient_storage_layout": {
                     "scratch": {"slot": 0, "type": "uint256", "n_slots": 1}
                 },
-                "code_layout": {
-                    "LIMIT": {"offset": 0, "type": "uint256", "length": 32}
-                },
+                "code_layout": {"LIMIT": {"offset": 0, "type": "uint256", "length": 32}},
             }
         },
     )
@@ -2758,9 +2736,7 @@ def test_layout_artifact_rejects_unknown_top_level_wrapper_siblings(
         "passed",
         artifacts={
             "layout": {
-                "storage_layout": {
-                    "owner": {"slot": 0, "type": "address", "n_slots": 1}
-                },
+                "storage_layout": {"owner": {"slot": 0, "type": "address", "n_slots": 1}},
                 **unknown_sibling,
             }
         },
@@ -2812,12 +2788,8 @@ def test_layout_artifact_rejects_malformed_code_layout(
             }
         },
         {
-            "storage_layout": {
-                "owner": {"slot": 0, "type": "address", "n_slots": 1}
-            },
-            "transient_storage_layout": {
-                "scratch": {"slot": 0, "type": "uint256"}
-            },
+            "storage_layout": {"owner": {"slot": 0, "type": "address", "n_slots": 1}},
+            "transient_storage_layout": {"scratch": {"slot": 0, "type": "uint256"}},
         },
     ],
 )
@@ -2845,11 +2817,7 @@ def test_layout_artifact_rejects_mixed_n_slots_schema(
                 }
             }
         },
-        {
-            "storage_layout": {
-                "values": {"slot": 2**256 - 2, "type": "uint256[3]", "n_slots": 3}
-            }
-        },
+        {"storage_layout": {"values": {"slot": 2**256 - 2, "type": "uint256[3]", "n_slots": 3}}},
     ],
 )
 def test_layout_artifact_rejects_storage_spans_past_uint256(
@@ -2920,13 +2888,7 @@ def test_compare_artifact_details_qualifies_nested_module_changes() -> None:
     "malformed_layout",
     [
         {"storage_layout": {"vault": {"owner": {"slot": 0}}}},
-        {
-            "storage_layout": {
-                "vault": {
-                    "owner": {"slot": 0, "type": "address", "n_slots": None}
-                }
-            }
-        },
+        {"storage_layout": {"vault": {"owner": {"slot": 0, "type": "address", "n_slots": None}}}},
         {
             "storage_layout": {
                 "vault": {
@@ -3012,9 +2974,7 @@ def test_compare_artifacts_rejects_empty_nested_storage_namespace() -> None:
     valid = CompileResult(
         "passed",
         artifacts={
-            "layout": {
-                "storage_layout": {"vault": {"owner": {"slot": 0, "type": "address"}}}
-            }
+            "layout": {"storage_layout": {"vault": {"owner": {"slot": 0, "type": "address"}}}}
         },
     )
 
@@ -3025,16 +2985,8 @@ def test_compare_artifacts_rejects_empty_nested_storage_namespace() -> None:
 @pytest.mark.parametrize(
     "layout",
     [
-        {
-            "storage_layout": {
-                "owner": {"slot": 0, "type": "address", "location": "transient"}
-            }
-        },
-        {
-            "storage_layout": {
-                "owner": {"slot": 0, "type": "address", "location": "memory"}
-            }
-        },
+        {"storage_layout": {"owner": {"slot": 0, "type": "address", "location": "transient"}}},
+        {"storage_layout": {"owner": {"slot": 0, "type": "address", "location": "memory"}}},
         {
             "storage_layout": {},
             "transient_storage_layout": {
@@ -3056,9 +3008,7 @@ def test_compare_artifacts_compares_n_slots_when_both_layouts_supply_it() -> Non
         "passed",
         artifacts={
             "layout": {
-                "storage_layout": {
-                    "values": {"slot": 0, "type": "CustomStruct", "n_slots": 1}
-                }
+                "storage_layout": {"values": {"slot": 0, "type": "CustomStruct", "n_slots": 1}}
             }
         },
     )
@@ -3066,17 +3016,14 @@ def test_compare_artifacts_compares_n_slots_when_both_layouts_supply_it() -> Non
         "passed",
         artifacts={
             "layout": {
-                "storage_layout": {
-                    "values": {"slot": 0, "type": "CustomStruct", "n_slots": 2}
-                }
+                "storage_layout": {"values": {"slot": 0, "type": "CustomStruct", "n_slots": 2}}
             }
         },
     )
 
     assert compare_artifacts(source, target) == (None, None, False)
     assert compare_artifact_details(source, target)[2] == [
-        "changed storage: values slot 0 CustomStruct -> 0 CustomStruct "
-        "(n_slots 1 -> 2)"
+        "changed storage: values slot 0 CustomStruct -> 0 CustomStruct (n_slots 1 -> 2)"
     ]
 
 
@@ -3088,11 +3035,7 @@ def test_compare_artifacts_infers_known_width_when_legacy_layout_omits_it() -> N
     target = CompileResult(
         "passed",
         artifacts={
-            "layout": {
-                "storage_layout": {
-                    "values": {"slot": 0, "type": "uint256", "n_slots": 1}
-                }
-            }
+            "layout": {"storage_layout": {"values": {"slot": 0, "type": "uint256", "n_slots": 1}}}
         },
     )
 
@@ -3103,11 +3046,7 @@ def test_layout_artifact_rejects_explicit_width_for_known_scalar() -> None:
     result = CompileResult(
         "passed",
         artifacts={
-            "layout": {
-                "storage_layout": {
-                    "values": {"slot": 0, "type": "uint256", "n_slots": 2}
-                }
-            }
+            "layout": {"storage_layout": {"values": {"slot": 0, "type": "uint256", "n_slots": 2}}}
         },
     )
 
@@ -3148,9 +3087,7 @@ def test_compare_artifacts_infers_known_legacy_storage_widths(
         "passed",
         artifacts={
             "layout": {
-                "storage_layout": {
-                    "value": {"slot": 0, "type": type_name, "n_slots": n_slots}
-                }
+                "storage_layout": {"value": {"slot": 0, "type": type_name, "n_slots": n_slots}}
             }
         },
     )
@@ -3163,18 +3100,12 @@ def test_compare_artifacts_infers_known_legacy_storage_widths(
 def test_compare_artifacts_infers_explicit_legacy_interface_width() -> None:
     source = CompileResult(
         "passed",
-        artifacts={
-            "layout": {"pool": {"slot": 0, "type": "interface Pool"}}
-        },
+        artifacts={"layout": {"pool": {"slot": 0, "type": "interface Pool"}}},
     )
     target = CompileResult(
         "passed",
         artifacts={
-            "layout": {
-                "storage_layout": {
-                    "pool": {"slot": 0, "type": "Pool.vyi", "n_slots": 1}
-                }
-            }
+            "layout": {"storage_layout": {"pool": {"slot": 0, "type": "Pool.vyi", "n_slots": 1}}}
         },
     )
 
@@ -3282,10 +3213,7 @@ def test_compare_artifacts_accepts_pairwise_interface_marker_omission(
             "ast": {
                 "ast_type": "Module",
                 "body": [
-                    *(
-                        {"ast_type": "InterfaceDef", "name": name}
-                        for name in interface_names
-                    ),
+                    *({"ast_type": "InterfaceDef", "name": name} for name in interface_names),
                     {
                         "ast_type": "VariableDecl",
                         "target": {"ast_type": "Name", "id": "value"},
@@ -3331,11 +3259,7 @@ def test_compare_artifacts_requires_top_level_target_interface_evidence(
     target = CompileResult(
         "passed",
         artifacts={
-            "layout": {
-                "storage_layout": {
-                    "value": {"slot": 0, "type": "HashMap[address, Pool]"}
-                }
-            },
+            "layout": {"storage_layout": {"value": {"slot": 0, "type": "HashMap[address, Pool]"}}},
             "ast": {
                 "ast_type": "Module",
                 "body": [
@@ -3390,11 +3314,7 @@ def test_compare_artifacts_rejects_missing_or_malformed_target_ast(
     target = CompileResult(
         "passed",
         artifacts={
-            "layout": {
-                "storage_layout": {
-                    "value": {"slot": 0, "type": "HashMap[address, Pool]"}
-                }
-            },
+            "layout": {"storage_layout": {"value": {"slot": 0, "type": "HashMap[address, Pool]"}}},
             "ast": target_ast,
         },
     )
@@ -3571,9 +3491,7 @@ def test_compare_artifacts_rejects_one_sided_unknown_storage_width() -> None:
         "passed",
         artifacts={
             "layout": {
-                "storage_layout": {
-                    "value": {"slot": 0, "type": "CustomStruct", "n_slots": 2}
-                }
+                "storage_layout": {"value": {"slot": 0, "type": "CustomStruct", "n_slots": 2}}
             }
         },
     )
@@ -3582,8 +3500,7 @@ def test_compare_artifacts_rejects_one_sided_unknown_storage_width() -> None:
     assert unavailable_validation_artifacts(target) == ["abi", "method_identifiers"]
     assert compare_artifacts(source, target) == (None, None, False)
     assert compare_artifact_details(source, target)[2] == [
-        "changed storage: value slot 0 CustomStruct -> 0 CustomStruct "
-        "(n_slots unknown -> 2)"
+        "changed storage: value slot 0 CustomStruct -> 0 CustomStruct (n_slots unknown -> 2)"
     ]
 
 
@@ -3616,9 +3533,7 @@ def test_compare_artifacts_accepts_symmetric_unknown_omitted_widths() -> None:
 def test_layout_artifact_rejects_flattened_and_normalized_name_collisions(
     storage_layout: dict[str, object],
 ) -> None:
-    result = CompileResult(
-        "passed", artifacts={"layout": {"storage_layout": storage_layout}}
-    )
+    result = CompileResult("passed", artifacts={"layout": {"storage_layout": storage_layout}})
 
     assert unavailable_validation_artifacts(result) == ["abi", "method_identifiers", "layout"]
 
@@ -3640,9 +3555,7 @@ def test_layout_artifact_distinguishes_legacy_storage_layout_variable_from_wrapp
         "passed",
         artifacts={
             "layout": {
-                "storage_layout": {
-                    "storage_layout": {"slot": 0, "type": "uint256", "n_slots": 1}
-                }
+                "storage_layout": {"storage_layout": {"slot": 0, "type": "uint256", "n_slots": 1}}
             }
         },
     )
@@ -3677,9 +3590,7 @@ def test_layout_artifact_preserves_explicit_legacy_wrapper_named_variables(
     )
     target_layout: dict[str, object] = {"storage_layout": {}}
     wrapper = "transient_storage_layout" if location == "transient" else "storage_layout"
-    target_layout[wrapper] = {
-        name: {"slot": 0, "type": "uint256", "n_slots": 1}
-    }
+    target_layout[wrapper] = {name: {"slot": 0, "type": "uint256", "n_slots": 1}}
     target = CompileResult("passed", artifacts={"layout": target_layout})
 
     assert unavailable_validation_artifacts(source) == ["abi", "method_identifiers"]
@@ -3719,9 +3630,7 @@ def test_layout_artifact_rejects_truncated_or_ambiguous_wrapper_named_roots(
 def test_layout_artifact_rejects_slots_outside_uint256(slot: int | str) -> None:
     result = CompileResult(
         "passed",
-        artifacts={
-            "layout": {"storage_layout": {"owner": {"slot": slot, "type": "address"}}}
-        },
+        artifacts={"layout": {"storage_layout": {"owner": {"slot": slot, "type": "address"}}}},
     )
 
     assert unavailable_validation_artifacts(result) == ["abi", "method_identifiers", "layout"]
@@ -3730,20 +3639,14 @@ def test_layout_artifact_rejects_slots_outside_uint256(slot: int | str) -> None:
 def test_compare_artifacts_compares_transient_layouts_explicitly() -> None:
     source = CompileResult(
         "passed",
-        artifacts={
-            "layout": {
-                "scratch": {"location": "transient", "slot": 0, "type": "uint256"}
-            }
-        },
+        artifacts={"layout": {"scratch": {"location": "transient", "slot": 0, "type": "uint256"}}},
     )
     target = CompileResult(
         "passed",
         artifacts={
             "layout": {
                 "storage_layout": {},
-                "transient_storage_layout": {
-                    "scratch": {"slot": 1, "type": "address"}
-                },
+                "transient_storage_layout": {"scratch": {"slot": 1, "type": "address"}},
             }
         },
     )
@@ -4221,9 +4124,7 @@ def test_compare_artifact_details_reports_full_storage_changes() -> None:
     assert not any(line.startswith("... ") for line in storage_diff)
 
 
-def test_compile_target_archive_requires_overlay_staging(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_compile_target_archive_requires_overlay_staging(tmp_path: Path, monkeypatch) -> None:
     entry = tmp_path / "main.vy"
     entry.write_text("#pragma version 0.4.3\n")
     overlay = TargetOverlay(tmp_path / "overlay", {}, (), ())
@@ -4231,7 +4132,7 @@ def test_compile_target_archive_requires_overlay_staging(
     def unexpected_run(*_args, **_kwargs):
         pytest.fail("archive compiler must not run without a staged entry")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", unexpected_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", unexpected_run)
 
     result = compile_target_archive(
         entry,
@@ -4246,9 +4147,7 @@ def test_compile_target_archive_requires_overlay_staging(
     assert "not staged" in result.stderr
 
 
-def test_compile_target_archive_replaces_existing_output(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_compile_target_archive_replaces_existing_output(tmp_path: Path, monkeypatch) -> None:
     entry = tmp_path / "main.vy"
     staged = tmp_path / "overlay" / "main.vy"
     staged.parent.mkdir()
@@ -4263,12 +4162,12 @@ def test_compile_target_archive_replaces_existing_output(
     )
     calls: list[list[str]] = []
 
-    def fake_run(command: list[str], **_kwargs):
+    def fake_run(command: list[str], *_args, **_kwargs):
         calls.append(command)
         Path(command[command.index("-o") + 1]).write_bytes(b"new archive")
-        return subprocess.CompletedProcess(command, 0, "", "")
+        return _compiler_process(command, stdout="")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = compile_target_archive(
         entry,
@@ -4301,11 +4200,11 @@ def test_compile_target_archive_cleans_temporary_output_on_failure(
         (staged.parent,),
     )
 
-    def fake_run(command: list[str], **_kwargs):
+    def fake_run(command: list[str], *_args, **_kwargs):
         Path(command[command.index("-o") + 1]).write_bytes(b"partial")
-        return subprocess.CompletedProcess(command, 1, "", "archive failed")
+        return _compiler_process(command, returncode=1, stdout="", stderr="archive failed")
 
-    monkeypatch.setattr("vyupgrade.compiler.subprocess.run", fake_run)
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
 
     result = compile_target_archive(
         entry,

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -479,7 +479,9 @@ dependencies = ["vyper==0.4.1"]
         )
 
 
-def test_declared_project_environment_keeps_managed_compiler_interpreter(tmp_path) -> None:
+def test_declared_project_environment_uses_project_interpreter_for_compiler_overlay(
+    tmp_path,
+) -> None:
     project = tmp_path / "project"
     contract = project / "contract.vy"
     project.mkdir()
@@ -488,6 +490,7 @@ def test_declared_project_environment_keeps_managed_compiler_interpreter(tmp_pat
         """[project]
 name = "compiler-overlay"
 version = "0.1.0"
+requires-python = ">=3.13"
 dependencies = ["requests==2.32.4"]
 """,
         encoding="utf-8",
@@ -507,10 +510,7 @@ dependencies = ["requests==2.32.4"]
         prepared,
         _context,
     ):
-        assert prepared[prepared.index("--python") : prepared.index("--python") + 2] == [
-            "--python",
-            "3.11",
-        ]
+        assert "--python" not in prepared
         assert prepared[prepared.index("--with") : prepared.index("--with") + 2] == [
             "--with",
             "vyper==0.3.10",

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from hashlib import sha256
 
 from pathlib import Path
 
@@ -28,7 +29,7 @@ from vyupgrade.compiler import (
     target_overlay,
     unavailable_validation_artifacts,
 )
-from vyupgrade.models import Config, DependencyContext, FailureOrigin
+from vyupgrade.models import Config, ContentIdentity, DependencyContext, FailureOrigin
 from vyupgrade.versions import KNOWN_VERSIONS, parse_version
 
 
@@ -431,7 +432,10 @@ dependencies = ["vyper==0.4.1", "snekmate==0.1.1", "requests==2.32.4"]
         assert context == DependencyContext(
             mode="project",
             project_root=str(project.resolve()),
-            manifest=str(pyproject.resolve()),
+            manifest=ContentIdentity(
+                str(pyproject.resolve()),
+                sha256(pyproject.read_bytes()).hexdigest(),
+            ),
         )
 
 
@@ -464,8 +468,14 @@ dependencies = ["vyper==0.4.1"]
         assert context == DependencyContext(
             mode="project",
             project_root=str(project.resolve()),
-            manifest=str(pyproject.resolve()),
-            lockfile=str(lockfile),
+            manifest=ContentIdentity(
+                str(pyproject.resolve()),
+                sha256(pyproject.read_bytes()).hexdigest(),
+            ),
+            lockfile=ContentIdentity(
+                str(lockfile.resolve()),
+                sha256(lockfile.read_bytes()).hexdigest(),
+            ),
         )
 
 
@@ -669,13 +679,13 @@ def test_compile_source_file_requests_ast_with_validation_outputs(monkeypatch, t
     )
 
 
-def test_compile_source_file_retries_legacy_span_error_with_final_newline(
+def test_compile_source_file_does_not_retry_or_transform_final_newline(
     monkeypatch, tmp_path
 ) -> None:
     contract = tmp_path / "contract.vy"
     source = "# @version 0.2.8\n# eof"
     contract.write_text(source, encoding="utf-8")
-    calls: list[tuple[Path, bytes]] = []
+    calls: list[tuple[Path, bytes, object]] = []
 
     def fake_run_compile_with_formats(
         command: list[str],
@@ -684,14 +694,10 @@ def test_compile_source_file_retries_legacy_span_error_with_final_newline(
         formats: tuple[str, ...],
         extra_paths: tuple[Path, ...],
         suppress_warnings: bool,
-        **_kwargs,
+        **kwargs,
     ) -> CompileResult:
-        calls.append((path, path.read_bytes()))
-        if len(calls) == 1:
-            return CompileResult(
-                "failed", stderr="ValueError: start (2,0) precedes previous end (3,0)"
-            )
-        return CompileResult("passed", artifacts={"abi": []})
+        calls.append((path, path.read_bytes(), kwargs.get("allow_format_retries")))
+        return CompileResult("failed", stderr="ValueError: start (2,0) precedes previous end (3,0)")
 
     monkeypatch.setattr("vyupgrade.compiler._prepare_command", lambda *args: (["vyper"], False))
     monkeypatch.setattr(
@@ -700,12 +706,8 @@ def test_compile_source_file_retries_legacy_span_error_with_final_newline(
 
     result = compile_source_file(contract, Config(paths=(contract,)), "0.2.8")
 
-    assert result.status == "passed"
-    assert calls[0] == (contract, source.encode())
-    assert calls[1][0].parent == contract.parent
-    assert calls[1][0] != contract
-    assert calls[1][1] == source.encode() + b"\n"
-    assert not calls[1][0].exists()
+    assert result.status == "failed"
+    assert calls == [(contract, source.encode(), False)]
     assert contract.read_text(encoding="utf-8") == source
 
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -673,10 +673,7 @@ def test_smoke_resumes_when_selected_compiler_differs_from_manifest_hint(
     monkeypatch, tmp_path: Path
 ) -> None:
     corpus = _load_corpus_module()
-    items = [
-        {"index": index, "repo": "test", "source_compiler": "0.3.3"}
-        for index in range(2)
-    ]
+    items = [{"index": index, "repo": "test", "source_compiler": "0.3.3"} for index in range(2)]
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps({"items": items}), encoding="utf-8")
     output_path = tmp_path / "smoke-results.json"
@@ -735,11 +732,7 @@ def test_smoke_does_not_resume_older_schema_result_rows(
     legacy_results = [
         {
             **items[0],
-            **(
-                {"smoke_schema_version": old_schema}
-                if old_schema is not None
-                else {}
-            ),
+            **({"smoke_schema_version": old_schema} if old_schema is not None else {}),
             "source_compile": "passed",
             "target_compile": "passed",
             "target_version": target_version,
@@ -773,8 +766,7 @@ def test_smoke_does_not_resume_older_schema_result_rows(
     assert sorted(submitted) == [0, 1]
     results = json.loads(output_path.read_text(encoding="utf-8"))
     assert all(
-        result["smoke_schema_version"] == corpus.SMOKE_RESULT_SCHEMA_VERSION
-        for result in results
+        result["smoke_schema_version"] == corpus.SMOKE_RESULT_SCHEMA_VERSION for result in results
     )
 
 
@@ -818,9 +810,7 @@ def test_smoke_does_not_resume_when_run_identity_changes(monkeypatch, tmp_path: 
     assert {result["target_version"] for result in results} == {"0.4.3"}
 
 
-def test_smoke_does_not_resume_when_runner_source_changes(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_smoke_does_not_resume_when_runner_source_changes(monkeypatch, tmp_path: Path) -> None:
     corpus = _load_corpus_module()
     items = [{"index": index, "repo": "test"} for index in range(2)]
     manifest_path = tmp_path / "manifest.json"
@@ -858,9 +848,7 @@ def test_smoke_does_not_resume_when_runner_source_changes(
     corpus.smoke_corpus(manifest_path, output_path, target_version, 2, 0)
 
     assert sorted(submitted) == [0, 1]
-    checkpoint = json.loads(
-        corpus._checkpoint_path(output_path).read_text(encoding="utf-8")
-    )
+    checkpoint = json.loads(corpus._checkpoint_path(output_path).read_text(encoding="utf-8"))
     assert checkpoint["identity"]["runner_sha256"] == "new-runner"
 
 
@@ -949,9 +937,10 @@ def test_smoke_malformed_resume_state_falls_back_safely(
 
     assert submitted == [0]
     assert json.loads(output_path.read_text(encoding="utf-8"))[0]["index"] == 0
-    assert json.loads(corpus._checkpoint_path(output_path).read_text(encoding="utf-8"))[
-        "completed"
-    ] == 1
+    assert (
+        json.loads(corpus._checkpoint_path(output_path).read_text(encoding="utf-8"))["completed"]
+        == 1
+    )
 
 
 def test_atomic_json_write_keeps_existing_destination_valid_on_replace_failure(
@@ -1036,9 +1025,7 @@ def test_smoke_uses_manifest_pragma_as_source_version(monkeypatch, tmp_path: Pat
     assert result["source_compile"] == "passed"
     assert result["target_compile"] == "passed"
     assert result["validation_status"] == "blocked"
-    assert result["validation_blockers"][0]["code"] == (
-        "target_artifacts_unavailable"
-    )
+    assert result["validation_blockers"][0]["code"] == ("target_artifacts_unavailable")
     assert result["validation_waivers"] == []
 
 
@@ -1090,13 +1077,9 @@ def test_smoke_records_artifact_diff_details_for_mismatches(monkeypatch, tmp_pat
 
     result = corpus._smoke_one(item, "0.4.3")
 
-    assert result["abi_diff"] == [
-        "changed ABI entry: f(): stateMutability 'view' -> 'nonpayable'"
-    ]
+    assert result["abi_diff"] == ["changed ABI entry: f(): stateMutability 'view' -> 'nonpayable'"]
     assert "method_id_diff" not in result
-    assert result["storage_layout_diff"] == [
-        "changed storage: x slot 0 uint256 -> 1 uint256"
-    ]
+    assert result["storage_layout_diff"] == ["changed storage: x slot 0 uint256 -> 1 uint256"]
 
 
 def test_smoke_tries_lowest_broad_pragma_compiler_before_syntax_hint(
@@ -1295,9 +1278,7 @@ def test_smoke_preserves_source_provenance_when_target_validation_raises(
     monkeypatch.setattr(
         corpus.engine,
         "apply_rules",
-        lambda source, config, path: SimpleNamespace(
-            source=source, fixes=[], diagnostics=[]
-        ),
+        lambda source, config, path: SimpleNamespace(source=source, fixes=[], diagnostics=[]),
     )
 
     def fail_target_validation(batch, config):
@@ -1344,9 +1325,7 @@ def test_smoke_uses_valid_manifest_compiler_when_pragma_is_unusable(
     monkeypatch.setattr(
         corpus.engine,
         "apply_rules",
-        lambda source, config, path: SimpleNamespace(
-            source=source, fixes=[], diagnostics=[]
-        ),
+        lambda source, config, path: SimpleNamespace(source=source, fixes=[], diagnostics=[]),
     )
     monkeypatch.setattr(
         corpus.engine,
@@ -1385,15 +1364,11 @@ def test_smoke_fails_closed_without_usable_source_version(
     def unexpected_source_compile(path, config, source_version):
         pytest.fail(f"unexpected source compiler: {source_version}")
 
-    monkeypatch.setattr(
-        corpus.engine, "compile_source_file", unexpected_source_compile
-    )
+    monkeypatch.setattr(corpus.engine, "compile_source_file", unexpected_source_compile)
     monkeypatch.setattr(
         corpus.engine,
         "apply_rules",
-        lambda source, config, path: SimpleNamespace(
-            source=source, fixes=[], diagnostics=[]
-        ),
+        lambda source, config, path: SimpleNamespace(source=source, fixes=[], diagnostics=[]),
     )
     monkeypatch.setattr(
         corpus.engine,
@@ -1409,14 +1384,10 @@ def test_smoke_fails_closed_without_usable_source_version(
     assert result["source_compiler"] is None
     assert result["source_compile"] == "skipped"
     assert result["validation_status"] == "blocked"
-    assert {issue["code"] for issue in result["validation_blockers"]} >= {
-        "source_compile_failed"
-    }
+    assert {issue["code"] for issue in result["validation_blockers"]} >= {"source_compile_failed"}
 
 
-def test_smoke_retries_broad_pragma_with_newer_source_compiler(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_smoke_retries_broad_pragma_with_newer_source_compiler(monkeypatch, tmp_path: Path) -> None:
     corpus = _load_corpus_module()
     contract = tmp_path / "contracts" / "chainsecurity_flat" / "0xabc.vy"
     contract.parent.mkdir(parents=True)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -9,6 +9,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from vyupgrade.compiler import CompileResult
+
 
 def _load_corpus_module():
     script = Path(__file__).parents[1] / "scripts" / "corpus.py"
@@ -1016,14 +1018,14 @@ def test_smoke_uses_manifest_pragma_as_source_version(monkeypatch, tmp_path: Pat
         return SimpleNamespace(source=source, fixes=[], diagnostics=[])
 
     def fake_compile_source_file(path, config, source_version):
-        return SimpleNamespace(status="passed", artifacts={}, stderr=None)
+        return CompileResult(status="passed", artifacts={}, stderr=None)
 
     monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
     monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1055,14 +1057,14 @@ def test_smoke_records_artifact_diff_details_for_mismatches(monkeypatch, tmp_pat
     monkeypatch.setattr(
         corpus.engine,
         "compile_source_file",
-        lambda path, config, source_version: SimpleNamespace(
+        lambda path, config, source_version: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1122,15 +1124,15 @@ def test_smoke_tries_lowest_broad_pragma_compiler_before_syntax_hint(
     def fake_compile_source_file(path, config, source_version):
         seen["compile_versions"].append(source_version)
         if source_version == "0.3.0":
-            return SimpleNamespace(status="failed", artifacts=None, stderr="syntax unavailable")
-        return SimpleNamespace(status="passed", artifacts={}, stderr=None)
+            return CompileResult(status="failed", artifacts=None, stderr="syntax unavailable")
+        return CompileResult(status="passed", artifacts={}, stderr=None)
 
     monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
     monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1197,7 +1199,7 @@ def multiplyHoldings() -> bool:
     def fake_compile_source_file(path, config, source_version):
         seen["compile_versions"].append(source_version)
         status = "passed" if source_version == "0.3.3" else "failed"
-        return SimpleNamespace(status=status, artifacts={}, stderr=None)
+        return CompileResult(status=status, artifacts={}, stderr=None)
 
     def fake_apply_rules(source, config, path):
         seen["rewrite_version"] = config.source_version
@@ -1208,7 +1210,7 @@ def multiplyHoldings() -> bool:
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1243,7 +1245,7 @@ def test_smoke_reports_winning_source_compiler_instead_of_manifest_hint(
     def fake_compile_source_file(path, config, source_version):
         seen["compile_versions"].append(source_version)
         status = "passed" if source_version == "0.3.4" else "failed"
-        return SimpleNamespace(status=status, artifacts={}, stderr=None)
+        return CompileResult(status=status, artifacts={}, stderr=None)
 
     def fake_apply_rules(source, config, path):
         seen["rewrite_version"] = config.source_version
@@ -1254,7 +1256,7 @@ def test_smoke_reports_winning_source_compiler_instead_of_manifest_hint(
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1286,7 +1288,7 @@ def test_smoke_preserves_source_provenance_when_target_validation_raises(
     monkeypatch.setattr(
         corpus.engine,
         "compile_source_file",
-        lambda path, config, source_version: SimpleNamespace(
+        lambda path, config, source_version: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1336,7 +1338,7 @@ def test_smoke_uses_valid_manifest_compiler_when_pragma_is_unusable(
 
     def fake_compile_source_file(path, config, source_version):
         compiled.append(source_version)
-        return SimpleNamespace(status="passed", artifacts={}, stderr=None)
+        return CompileResult(status="passed", artifacts={}, stderr=None)
 
     monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
@@ -1349,7 +1351,7 @@ def test_smoke_uses_valid_manifest_compiler_when_pragma_is_unusable(
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1396,7 +1398,7 @@ def test_smoke_fails_closed_without_usable_source_version(
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1430,8 +1432,8 @@ def test_smoke_retries_broad_pragma_with_newer_source_compiler(
     def fake_compile_source_file(path, config, source_version):
         seen["compile_versions"].append(source_version)
         if source_version == "0.3.0":
-            return SimpleNamespace(status="failed", artifacts=None, stderr="old compiler failed")
-        return SimpleNamespace(status="passed", artifacts={}, stderr=None)
+            return CompileResult(status="failed", artifacts=None, stderr="old compiler failed")
+        return CompileResult(status="passed", artifacts={}, stderr=None)
 
     def fake_apply_rules(source, config, path):
         seen["rewrite_version"] = config.source_version
@@ -1442,7 +1444,7 @@ def test_smoke_retries_broad_pragma_with_newer_source_compiler(
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1475,14 +1477,14 @@ def test_smoke_uses_standard_json_compiler_version_for_source(monkeypatch, tmp_p
 
     def fake_compile_source_file(path, config, source_version):
         seen["compile_version"] = source_version
-        return SimpleNamespace(status="passed", artifacts={}, stderr=None)
+        return CompileResult(status="passed", artifacts={}, stderr=None)
 
     monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
     monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )
@@ -1528,14 +1530,14 @@ def test_smoke_uses_standard_json_search_paths(monkeypatch, tmp_path: Path) -> N
 
     def fake_compile_source_file(path, config, source_version):
         seen["source_paths"] = config.compiler_search_paths
-        return SimpleNamespace(status="passed", artifacts={}, stderr=None)
+        return CompileResult(status="passed", artifacts={}, stderr=None)
 
     monkeypatch.setattr(corpus.engine, "apply_rules", fake_apply_rules)
     monkeypatch.setattr(corpus.engine, "compile_source_file", fake_compile_source_file)
     monkeypatch.setattr(
         corpus.engine,
         "compile_target_source",
-        lambda path, source, config, overlay: SimpleNamespace(
+        lambda path, source, config, overlay: CompileResult(
             status="passed", artifacts={}, stderr=None
         ),
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -47,21 +47,14 @@ def test_bounded_request_preserves_cli_compiler_selection(tmp_path: Path) -> Non
         path, source, _config(tmp_path, source_vyper="/tmp/vyper")
     )
 
-    assert inferred.source_attempts == (
-        SourceCompileAttempt("0.4.3", ">0.3.10", "0.4.3"),
-    )
-    assert explicit.source_attempts == (
-        SourceCompileAttempt(">0.3.10", ">0.3.10"),
-    )
+    assert inferred.source_attempts == (SourceCompileAttempt("0.4.3", ">0.3.10", "0.4.3"),)
+    assert explicit.source_attempts == (SourceCompileAttempt(">0.3.10", ">0.3.10"),)
 
 
-def test_prepare_uses_first_passing_retry_and_its_rule_version(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_prepare_uses_first_passing_retry_and_its_rule_version(monkeypatch, tmp_path: Path) -> None:
     path = tmp_path / "Contract.vy"
     attempts = tuple(
-        SourceCompileAttempt(version, version)
-        for version in ("0.3.0", "0.3.1", "0.3.2")
+        SourceCompileAttempt(version, version) for version in ("0.3.0", "0.3.1", "0.3.2")
     )
     seen: dict[str, object] = {"compile": []}
 
@@ -78,22 +71,17 @@ def test_prepare_uses_first_passing_retry_and_its_rule_version(
     monkeypatch.setattr(engine, "compile_source_file", compile_source)
     monkeypatch.setattr(engine, "apply_rules", apply)
 
-    batch = engine.prepare_migrations(
-        (_request(path, "0.3.0", attempts),), _config(tmp_path)
-    )
+    batch = engine.prepare_migrations((_request(path, "0.3.0", attempts),), _config(tmp_path))
 
     assert seen == {"compile": ["0.3.0", "0.3.1"], "rule_version": "0.3.1"}
     assert batch.files[0].source_version == "0.3.1"
     assert batch.files[0].source_compile.status == "passed"
 
 
-def test_prepare_retains_first_failure_when_all_retries_fail(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_prepare_retains_first_failure_when_all_retries_fail(monkeypatch, tmp_path: Path) -> None:
     path = tmp_path / "Contract.vy"
     attempts = tuple(
-        SourceCompileAttempt(version, version)
-        for version in ("0.3.0", "0.3.1", "0.3.2")
+        SourceCompileAttempt(version, version) for version in ("0.3.0", "0.3.1", "0.3.2")
     )
     seen: dict[str, object] = {"compile": []}
 
@@ -108,9 +96,7 @@ def test_prepare_retains_first_failure_when_all_retries_fail(
     monkeypatch.setattr(engine, "compile_source_file", compile_source)
     monkeypatch.setattr(engine, "apply_rules", apply)
 
-    batch = engine.prepare_migrations(
-        (_request(path, "0.3.0", attempts),), _config(tmp_path)
-    )
+    batch = engine.prepare_migrations((_request(path, "0.3.0", attempts),), _config(tmp_path))
 
     assert seen == {
         "compile": ["0.3.0", "0.3.1", "0.3.2"],
@@ -204,9 +190,7 @@ def test_candidate_override_and_revalidation_reset_only_engine_diagnostics(
     monkeypatch.setattr(
         engine,
         "apply_rules",
-        lambda source, config, path: RewriteResult(
-            source + "# rewritten\n", [], [rule_diagnostic]
-        ),
+        lambda source, config, path: RewriteResult(source + "# rewritten\n", [], [rule_diagnostic]),
     )
 
     def compile_target(path, source, config, overlay):
@@ -271,9 +255,7 @@ def test_generated_interface_and_cross_file_sources_share_one_overlay(
         return RewriteResult(source, [], [], generated)
 
     @contextmanager
-    def overlay(
-        sources, target_version, search_paths, *, include_dependencies=False
-    ):
+    def overlay(sources, target_version, search_paths, *, include_dependencies=False):
         assert include_dependencies is False
         overlay_sources.update(sources)
         yield overlay_token
@@ -296,9 +278,7 @@ def test_generated_interface_and_cross_file_sources_share_one_overlay(
     assert decision.status == "passed"
 
 
-def test_validation_rejects_duplicate_resolved_destinations(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_validation_rejects_duplicate_resolved_destinations(monkeypatch, tmp_path: Path) -> None:
     first = tmp_path / "First.vy"
     second = tmp_path / "Second.vy"
     interface = tmp_path / "Shared.vyi"
@@ -319,17 +299,13 @@ def test_validation_rejects_duplicate_resolved_destinations(
         return RewriteResult(source, [], [], [generated])
 
     monkeypatch.setattr(engine, "apply_rules", apply)
-    batch = engine.prepare_migrations(
-        (_request(first), _request(second)), _config(tmp_path)
-    )
+    batch = engine.prepare_migrations((_request(first), _request(second)), _config(tmp_path))
 
     with pytest.raises(engine.CandidatePathConflictError, match=r"Shared\.vyi"):
         engine.validate_migrations(batch, _config(tmp_path))
 
 
-def test_malformed_target_artifacts_remain_unwaivable(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_malformed_target_artifacts_remain_unwaivable(monkeypatch, tmp_path: Path) -> None:
     path = tmp_path / "Contract.vy"
     monkeypatch.setattr(
         engine,
@@ -403,9 +379,7 @@ def test_interface_validation_is_target_only(
         "0.3.10",
         (SourceCompileAttempt("0.3.10", "0.3.10"),),
     )
-    monkeypatch.setattr(
-        engine, "compile_source_file", lambda *_args: CompileResult("skipped")
-    )
+    monkeypatch.setattr(engine, "compile_source_file", lambda *_args: CompileResult("skipped"))
     monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
     monkeypatch.setattr(engine, "compile_target_source", lambda *_args: target)
     config = _config(tmp_path)
@@ -445,17 +419,13 @@ def test_prepare_migrations_skips_interface_split_for_dependencies(
 
     monkeypatch.setattr(engine, "split_interfaces_to_vyi", unexpected_split)
 
-    batch = engine.prepare_migrations(
-        (request,), _config(tmp_path, split_interfaces=True)
-    )
+    batch = engine.prepare_migrations((request,), _config(tmp_path, split_interfaces=True))
 
     assert batch.files[0].report.role == "dependency"
     assert batch.generated == []
 
 
-def test_validate_migrations_threads_closure_mode(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_validate_migrations_threads_closure_mode(monkeypatch, tmp_path: Path) -> None:
     project_root = tmp_path / "project"
     project = project_root / "main.vy"
     search_path = tmp_path / "site-packages"
@@ -501,8 +471,8 @@ def test_validate_migrations_threads_closure_mode(
 
     def compile_target(path, source, config, overlay):
         assert overlay is not None
-        observed_search_paths[config.include_dependencies] = (
-            compiler._overlay_search_paths(overlay, config.compiler_search_paths)
+        observed_search_paths[config.include_dependencies] = compiler._overlay_search_paths(
+            overlay, config.compiler_search_paths
         )
         if path == dependency:
             target = overlay.paths[dependency.resolve()]
@@ -536,9 +506,7 @@ def test_validate_migrations_threads_closure_mode(
         compiler_search_paths=(search_path,),
     )
 
-    closure_batch = engine.prepare_migrations(
-        (project_request, dependency_request), closure_config
-    )
+    closure_batch = engine.prepare_migrations((project_request, dependency_request), closure_config)
     default_batch = engine.prepare_migrations((project_request,), default_config)
     engine.validate_migrations(closure_batch, closure_config)
     engine.validate_migrations(default_batch, default_config)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -55,7 +55,7 @@ def test_json_report_declares_additive_schema_version() -> None:
 
     data = report.to_json_obj()
 
-    assert data["schema_version"] == 2
+    assert data["schema_version"] == 3
     assert data["files"] == []
     assert data["target_version"] == "0.4.3"
     assert data["closure"] is None

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -50,12 +50,12 @@ def test_render_text_includes_compile_errors() -> None:
     assert 'Version specification "0.2.11" is not compatible' in text
 
 
-def test_json_report_declares_additive_schema_version() -> None:
+def test_json_report_declares_attestation_schema_version() -> None:
     report = RunReport(source_version=None, target_version="0.4.3", files=[])
 
     data = report.to_json_obj()
 
-    assert data["schema_version"] == 3
+    assert data["schema_version"] == 4
     assert data["files"] == []
     assert data["target_version"] == "0.4.3"
     assert data["closure"] is None
@@ -179,7 +179,11 @@ def test_write_human_report_uses_plain_text_for_non_tty_streams() -> None:
     report = RunReport(
         source_version=None,
         target_version="0.4.3",
-        files=[FileReport(path=Path("ok.vy"), changed=True, source_compile="passed", target_compile="passed")],
+        files=[
+            FileReport(
+                path=Path("ok.vy"), changed=True, source_compile="passed", target_compile="passed"
+            )
+        ],
     )
     stream = StringIO()
 
@@ -333,9 +337,7 @@ def test_render_rich_splits_diagnostic_line_styles() -> None:
     render_rich(report, console)
 
     assert (
-        "  \x1b[1;32mVY001\x1b[0m"
-        "\x1b[32m modernized version pragma\x1b[0m"
-        "\x1b[2m (line 2)\x1b[0m"
+        "  \x1b[1;32mVY001\x1b[0m\x1b[32m modernized version pragma\x1b[0m\x1b[2m (line 2)\x1b[0m"
     ) in stream.getvalue()
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -264,7 +264,5 @@ def f() -> uint256:
 
     assert result.source == source
     assert result.fixes == []
-    assert [(diag.rule, diag.severity) for diag in result.diagnostics] == [
-        ("VYD018", "error")
-    ]
+    assert [(diag.rule, diag.severity) for diag in result.diagnostics] == [("VYD018", "error")]
     assert "matches no Vyper compiler" in result.diagnostics[0].message

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -7,7 +7,6 @@ from vyupgrade.versions import (
     LEGACY_PRERELEASE_VERSIONS,
     MigrationContext,
     VyperVersion,
-    compiler_version_for_source,
     compiler_version_for_source_validation,
     compiler_version_for_spec,
     default_evm_version_for_spec,
@@ -72,25 +71,6 @@ VERSION: constant(String[32]) = "# pragma version 0.4.2"
 
     assert infer_pragma(source) == "0.3.10"
     assert infer_pragma('''"""\n# @version 0.4.3\n"""\n''') is None
-
-
-def test_source_syntax_hints_raise_broad_pragma_compiler_floor() -> None:
-    assert compiler_version_for_source("^0.3.0", "xs: DynArray[String[32], 100]") == "0.3.3"
-    assert compiler_version_for_source("^0.3.3", "xs: DynArray[address, 50_000]") == "0.3.3"
-    assert compiler_version_for_source("^0.3.0", "xs: DynArray[Reward, MAX_REWARDS]") == "0.3.7"
-    assert compiler_version_for_source("^0.3.0", "TOKEN: immutable(address)") == "0.3.1"
-    assert compiler_version_for_source(">=0.3.2", "enum Side:\n    BUY\n") == "0.3.4"
-    assert compiler_version_for_source("^0.3.0", "decimals: public(uint8)") == "0.3.1"
-    assert compiler_version_for_source("^0.3.0", "value: public(uint16)") == "0.3.2"
-    assert compiler_version_for_source("^0.3.0", "send(self.owner, fee, gas=msg.gas)") == "0.3.8"
-    assert compiler_version_for_source(">=0.3.8,<0.4.0", "TOKEN: immutable(address)") == "0.3.8"
-    assert compiler_version_for_source(">=0.3.0,<0.3.4", "enum Side:\n    BUY\n") == "0.3.0"
-    assert (
-        compiler_version_for_source(
-            ">=0.5.0a1,<0.6.0", "error Unauthorized:\n    caller: address\n"
-        )
-        == "0.5.0a3"
-    )
 
 
 def test_source_validation_compiler_uses_newest_target_bounded_version() -> None:


### PR DESCRIPTION
_co-authored by gpt 5.6 sol_

## Summary

Make source-validation attribution explicit and typed. Source compiles use the full selected uv project/workspace environment, report the compiler and dependency artifacts actually loaded, and classify failures without inferring dependencies or rejection from compiler text.

## Why

The previous validation path translated selected dependency declarations into `--with` arguments and retried failures using import names or compiler stderr. A nonzero process result alone could then be labeled as compiler rejection, even for an incoherent project/compiler declaration, an adapter failure, or a crashed process.

The immediate consumer is alan-app's source-translation classifier: it needs producer-owned evidence that distinguishes a declared-context compiler rejection from environment, launch, timeout, adapter, fixed-target, and internal failures.

## Design

- Use the selected uv project with all groups and extras. Discover an owning uv workspace from its declared member/exclusion model, attest the root manifest, lock, and local/workspace sources, and keep the member as `uv --project`.
- Enforce an existing owning-workspace lock with `--frozen`, or resolve from a temporary project/workspace mirror so the source tree is not mutated.
- Give only an active PEP 508 Vyper requirement in uv's selected dependency model project authority. Evaluate environment markers, and do not treat Poetry-only tables as uv dependencies.
- When the project does not provide Vyper, layer the inferred compiler onto a Python request compatible with the project's `requires-python`; otherwise let uv select the project interpreter.
- Require a declared project compiler to satisfy the source pragma before compilation. The parent passes the deterministic accepted-version set to a stdlib-only project-environment runner, so adapter evidence does not depend on the project installing `packaging`.
- Treat only a managed Vyper exception as compiler rejection. Signals and internal exceptions are compiler-internal; launch, timeout, environment, and adapter failures remain distinct.
- Emit report schema v4 with producer identity and separate source and target attestations: declared source snapshot and compiler declarations, authority rule, resolved compiler executable/artifact identity, manifest/lock/resolved package and source context, process completion and exit status, validated sources, exact compile attempt, typed failure origin, and compiler output on failure.
- Give target failures typed origins for fixed-target rewrites and dependencies.
- Remove source-validation import matching, package-name mappings, syntax-floor inference, and output-format or transformed-source retries. Target compatibility retries remain limited to target compilation.

## Safety invariants

- `failure_origin = "compiler"` requires a genuine managed Vyper rejection, not merely a nonzero return code.
- A project pin that conflicts with a source pragma is an environment-resolution failure before the compiler starts.
- Compiler and dependency authority comes from active declarations and the selected uv project/workspace model, never package-name, path-proximity, Poetry-table, or diagnostic-text inference.
- `compiler_output` is populated only from compiler process stdout/stderr; environment-manager and adapter prose is excluded.
- Project resolution does not write a new lockfile into an unlocked source tree.
- Target compilation uses the requested target compiler while retaining the declared dependency environment.
- Every reported source attempt identifies the exact source bytes, exit status, and origin; source validation does not retry.

## Failure prevented

- A locked `packages/app` workspace member no longer loses the root `uv.lock` or root `{ workspace = true }` source mapping.
- A project requiring Python 3.13+ no longer fails before launch because an inferred compiler forced Python 3.11.
- Inactive marker-gated and Poetry-only Vyper declarations no longer displace the inferred compiler.
- Project environments without `packaging` no longer crash the adapter before it writes structured evidence.

## Verification

- `uv run pytest tests/test_compiler.py tests/test_cli_integration.py` — 256 passed.
- The focused regressions exercise a real locked uv workspace member/source mapping, a Python 3.13+ project interpreter, inactive-marker and Poetry-only declarations, and a runner process started with `python -S`.
- Touched-file Ruff lint and format checks passed.

## Diff breakdown

Whole-PR comparison: `master@942b1fb4` → `b066dc8b`.

| Category | Files | Added | Removed |
|---|---:|---:|---:|
| Production code | 13 | 1,751 | 651 |
| Tests | 10 | 1,342 | 933 |
| Config / CI / workflows | 0 | 0 | 0 |
| Docs / prompts | 2 | 38 | 19 |
| Generated / lockfiles | 0 | 0 | 0 |
| **Total** | **25** | **3,131** | **1,603** |

## Concept delta

Whole-PR conceptual comparison: `master@942b1fb4` → `b066dc8b`.

| Concept class | Added | Removed | Net |
|---|---:|---:|---:|
| Files/modules | +1 | -0 | +1 |
| Production capability abstractions | +9 | -4 | +5 |
| Decision authorities | +4 | -4 | 0 |
| Retry/inference branches | +0 | -5 | -5 |

Added file/module:
- `compiler_runner.py` — isolates compiler execution inside the selected environment and writes typed process evidence before the parent classifies the result.

Added production capability abstractions:
- **Validation attestation model** — binds declaration, compiler, dependency, source-set, attempt, exit, origin, and compiler-only output into one report contract.
- **Dependency-context model** — carries manifest, lock, Python constraint, declared source, and resolved package identities.
- **Resolved compiler/package content identities** — prove which executable, distribution artifact, and dependency artifacts actually ran.
- **Declared project-environment resolver** — runs the full selected uv dependency model rather than reconstructing import-matched `--with` arguments.
- **uv workspace ownership selector** — binds a member to its declared owning root before lock/mirror choice.
- **Compiler adapter boundary** — separates managed compiler exceptions from launch, timeout, signal, environment, adapter, and internal failures.
- **Import-closure resolver** — gives dependency compilation a concrete source closure instead of stderr-driven package guesses.
- **Target overlay materializer** — validates rewritten roots and dependencies in one deterministic staged tree.
- **Closure output/archive writer** — emits only the validated closure while preserving source-tree immutability.

Removed production capability abstractions:
- **Import-matched dependency injector** — removed because partial dependency reconstruction was not the declared environment.
- **Missing-module package retry** — removed because compiler text cannot authorize a dependency mutation.
- **Final-newline source retry** — removed because transformed-source retry weakens exact-source attribution.
- **Syntax-floor compiler selector** — removed because syntax inspection is heuristic version authority.

Authority changes:
- **+1 project compiler authority:** an active Vyper requirement in uv's selected model, concretized by the owning lock when present, is authoritative.
- **+1 deterministic pragma authority:** exact/ranged pragma selection uses the documented version rule only when the project has no active Vyper requirement.
- **+1 typed execution-origin authority:** the adapter's `failure_origin` replaces exception-text and generic-return-code attribution.
- **+1 content-identity authority:** manifest, lock, compiler, package, and source hashes bind evidence to the execution.
- **-1 Poetry-table authority:** Poetry-only declarations no longer override what uv actually resolves.
- **-1 import/package-name authority:** imports, built-in mappings, and normalized package guesses no longer select dependencies.
- **-1 diagnostic-text authority:** stderr classes and wording no longer decide blame or routing.
- **-1 syntax-shape authority:** source syntax no longer biases compiler selection.

Removed retry/inference branches:
- **ModuleNotFound dependency retry** — no guessed package is added after compiler output.
- **Final-newline retry** — source bytes are compiled once as submitted.
- **Source output-format retry** — source evidence is not reconstructed across compiler attempts.
- **Transformed-source retry** — a failed original source cannot be replaced to manufacture source-valid evidence.
- **Generic nonzero rejection inference** — nonzero results require a typed managed-compiler origin.

## Weight and smaller alternative

The added surface is weight-bearing because the report consumer must distinguish user-source rejection from toolchain failure using evidence produced at execution time. The smaller alternatives—nearest-lock search, dependency-name matching, importing `packaging` from the project, or parsing uv/compiler text—would reproduce individual examples but would restore heuristic attribution.

## Scope and rollout

Schema v4 supersedes v3 as a clean report-contract cutover. There are no compatibility aliases, heuristic fallbacks, dual-schema mode, app-side changes, or merge in this PR. The PR remains draft with the requested reviewer fixes pushed.
