### PR TITLE
fix: accept Vyper build metadata in coherence checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fixed declared-project source validation for explicit Vyper executables that
+  report commit build metadata and for sources without version pragmas.
+
 ## 0.6.1 - 2026-07-25
 
 - Made source validation use the nearest declared project environment and

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -2043,11 +2043,9 @@ def _command_vyper_version(command: list[str]) -> str | None:
 
 
 def _compiler_coherence(source_spec: str | None) -> str:
-    versions = (
-        [str(version) for version in known_versions_satisfying(source_spec)]
-        if source_spec is not None
-        else []
-    )
+    if source_spec is None:
+        return ""
+    versions = [str(version) for version in known_versions_satisfying(source_spec)]
     return json.dumps(
         {"declaration": source_spec, "versions": versions},
         sort_keys=True,

--- a/src/vyupgrade/compiler_runner.py
+++ b/src/vyupgrade/compiler_runner.py
@@ -336,7 +336,10 @@ def _compiler_coherence_error(version: str, raw_evidence: str) -> str | None:
         or not all(isinstance(candidate, str) for candidate in versions)
     ):
         return "compiler coherence evidence is malformed"
-    if version in versions:
+    # Vyper release executables report versions such as
+    # ``0.4.1+commit.8a93dd27`` while pragmas name the public ``0.4.1`` release.
+    public_version = version.partition("+")[0]
+    if public_version in {candidate.partition("+")[0] for candidate in versions}:
         return None
     return f"resolved project compiler {version} conflicts with source declaration {declaration}"
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1214,6 +1214,58 @@ dependencies = ["vyper==0.4.3"]
         str(contract),
     ]
 
+
+@pytest.mark.parametrize(
+    ("source", "source_version", "resolved_version"),
+    [
+        ("# pragma version 0.4.1\n", "0.4.1", "0.4.1+commit.8a93dd27"),
+        ("value: public(uint256)\n", None, "0.4.1"),
+    ],
+    ids=["local-build-metadata", "missing-pragma"],
+)
+def test_real_explicit_project_compiler_accepts_coherent_source(
+    tmp_path: Path,
+    source: str,
+    source_version: str | None,
+    resolved_version: str,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        """[project]
+name = "explicit-source-coherence"
+version = "0.1.0"
+dependencies = ["vyper==0.4.1"]
+""",
+        encoding="utf-8",
+    )
+    contract = project / "contract.vy"
+    contract.write_text(source, encoding="utf-8")
+    executable = _write_test_compiler(
+        tmp_path,
+        """print("[]")
+print("{}")
+print("{}")
+print('{"ast_type": "Module", "body": []}')
+""",
+        version=resolved_version,
+    )
+
+    result = compile_source_file(
+        contract,
+        Config(
+            paths=(contract,),
+            target_version="0.4.3",
+            source_vyper=str(executable),
+        ),
+        source_version,
+    )
+
+    assert result.status == "passed"
+    assert result.resolved_compiler == resolved_version
+    assert result.compiler_authority == "explicit-executable"
+
+
 def test_real_compiler_overlay_uses_project_interpreter(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()
@@ -1873,14 +1925,19 @@ def _write_managed_vyper_environment(
     return site, bin_dir
 
 
-def _write_test_compiler(tmp_path: Path, compile_body: str) -> Path:
+def _write_test_compiler(
+    tmp_path: Path,
+    compile_body: str,
+    *,
+    version: str = "0.4.1",
+) -> Path:
     executable = tmp_path / "test-vyper"
     executable.write_text(
         f"""#!/usr/bin/env python3
 import sys
 
 if "--version" in sys.argv:
-    print("0.4.1")
+    print({version!r})
     raise SystemExit
 
 {compile_body}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -12,6 +12,7 @@ from vyupgrade.compiler import (
     TargetOverlay,
     _CompilerProcess,
     _declared_project_environment,
+    _compiler_coherence,
     _compiler_command,
     _overlay_search_paths,
     _run_compile,
@@ -29,6 +30,7 @@ from vyupgrade.compiler import (
     target_overlay,
     unavailable_validation_artifacts,
 )
+from vyupgrade.compiler_runner import _compiler_coherence_error
 from vyupgrade.models import Config, ContentIdentity, DependencyContext, FailureOrigin
 from vyupgrade.versions import KNOWN_VERSIONS, parse_version
 
@@ -69,6 +71,26 @@ def test_compiler_command_uses_packaged_uv_bin(monkeypatch) -> None:
     monkeypatch.setattr("vyupgrade.compiler.find_uv_bin", lambda: "/tmp/uv")
 
     assert _compiler_command(None, "0.3.7", None)[0] == "/tmp/uv"
+
+
+def test_compiler_coherence_skips_missing_source_declaration() -> None:
+    assert _compiler_coherence(None) == ""
+
+
+def test_compiler_coherence_accepts_local_build_metadata() -> None:
+    evidence = '{"declaration":"0.4.1","versions":["0.4.1"]}'
+
+    assert _compiler_coherence_error("0.4.1+commit.8a93dd27", evidence) is None
+
+
+def test_compiler_coherence_rejects_genuine_version_mismatch() -> None:
+    evidence = '{"declaration":"0.4.1","versions":["0.4.1"]}'
+
+    assert (
+        _compiler_coherence_error("0.4.2+commit.c4227f2", evidence)
+        == "resolved project compiler 0.4.2+commit.c4227f2 "
+        "conflicts with source declaration 0.4.1"
+    )
 
 
 def test_compiler_command_pins_python_for_uv(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- accept the public Vyper release when an explicit executable reports commit
  build metadata such as `0.4.1+commit.8a93dd27`
- skip source-pragma coherence when a declared-project source has no version
  pragma
- retain fail-closed rejection for genuine compiler/declaration mismatches

## Root cause

The schema-v4 compiler runner compared the executable's full version string
literally against known public releases, so a stock Vyper release with commit
metadata did not match its own `0.4.1` pragma. It also emitted malformed
coherence evidence when no source pragma existed.

## Impact

This restores the documented explicit `--source-vyper` path inside declared
project environments and lets pragma-less closure members use the declared
source compiler.

## Validation

- focused failing-then-passing coherence tests: 5 passed
- full suite: 868 passed
- Ruff: passed
- `scripts/smoke-wheel.sh`: passed
- pinned Twocrypto reproduction with stock Vyper
  `0.4.1+commit.8a93dd27`: all three consumer roots and the pragma-less
  dependency pass; only the independently tracked standalone-module behavior
  in #32 remains blocked
