### PR TITLE
chore: prepare 0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.2 - 2026-07-25
+
 - Fixed declared-project source validation for explicit Vyper executables that
   report commit build metadata and for sources without version pragmas.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "vyupgrade"
-version = "0.6.1"
+version = "0.6.2"
 description = "Compiler-backed tool for upgrading Vyper contracts."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1006,7 +1006,7 @@ def decimals() -> uint8:
 
     report_data = json.loads(report.read_text(encoding="utf-8"))
     assert report_data["schema_version"] == 4
-    assert report_data["producer"] == {"name": "vyupgrade", "version": "0.6.1"}
+    assert report_data["producer"] == {"name": "vyupgrade", "version": "0.6.2"}
     validation = report_data["files"][0]["validation"]
     attestation = validation["source_attestation"]
     declarations = attestation["declared_spec"]["compiler_declarations"]

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "vyupgrade"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary

- promote the compiler-coherence hotfix notes to 0.6.2 dated 2026-07-25
- bump package and lock metadata from 0.6.1 to 0.6.2
- update the schema-v4 producer-version assertion

## Validation

- `uv lock --check`
- Ruff
- full pytest: 868 passed
- `scripts/smoke-wheel.sh`
- `scripts/release_notes.py v0.6.2`
- `scripts/release_preflight.py v0.6.2 --dist dist`
