### PR TITLE
chore: prepare 0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.1 - 2026-07-25
+
 - Made source validation use the nearest declared project environment and
   removed source-validation import guessing and retry behavior.
 - Replaced JSON report schema v3 with v4, which records producer identity and
@@ -10,6 +12,8 @@
   lock, resolved packages and sources, process completion and exit status,
   validated sources, exact compile attempt, typed failure origin, and compiler
   output on failure.
+- Preserved explicit `--source-vyper` selection and compiler arguments inside
+  declared project environments.
 
 ## 0.6.0 - 2026-07-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "vyupgrade"
-version = "0.6.0"
+version = "0.6.1"
 description = "Compiler-backed tool for upgrading Vyper contracts."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1006,7 +1006,7 @@ def decimals() -> uint8:
 
     report_data = json.loads(report.read_text(encoding="utf-8"))
     assert report_data["schema_version"] == 4
-    assert report_data["producer"] == {"name": "vyupgrade", "version": "0.6.0"}
+    assert report_data["producer"] == {"name": "vyupgrade", "version": "0.6.1"}
     validation = report_data["files"][0]["validation"]
     attestation = validation["source_attestation"]
     declarations = attestation["declared_spec"]["compiler_declarations"]

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "vyupgrade"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary

- promote the current Unreleased notes to `0.6.1` dated 2026-07-25
- bump package and lock metadata from `0.6.0` to `0.6.1`
- update the schema-v4 producer identity integration assertion for the release version

## Release contents

- source validation now uses the nearest declared project environment without import guessing or source retries
- report schema v4 records producer, compiler authority and identity, dependency context, exact attempts, and typed failure origins
- explicit `--source-vyper` selection and arguments remain authoritative inside declared project environments

## Validation

- `uv lock --check`
- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py`
- `uv run --locked pytest` — 863 passed
- `scripts/smoke-wheel.sh` — built, installed, and exercised `vyupgrade 0.6.1`
- `uv run --locked python scripts/release_notes.py v0.6.1`
- `uv run --locked python scripts/release_preflight.py v0.6.1 --dist dist`
