### PR TITLE
fix: validate dependency modules through consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Analyze upgraded dependency modules with compiler-annotated ASTs, validate
+  them through their consumer contracts instead of as standalone contracts,
+  and report that consumer-root evidence explicitly in JSON schema v5.
+
 ## 0.6.2 - 2026-07-25
 
 - Fixed declared-project source validation for explicit Vyper executables that

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ stderr; environment-manager or adapter diagnostics remain separate.
 - `--write` — apply changes in place only after the validation decision passes.
 - `--check` — exit non-zero if any file would change; write nothing.
 - `--aggressive` — enable rewrites that change behavior or are not provably safe (e.g. `enum` → `flag`).
-- `--include-dependencies` (alias `--upgrade-closure`) — also upgrade and cross-validate the resolved import closure, including dependencies found via `--compiler-search-paths`; dependency sources are never rewritten in place, so `--write` additionally requires a closure destination.
+- `--include-dependencies` (alias `--upgrade-closure`) — also upgrade and cross-validate the resolved import closure, including dependencies found via `--compiler-search-paths`; dependency modules are analyzed with compiler ASTs but validated through their consumer roots, and dependency sources are never rewritten in place, so `--write` additionally requires a closure destination.
 - `--closure-output DIR` — write the validated upgraded closure (project + dependencies, laid out import-root-relative so `vyper -p DIR` resolves every import) into DIR; requires `--include-dependencies`; overwrites files inside DIR, never deletes extras, never modifies dependency sources in place.
 - `--closure-archive OUT.vyz` — emit the validated upgraded closure (dependencies bundled) as a single Vyper archive via the target compiler; requires `--include-dependencies`, a target >= 0.4.0, and exactly one entry contract.
 - `--split-interfaces` — move top-level `interface` blocks into sibling `.vyi` files and import them.
@@ -133,16 +133,20 @@ stderr; environment-manager or adapter diagnostics remain separate.
 - `--allow-storage-layout-change` — write despite a storage-layout comparison mismatch.
 - `--config PATH` — read configuration from a specific `pyproject.toml`.
 
-JSON reports include a top-level `schema_version`. Version `4` provides producer
-identity plus separate source and target validation attestations. Each
+JSON reports include a top-level `schema_version`. Version `5` distinguishes
+direct contract validation from dependency validation attributed through one or
+more consumer roots. Dependency reports list those roots and summarize their
+compile outcomes without claiming standalone compiler attestations. Version `4`
+provides producer identity plus separate source and target validation
+attestations. Each
 attestation records the declared source snapshot and compiler declarations,
 compiler authority and identity, dependency context, process completion and
 exit status, validated sources, the exact compile attempt, typed failure origin,
 and compiler output when validation fails. Version `2` added a per-file `role`
 and a top-level `closure` object; version `3` first introduced source-validation
-evidence and is superseded by version `4`. Consumers should treat a missing
-version as the legacy unversioned format and require a new schema version before
-relying on renamed, removed, or type-changed fields.
+evidence and is superseded by versions `4` and `5`. Consumers should treat a
+missing version as the legacy unversioned format and require a new schema
+version before relying on renamed, removed, or type-changed fields.
 
 ### Configuration
 

--- a/src/vyupgrade/cli.py
+++ b/src/vyupgrade/cli.py
@@ -356,6 +356,7 @@ def _dependency_requests(
             path.read_text(encoding="utf-8"),
             dependency_config,
             role="dependency",
+            consumer_roots=closure.consumers.get(path, ()),
         )
         for path in closure.dependencies
         if path.suffix in {".vy", ".vyi"}

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -9,7 +9,7 @@ import subprocess
 import tempfile
 import sys
 import tomllib
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field as dataclass_field, replace
 from functools import cache
@@ -159,6 +159,7 @@ class TargetOverlay:
 class ImportClosure:
     roots: tuple[Path, ...]
     dependencies: tuple[Path, ...]
+    consumers: Mapping[Path, tuple[Path, ...]]
     source_roots: tuple[Path, ...]
     common_root: Path
 
@@ -496,9 +497,24 @@ def resolve_import_closure(
         )
         if not is_override
     ]
+    dependency_paths = set(dependencies)
+    consumers: dict[Path, list[Path]] = {path: [] for path in dependency_paths}
+    for root in sorted(resolved_sources):
+        for path, _source, _relative_path, is_override in _walk_validation_closure(
+            source_roots,
+            import_roots,
+            common_root,
+            resolved_sources,
+            entry_paths=(root,),
+        ):
+            if not is_override and path in dependency_paths:
+                consumers[path].append(root)
     return ImportClosure(
         roots=tuple(sorted(resolved_sources)),
         dependencies=tuple(sorted(dict.fromkeys(dependencies))),
+        consumers={
+            path: tuple(sorted(dict.fromkeys(paths))) for path, paths in sorted(consumers.items())
+        },
         source_roots=source_roots,
         common_root=common_root,
     )
@@ -748,28 +764,38 @@ def _walk_validation_closure(
     import_roots: tuple[Path, ...],
     common_root: Path,
     overrides: Mapping[Path, str],
+    *,
+    entry_paths: Iterable[Path] | None = None,
 ) -> Iterator[tuple[Path, str, Path, bool]]:
     override_paths = set(overrides)
-    incoming_overrides: set[Path] = set()
-    for path, source in overrides.items():
-        import_source = _standard_json_package_dependency_source(path, source, common_root)
-        for source_root in _containing_import_roots(path, source_roots):
-            relative_path = path.relative_to(source_root)
-            incoming_overrides.update(
-                imported.path
-                for imported in _validation_import_sources(
-                    path,
-                    import_source,
-                    source_root,
-                    import_roots,
-                    relative_path,
+    if entry_paths is None:
+        incoming_overrides: set[Path] = set()
+        for path, source in overrides.items():
+            import_source = _standard_json_package_dependency_source(path, source, common_root)
+            for source_root in _containing_import_roots(path, source_roots):
+                relative_path = path.relative_to(source_root)
+                incoming_overrides.update(
+                    imported.path
+                    for imported in _validation_import_sources(
+                        path,
+                        import_source,
+                        source_root,
+                        import_roots,
+                        relative_path,
+                    )
+                    if imported.path in override_paths
                 )
-                if imported.path in override_paths
-            )
+        initial_paths = override_paths - incoming_overrides
+        include_disconnected_overrides = True
+    else:
+        initial_paths = {path.resolve() for path in entry_paths}
+        if not initial_paths <= override_paths:
+            missing = ", ".join(str(path) for path in sorted(initial_paths - override_paths))
+            raise ValueError(f"closure entry paths are not source overrides: {missing}")
+        include_disconnected_overrides = False
 
-    entry_paths = override_paths - incoming_overrides
     queue: list[tuple[Path, str, Path, Path, bool]] = []
-    for path in sorted(entry_paths):
+    for path in sorted(initial_paths):
         source_root = _containing_import_roots(path, source_roots)[0]
         queue.append(
             (
@@ -782,7 +808,7 @@ def _walk_validation_closure(
         )
     layouts: dict[Path, Path] = {}
     processed: set[Path] = set()
-    while queue or override_paths - processed:
+    while queue or (include_disconnected_overrides and override_paths - processed):
         if not queue:
             path = min(override_paths - processed)
             source_root = _containing_import_roots(path, source_roots)[0]
@@ -1229,6 +1255,7 @@ def _copy_project_configs(
 
 
 def compile_source_ast(path: Path, config: Config, source_version: str | None) -> CompileResult:
+    """Load rewrite facts without requiring a module to be a deployable entry point."""
     if path.suffix != ".vy":
         return CompileResult("skipped")
     command, suppress_warnings = _prepare_command(
@@ -1236,16 +1263,23 @@ def compile_source_ast(path: Path, config: Config, source_version: str | None) -
         source_version or infer_pragma(path.read_text()),
         config.source_python,
     )
-    return _run_compile_with_formats(
-        command,
-        path,
-        config,
-        ("ast",),
-        (),
-        suppress_warnings,
-        allow_unsupported_formats=True,
-        project_compiler=True,
-    )
+    result: CompileResult | None = None
+    for output_format in ("annotated_ast", "ast"):
+        result = _run_compile_with_formats(
+            command,
+            path,
+            config,
+            (output_format,),
+            (),
+            suppress_warnings,
+            allow_unsupported_formats=True,
+            project_compiler=True,
+        )
+        artifact = (result.artifacts or {}).get(output_format)
+        if result.status == "passed" and isinstance(artifact, dict):
+            return replace(result, artifacts={"ast": artifact})
+    assert result is not None
+    return result
 
 
 def compare_artifacts(

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -9,6 +9,7 @@ from .compiler import (
     CompileResult,
     compare_artifact_details,
     compare_artifacts,
+    compile_source_ast,
     compile_source_file,
     compile_target_source,
     target_overlay,
@@ -66,6 +67,7 @@ class MigrationRequest:
     source_attempts: tuple[SourceCompileAttempt, ...]
     skip_target_on_blocked_source: bool = True
     role: str = "project"
+    consumer_roots: tuple[Path, ...] = ()
 
 
 @dataclass
@@ -110,7 +112,12 @@ class MigrationBatch:
 
 
 def bounded_migration_request(
-    path: Path, original: str, config: Config, *, role: str = "project"
+    path: Path,
+    original: str,
+    config: Config,
+    *,
+    role: str = "project",
+    consumer_roots: tuple[Path, ...] = (),
 ) -> MigrationRequest:
     """Build the target-bounded source compiler request used by the CLI."""
     source_version = config.source_version or infer_pragma(original)
@@ -124,7 +131,14 @@ def bounded_migration_request(
             source_version, config.target_version, original
         )
         attempts = (SourceCompileAttempt(compiler, source_version, compiler),)
-    return MigrationRequest(path, original, source_version, attempts, role=role)
+    return MigrationRequest(
+        path,
+        original,
+        source_version,
+        attempts,
+        role=role,
+        consumer_roots=consumer_roots,
+    )
 
 
 def prepare_migrations(requests: Iterable[MigrationRequest], config: Config) -> MigrationBatch:
@@ -140,6 +154,7 @@ def prepare_migrations(requests: Iterable[MigrationRequest], config: Config) -> 
     files: list[MigrationFile] = []
     for request in request_list:
         attempt, source_compile = _compile_source(request, config)
+        contextual_validation = request.role == "dependency"
         source_version = attempt.rule_version if attempt is not None else request.source_version
         source_compiler = source_compile.resolved_compiler or (
             attempt.compiler_label if attempt is not None else None
@@ -170,6 +185,8 @@ def prepare_migrations(requests: Iterable[MigrationRequest], config: Config) -> 
         report = FileReport(
             path=request.path,
             role=request.role,
+            validation_mode="consumer-roots" if contextual_validation else "direct",
+            consumer_roots=tuple(path.resolve() for path in request.consumer_roots),
             changed=request.original != rewrite.source,
             fixes=rewrite.fixes,
             # Validation diagnostics belong to the report, not the rule result.
@@ -177,10 +194,20 @@ def prepare_migrations(requests: Iterable[MigrationRequest], config: Config) -> 
             # as the corpus result's `diagnostics` field.
             diagnostics=list(rewrite.diagnostics),
             source_version=source_version,
-            source_compiler=source_compiler,
-            source_compile=source_compile.status,
-            source_unavailable_formats=list(getattr(source_compile, "unavailable_formats", ())),
-            source_error=(source_compile.stderr if source_compile.status == "failed" else None),
+            source_compiler=None if contextual_validation else source_compiler,
+            source_compile="skipped" if contextual_validation else source_compile.status,
+            source_unavailable_formats=(
+                []
+                if contextual_validation
+                else list(getattr(source_compile, "unavailable_formats", ()))
+            ),
+            source_error=(
+                None
+                if contextual_validation
+                else source_compile.stderr
+                if source_compile.status == "failed"
+                else None
+            ),
             source_attestation=_validation_attestation(
                 source_compile,
                 _declared_spec(snapshot_sources, source_compile.compiler_declarations),
@@ -189,10 +216,10 @@ def prepare_migrations(requests: Iterable[MigrationRequest], config: Config) -> 
                     hashlib.sha256(request.original.encode()).hexdigest(),
                 ),
             )
-            if source_compile.status != "skipped"
+            if not contextual_validation and source_compile.status != "skipped"
             else None,
         )
-        if source_compile.status != "skipped":
+        if not contextual_validation and source_compile.status != "skipped":
             report.source_unavailable_artifacts = unavailable_validation_artifacts(source_compile)
         files.append(
             MigrationFile(
@@ -245,6 +272,8 @@ def validate_migrations(
         for migration in batch.files:
             _reset_target_validation(migration.report, migration.validation_diagnostics)
             migration.target_compile = None
+            if migration.report.validation_mode == "consumer-roots":
+                continue
             source_context = MigrationContext.from_specs(
                 migration.request.source_version, config.target_version
             )
@@ -311,9 +340,10 @@ def _compile_source(
 
     first_attempt: SourceCompileAttempt | None = None
     first_result: CompileResult | None = None
+    compile_source = compile_source_ast if request.role == "dependency" else compile_source_file
     for attempt in request.source_attempts:
         attempt_config = replace(config, source_version=attempt.rule_version, source_ast=None)
-        result = compile_source_file(request.path, attempt_config, attempt.compile_version)
+        result = compile_source(request.path, attempt_config, attempt.compile_version)
         if first_result is None:
             first_attempt = attempt
             first_result = result

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -40,7 +40,9 @@ CompletionStatus = Literal[
 ]
 Severity = Literal["info", "warning", "error"]
 ValidationDecisionStatus = Literal["not-required", "passed", "waived", "blocked"]
+ValidationMode = Literal["direct", "consumer-roots"]
 ValidationIssueCode = Literal[
+    "consumer_roots_unavailable",
     "target_compile_failed",
     "target_artifacts_unavailable",
     "source_compile_failed",
@@ -50,7 +52,7 @@ ValidationIssueCode = Literal[
     "method_identifiers_changed",
     "storage_layout_changed",
 ]
-REPORT_SCHEMA_VERSION = 4
+REPORT_SCHEMA_VERSION = 5
 
 
 @dataclass(frozen=True)
@@ -280,6 +282,8 @@ class ValidationAttestation:
 class FileReport:
     path: Path
     role: str = "project"
+    validation_mode: ValidationMode = "direct"
+    consumer_roots: tuple[Path, ...] = ()
     changed: bool = False
     fixes: list[Fix] = field(default_factory=list)
     diagnostics: list[Diagnostic] = field(default_factory=list)
@@ -418,6 +422,8 @@ class RunReport:
                     "fixes": [fix.__dict__ for fix in file.fixes],
                     "diagnostics": [diag.__dict__ for diag in file.diagnostics],
                     "validation": {
+                        "mode": file.validation_mode,
+                        "consumer_roots": [str(path) for path in file.consumer_roots],
                         "source_version": file.source_version,
                         "source_compiler": file.source_compiler,
                         "source_compile": file.source_compile,

--- a/src/vyupgrade/reporting.py
+++ b/src/vyupgrade/reporting.py
@@ -126,6 +126,9 @@ def _render_text_file(file: FileReport) -> str:
         lines.append(f"  {_group_text(group)}")
     for group in _group_items(file.diagnostics, lambda diag: _severity_style(diag.severity)):
         lines.append(f"  {_group_text(group)}")
+    if file.validation_mode == "consumer-roots":
+        lines.append("  validation mode: consumer roots")
+        lines.append("  consumer roots: " + ", ".join(str(path) for path in file.consumer_roots))
     for label, status, error_label, error in _compile_outputs(file):
         lines.append(f"  {label}: {status}")
         if status == "failed" and error:
@@ -280,6 +283,14 @@ def _render_file(console: Console, file: FileReport) -> None:
         console.print(_group_rich_text(group))
     for group in _group_items(file.diagnostics, lambda diag: _severity_style(diag.severity)):
         console.print(_group_rich_text(group))
+    if file.validation_mode == "consumer-roots":
+        console.print(_indented("validation mode: consumer roots", "vy.muted"))
+        console.print(
+            _indented(
+                "consumer roots: " + ", ".join(str(path) for path in file.consumer_roots),
+                "vy.muted",
+            )
+        )
     for label, status, error_label, error in _compile_outputs(file):
         console.print(_compile_line(label, status))
         if status == "failed" and error:
@@ -328,10 +339,11 @@ def _render_file(console: Console, file: FileReport) -> None:
 
 
 def _compile_outputs(file: FileReport) -> tuple[tuple[str, str, str, str | None], ...]:
-    source_label = _compile_label("source compile", file.source_compiler)
+    scope = "consumer-root " if file.validation_mode == "consumer-roots" else ""
+    source_label = _compile_label(f"{scope}source compile", file.source_compiler)
     return (
         (source_label, file.source_compile, "source error", file.source_error),
-        ("target compile", file.target_compile, "target error", file.target_error),
+        (f"{scope}target compile", file.target_compile, "target error", file.target_error),
     )
 
 

--- a/src/vyupgrade/validation.py
+++ b/src/vyupgrade/validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from pathlib import Path
 
 from .models import (
     Config,
@@ -14,9 +15,19 @@ from .models import (
 def decide_run_validation(
     reports: Iterable[FileReport], config: Config
 ) -> ValidationDecision:
+    report_list = tuple(reports)
+    reports_by_path = {report.path.resolve(): report for report in report_list}
     decisions: list[ValidationDecision] = []
-    for report in reports:
+    for report in report_list:
+        if report.validation_mode != "direct":
+            continue
         decision = decide_file_validation(report, config)
+        report.validation_decision = decision
+        decisions.append(decision)
+    for report in report_list:
+        if report.validation_mode != "consumer-roots":
+            continue
+        decision = _decide_consumer_root_validation(report, reports_by_path)
         report.validation_decision = decision
         decisions.append(decision)
 
@@ -29,6 +40,67 @@ def decide_run_validation(
     if any(decision.status != "not-required" for decision in decisions):
         return ValidationDecision("passed", True)
     return ValidationDecision()
+
+
+def _decide_consumer_root_validation(
+    report: FileReport,
+    reports_by_path: dict[Path, FileReport],
+) -> ValidationDecision:
+    consumer_paths = tuple(path.resolve() for path in report.consumer_roots)
+    missing = tuple(path for path in consumer_paths if path not in reports_by_path)
+    if not consumer_paths or missing:
+        detail = (
+            "no consumer roots were resolved"
+            if not consumer_paths
+            else "consumer root reports are unavailable: " + ", ".join(str(path) for path in missing)
+        )
+        issue = ValidationIssue(
+            "consumer_roots_unavailable",
+            f"dependency validation cannot be attributed because {detail}",
+            report.path,
+        )
+        return ValidationDecision("blocked", False, (issue,))
+
+    consumers = tuple(reports_by_path[path] for path in consumer_paths)
+    report.source_compile = _aggregate_compile_status(
+        consumer.source_compile for consumer in consumers
+    )
+    report.target_compile = _aggregate_compile_status(
+        consumer.target_compile for consumer in consumers
+    )
+    compilers = {consumer.source_compiler for consumer in consumers}
+    report.source_compiler = compilers.pop() if len(compilers) == 1 else None
+    report.source_error = None
+    report.target_error = None
+    report.source_attestation = None
+    report.target_attestation = None
+    report.source_unavailable_artifacts.clear()
+    report.target_unavailable_artifacts.clear()
+    report.source_unavailable_formats.clear()
+    report.target_unavailable_formats.clear()
+    report.abi_equal = None
+    report.method_ids_equal = None
+    report.storage_layout_equal = None
+    report.abi_diff.clear()
+    report.method_id_diff.clear()
+    report.storage_layout_diff.clear()
+
+    decisions = tuple(consumer.validation_decision for consumer in consumers)
+    if any(decision.status == "blocked" for decision in decisions):
+        return ValidationDecision("blocked", False)
+    if any(decision.status == "waived" for decision in decisions):
+        return ValidationDecision("waived", True)
+    if any(decision.status == "passed" for decision in decisions):
+        return ValidationDecision("passed", True)
+    return ValidationDecision()
+
+
+def _aggregate_compile_status(statuses: Iterable[str]) -> str:
+    status_set = set(statuses)
+    for status in ("failed", "degraded", "passed"):
+        if status in status_set:
+            return status
+    return "skipped"
 
 
 def decide_file_validation(report: FileReport, config: Config) -> ValidationDecision:
@@ -130,6 +202,7 @@ def validation_exit_code(decision: ValidationDecision) -> int | None:
     if codes & {"target_compile_failed", "target_artifacts_unavailable"}:
         return 2
     if codes & {
+        "consumer_roots_unavailable",
         "source_compile_failed",
         "source_artifacts_unavailable",
         "artifact_comparison_unavailable",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1630,7 +1630,7 @@ def test_overlay_layout_conflict_exits_4(tmp_path: Path, passing_compiler, capsy
     assert str(second.resolve()) in stderr
 
 
-def test_report_json_schema_v4(tmp_path: Path, passing_compiler) -> None:
+def test_report_json_schema_v5(tmp_path: Path, passing_compiler) -> None:
     project, dependency, search_path, json_dependency = _write_dependency_cli_fixture(
         tmp_path, include_json=True
     )
@@ -1662,7 +1662,7 @@ def test_report_json_schema_v4(tmp_path: Path, passing_compiler) -> None:
     assert closure_code == 0
     project_data = json.loads(project_report.read_text())
     closure_data = json.loads(closure_report.read_text())
-    assert project_data["schema_version"] == 4
+    assert project_data["schema_version"] == 5
     assert project_data["producer"]["name"] == "vyupgrade"
     assert project_data["producer"]["version"]
     assert project_data["closure"] is None
@@ -1681,7 +1681,7 @@ def test_report_json_schema_v4(tmp_path: Path, passing_compiler) -> None:
         "failure_origin",
         "compiler_output",
     } == source_attestation.keys()
-    assert closure_data["schema_version"] == 4
+    assert closure_data["schema_version"] == 5
     assert closure_data["closure"] == {
         "requested": True,
         "dependencies": sorted([str(dependency.resolve()), str(json_dependency.resolve())]),

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -714,10 +714,16 @@ def test_real_compiler_include_dependencies_upgrades_closure(
     files = {Path(file["path"]): file for file in data["files"]}
     assert files[project.resolve()]["validation"]["target_compile"] == "passed"
     assert files[dependency.resolve()]["validation"]["target_compile"] == "passed"
+    assert files[dependency.resolve()]["validation"]["mode"] == "consumer-roots"
+    assert files[dependency.resolve()]["validation"]["consumer_roots"] == [
+        str(project.resolve())
+    ]
     assert files[dependency.resolve()]["role"] == "dependency"
 
 
-def test_real_fixed_target_dependency_rejection_has_typed_origin(tmp_path: Path) -> None:
+def test_real_fixed_target_dependency_rejection_is_attributed_to_consumer_root(
+    tmp_path: Path,
+) -> None:
     project_root = tmp_path / "project"
     project = project_root / "main.vy"
     search_path = tmp_path / "site-packages"
@@ -753,16 +759,104 @@ def test_real_fixed_target_dependency_rejection_has_typed_origin(tmp_path: Path)
 
     assert code != 0
     files = {Path(file["path"]): file for file in json.loads(report.read_text())["files"]}
+    project_report = files[project.resolve()]
     dependency_report = files[dependency.resolve()]
-    assert dependency_report["role"] == "dependency"
-    assert dependency_report["validation"]["source_compile"] == "passed"
-    assert dependency_report["validation"]["target_compile"] == "failed"
-    target_attestation = dependency_report["validation"]["target_attestation"]
+    assert project_report["validation"]["target_compile"] == "failed"
+    target_attestation = project_report["validation"]["target_attestation"]
     assert target_attestation["authority_rule"] == "fixed-target"
-    assert target_attestation["failure_origin"] == "fixed-target-dependency"
+    assert target_attestation["failure_origin"] == "fixed-target-rewrite"
     assert target_attestation["compiler_started"] is True
     assert target_attestation["exit_status"] == {"code": 1, "signal": None}
     assert target_attestation["compiler_output"]["stderr"]
+    assert dependency_report["role"] == "dependency"
+    assert dependency_report["validation"]["mode"] == "consumer-roots"
+    assert dependency_report["validation"]["consumer_roots"] == [str(project.resolve())]
+    assert dependency_report["validation"]["source_compile"] == "passed"
+    assert dependency_report["validation"]["target_compile"] == "failed"
+    assert dependency_report["validation"]["target_attestation"] is None
+    assert dependency_report["validation"]["decision"]["status"] == "blocked"
+
+
+def test_real_stateful_dependency_validates_through_consumer_root(tmp_path: Path) -> None:
+    root = tmp_path / "main.vy"
+    ownable = tmp_path / "ownable.vy"
+    token = tmp_path / "token.vy"
+    ownable.write_text(
+        """# pragma version 0.4.1
+
+owner: public(address)
+
+@deploy
+def __init__():
+    self.owner = msg.sender
+""",
+        encoding="utf-8",
+    )
+    token.write_text(
+        """# pragma version 0.4.1
+
+from . import ownable
+uses: ownable
+
+@external
+@view
+def get_owner() -> address:
+    return ownable.owner
+""",
+        encoding="utf-8",
+    )
+    root.write_text(
+        """# pragma version 0.4.1
+
+from . import ownable
+initializes: ownable
+
+from . import token
+initializes: token[ownable := ownable]
+exports: token.get_owner
+
+@deploy
+def __init__():
+    ownable.__init__()
+""",
+        encoding="utf-8",
+    )
+    output = tmp_path / "output"
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(root),
+            "--target-version",
+            "0.4.3",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(tmp_path),
+            "--closure-output",
+            str(output),
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 0
+    files = {Path(file["path"]): file for file in json.loads(report.read_text())["files"]}
+    root_report = files[root.resolve()]
+    token_report = files[token.resolve()]
+    assert root_report["validation"]["source_compile"] == "passed"
+    assert root_report["validation"]["target_compile"] == "passed"
+    assert root_report["validation"]["abi_equal"] is True
+    assert root_report["validation"]["method_ids_equal"] is True
+    assert root_report["validation"]["storage_layout_equal"] is True
+    assert token_report["role"] == "dependency"
+    assert token_report["validation"]["mode"] == "consumer-roots"
+    assert token_report["validation"]["consumer_roots"] == [str(root.resolve())]
+    assert token_report["validation"]["source_compile"] == "passed"
+    assert token_report["validation"]["target_compile"] == "passed"
+    assert token_report["validation"]["source_attestation"] is None
+    assert token_report["validation"]["target_attestation"] is None
+    assert token_report["validation"]["decision"]["status"] == "passed"
+    assert (output / "token.vy").is_file()
 
 
 def test_real_compiler_closure_output_tree_compiles_standalone(
@@ -1005,7 +1099,7 @@ def decimals() -> uint8:
     )
 
     report_data = json.loads(report.read_text(encoding="utf-8"))
-    assert report_data["schema_version"] == 4
+    assert report_data["schema_version"] == 5
     assert report_data["producer"] == {"name": "vyupgrade", "version": "0.6.2"}
     validation = report_data["files"][0]["validation"]
     attestation = validation["source_attestation"]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -625,7 +625,7 @@ def test_compile_preserves_typed_timeout_failure(monkeypatch) -> None:
     assert result.compiler_started is True
 
 
-def test_compile_source_ast_requests_ast_format(monkeypatch, tmp_path) -> None:
+def test_compile_source_ast_prefers_annotated_ast(monkeypatch, tmp_path) -> None:
     contract = tmp_path / "contract.vy"
     contract.write_text("# @version 0.4.3\n", encoding="utf-8")
     calls: dict[str, object] = {}
@@ -646,7 +646,10 @@ def test_compile_source_ast_requests_ast_format(monkeypatch, tmp_path) -> None:
         **_kwargs,
     ) -> CompileResult:
         calls["run"] = (command, path, formats, extra_paths, suppress_warnings)
-        return CompileResult("passed", artifacts={"ast": {"ast_type": "Module"}})
+        return CompileResult(
+            "passed",
+            artifacts={"annotated_ast": {"ast": {"ast_type": "Module"}}},
+        )
 
     monkeypatch.setattr("vyupgrade.compiler._compiler_command", fake_compiler_command)
     monkeypatch.setattr(
@@ -656,8 +659,40 @@ def test_compile_source_ast_requests_ast_format(monkeypatch, tmp_path) -> None:
     result = compile_source_ast(contract, Config(paths=(contract,)), None)
 
     assert result.status == "passed"
+    assert result.artifacts == {"ast": {"ast": {"ast_type": "Module"}}}
     assert calls["compiler"] == (None, "0.4.3", None)
-    assert calls["run"] == (["vyper"], contract, ("ast",), (), True)
+    assert calls["run"] == (["vyper"], contract, ("annotated_ast",), (), True)
+
+
+def test_compile_source_ast_falls_back_to_raw_ast(monkeypatch, tmp_path) -> None:
+    contract = tmp_path / "contract.vy"
+    contract.write_text("# @version 0.4.3\n", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run_compile_with_formats(
+        command: list[str],
+        path: Path,
+        config: Config,
+        formats: tuple[str, ...],
+        extra_paths: tuple[Path, ...],
+        suppress_warnings: bool,
+        **_kwargs,
+    ) -> CompileResult:
+        calls.append(formats)
+        if formats == ("annotated_ast",):
+            return CompileResult("failed", unavailable_formats=("annotated_ast",))
+        return CompileResult("passed", artifacts={"ast": {"ast_type": "Module"}})
+
+    monkeypatch.setattr("vyupgrade.compiler._prepare_command", lambda *args: (["vyper"], True))
+    monkeypatch.setattr(
+        "vyupgrade.compiler._run_compile_with_formats", fake_run_compile_with_formats
+    )
+
+    result = compile_source_ast(contract, Config(paths=(contract,)), None)
+
+    assert result.status == "passed"
+    assert result.artifacts == {"ast": {"ast_type": "Module"}}
+    assert calls == [("annotated_ast",), ("ast",)]
 
 
 def test_compile_source_file_requests_ast_with_validation_outputs(monkeypatch, tmp_path) -> None:
@@ -1064,6 +1099,36 @@ def test_resolve_import_closure_lists_transitive_dependencies(tmp_path) -> None:
     assert closure.files == (contract.resolve(), *expected_dependencies)
     assert closure.source_roots == (tmp_path / "project",)
     assert closure.common_root == tmp_path / "project"
+    assert closure.consumers == {
+        dependency: (contract.resolve(),) for dependency in expected_dependencies
+    }
+
+
+def test_resolve_import_closure_tracks_each_dependency_consumer(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    first = project / "first.vy"
+    second = project / "second.vy"
+    shared = project / "shared.vy"
+    first_only = project / "first_only.vy"
+    project.mkdir()
+    first_source = (
+        "#pragma version 0.4.3\nfrom . import shared\nfrom . import first_only\n"
+    )
+    second_source = "#pragma version 0.4.3\nfrom . import shared\n"
+    first.write_text(first_source, encoding="utf-8")
+    second.write_text(second_source, encoding="utf-8")
+    shared.write_text("#pragma version 0.4.3\n", encoding="utf-8")
+    first_only.write_text("#pragma version 0.4.3\n", encoding="utf-8")
+
+    closure = resolve_import_closure(
+        {first: first_source, second: second_source},
+        (project,),
+    )
+
+    assert closure.consumers == {
+        first_only.resolve(): (first.resolve(),),
+        shared.resolve(): (first.resolve(), second.resolve()),
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,6 +9,7 @@ from vyupgrade import compiler, engine
 from vyupgrade.compiler import CompileResult
 from vyupgrade.engine import MigrationRequest, SourceCompileAttempt
 from vyupgrade.models import Config, Diagnostic, Fix, GeneratedFile, RewriteResult
+from vyupgrade.validation import validation_exit_code
 
 
 VALIDATION_ARTIFACTS = {"abi": [], "method_identifiers": {}, "layout": {}}
@@ -278,6 +279,141 @@ def test_generated_interface_and_cross_file_sources_share_one_overlay(
     assert decision.status == "passed"
 
 
+def test_dependency_validation_uses_consumer_root_artifacts(
+    monkeypatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "Main.vy"
+    dependency = tmp_path / "Stateful.vy"
+    compiled: list[Path] = []
+
+    def compile_source(path, config, source_version):
+        if path == dependency:
+            return CompileResult("failed", stderr="module requires consumer initialization")
+        return CompileResult("passed", artifacts=SOURCE_ARTIFACTS)
+
+    @contextmanager
+    def overlay(_sources, _target_version, _search_paths, *, include_dependencies=False):
+        assert include_dependencies is True
+        yield object()
+
+    def compile_target(path, source, config, overlay):
+        compiled.append(path)
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    dependency_request = MigrationRequest(
+        dependency,
+        "#pragma version 0.3.10\n",
+        "0.3.10",
+        (SourceCompileAttempt("0.3.10", "0.3.10"),),
+        role="dependency",
+        consumer_roots=(root,),
+    )
+    monkeypatch.setattr(engine, "compile_source_file", compile_source)
+    monkeypatch.setattr(engine, "compile_source_ast", compile_source)
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+    monkeypatch.setattr(engine, "target_overlay", overlay)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target)
+    config = _config(tmp_path, include_dependencies=True)
+
+    batch = engine.prepare_migrations((_request(root), dependency_request), config)
+    decision = engine.validate_migrations(batch, config)
+    dependency_report = batch.files[1].report
+
+    assert compiled == [root]
+    assert decision.status == "passed"
+    assert dependency_report.validation_mode == "consumer-roots"
+    assert dependency_report.consumer_roots == (root.resolve(),)
+    assert dependency_report.source_compile == "passed"
+    assert dependency_report.target_compile == "passed"
+    assert dependency_report.source_attestation is None
+    assert dependency_report.target_attestation is None
+    assert dependency_report.validation_decision.status == "passed"
+
+
+def test_dependency_validation_aggregates_multiple_consumer_roots(
+    monkeypatch, tmp_path: Path
+) -> None:
+    first = tmp_path / "First.vy"
+    second = tmp_path / "Second.vy"
+    dependency = tmp_path / "Shared.vy"
+    compiled: list[Path] = []
+
+    def compile_source(path, config, source_version):
+        if path == dependency:
+            return CompileResult("failed", stderr="module requires a consumer")
+        return CompileResult("passed", artifacts=SOURCE_ARTIFACTS)
+
+    @contextmanager
+    def overlay(_sources, _target_version, _search_paths, *, include_dependencies=False):
+        assert include_dependencies is True
+        yield object()
+
+    def compile_target(path, source, config, overlay):
+        compiled.append(path)
+        if path == second:
+            return CompileResult("failed", stderr="second consumer failed")
+        return CompileResult("passed", artifacts=VALIDATION_ARTIFACTS)
+
+    dependency_request = MigrationRequest(
+        dependency,
+        "#pragma version 0.3.10\n",
+        "0.3.10",
+        (SourceCompileAttempt("0.3.10", "0.3.10"),),
+        role="dependency",
+        consumer_roots=(first, second),
+    )
+    monkeypatch.setattr(engine, "compile_source_file", compile_source)
+    monkeypatch.setattr(engine, "compile_source_ast", compile_source)
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+    monkeypatch.setattr(engine, "target_overlay", overlay)
+    monkeypatch.setattr(engine, "compile_target_source", compile_target)
+    config = _config(tmp_path, include_dependencies=True)
+
+    batch = engine.prepare_migrations(
+        (_request(first), _request(second), dependency_request),
+        config,
+    )
+    decision = engine.validate_migrations(batch, config)
+    dependency_report = batch.files[2].report
+
+    assert compiled == [first, second]
+    assert decision.status == "blocked"
+    assert [(issue.code, issue.path) for issue in decision.blockers] == [
+        ("target_compile_failed", second)
+    ]
+    assert dependency_report.source_compile == "passed"
+    assert dependency_report.target_compile == "failed"
+    assert dependency_report.validation_decision.status == "blocked"
+    assert dependency_report.validation_decision.blockers == ()
+
+
+def test_dependency_validation_fails_closed_without_consumer_roots(
+    monkeypatch, tmp_path: Path
+) -> None:
+    dependency = tmp_path / "Orphan.vy"
+    request = MigrationRequest(
+        dependency,
+        "#pragma version 0.3.10\n",
+        "0.3.10",
+        (SourceCompileAttempt("0.3.10", "0.3.10"),),
+        role="dependency",
+    )
+    monkeypatch.setattr(
+        engine,
+        "compile_source_ast",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+    config = _config(tmp_path, include_dependencies=True)
+
+    batch = engine.prepare_migrations((request,), config)
+    decision = engine.validate_migrations(batch, config)
+
+    assert decision.status == "blocked"
+    assert [issue.code for issue in decision.blockers] == ["consumer_roots_unavailable"]
+    assert validation_exit_code(decision) == 3
+
+
 def test_validation_rejects_duplicate_resolved_destinations(monkeypatch, tmp_path: Path) -> None:
     first = tmp_path / "First.vy"
     second = tmp_path / "Second.vy"
@@ -409,9 +545,14 @@ def test_prepare_migrations_skips_interface_split_for_dependencies(
     )
     monkeypatch.setattr(
         engine,
-        "compile_source_file",
+        "compile_source_ast",
         lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
     )
+
+    def unexpected_full_compile(*_args):
+        raise AssertionError("dependency analysis must not request deployable artifacts")
+
+    monkeypatch.setattr(engine, "compile_source_file", unexpected_full_compile)
     monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
 
     def unexpected_split(*_args):
@@ -447,6 +588,11 @@ def test_validate_migrations_threads_closure_mode(monkeypatch, tmp_path: Path) -
         "compile_source_file",
         lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
     )
+    monkeypatch.setattr(
+        engine,
+        "compile_source_ast",
+        lambda *_args: CompileResult("passed", artifacts={"ast": {}}),
+    )
 
     def apply(source, config, path):
         rewritten = rewritten_dependency if path == dependency else source
@@ -474,7 +620,7 @@ def test_validate_migrations_threads_closure_mode(monkeypatch, tmp_path: Path) -
         observed_search_paths[config.include_dependencies] = compiler._overlay_search_paths(
             overlay, config.compiler_search_paths
         )
-        if path == dependency:
+        if config.include_dependencies:
             target = overlay.paths[dependency.resolve()]
             assert target == overlay.root / "depkg" / "mod.vy"
             assert target.read_text() == rewritten_dependency
@@ -552,5 +698,7 @@ def test_dependency_source_final_newline_retry_handles_read_only_directory(
     batch = engine.prepare_migrations((request,), _config(tmp_path))
 
     assert batch.files[0].source_compile is original_failure
-    assert batch.files[0].report.source_compile == "failed"
+    assert batch.files[0].report.validation_mode == "consumer-roots"
+    assert batch.files[0].report.source_compile == "skipped"
+    assert batch.files[0].report.source_attestation is None
     assert set(dependency_directory.iterdir()) == original_entries

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -55,7 +55,7 @@ def test_json_report_declares_attestation_schema_version() -> None:
 
     data = report.to_json_obj()
 
-    assert data["schema_version"] == 4
+    assert data["schema_version"] == 5
     assert data["files"] == []
     assert data["target_version"] == "0.4.3"
     assert data["closure"] is None
@@ -365,3 +365,34 @@ def test_closure_summary_omits_impossible_write_hint() -> None:
 
     assert "run with --write" not in text
     assert "run with --write" not in stream.getvalue()
+
+
+def test_render_reports_consumer_root_validation_context() -> None:
+    root = Path("/project/main.vy")
+    file_report = FileReport(
+        path=Path("/project/modules/token.vy"),
+        role="dependency",
+        validation_mode="consumer-roots",
+        consumer_roots=(root,),
+        changed=True,
+        source_compile="passed",
+        target_compile="passed",
+    )
+    report = RunReport(source_version=None, target_version="0.4.3", files=[file_report])
+    stream = StringIO()
+    console = Console(file=stream, no_color=True, width=120)
+
+    text = render_text(report)
+    render_rich(report, console)
+    data = report.to_json_obj()["files"][0]["validation"]
+
+    assert "validation mode: consumer roots" in text
+    assert f"consumer roots: {root}" in text
+    assert "consumer-root source compile: passed" in text
+    assert "consumer-root target compile: passed" in text
+    assert "validation mode: consumer roots" in stream.getvalue()
+    assert f"consumer roots: {root}" in stream.getvalue()
+    assert "consumer-root source compile: passed" in stream.getvalue()
+    assert "consumer-root target compile: passed" in stream.getvalue()
+    assert data["mode"] == "consumer-roots"
+    assert data["consumer_roots"] == [str(root)]


### PR DESCRIPTION
## Summary

- analyze dependency modules with compiler `annotated_ast` output, falling back to raw AST for older compilers
- track the consumer roots for every dependency in the resolved import closure
- compile and compare artifacts only at project/consumer roots while retaining dependency-local rewrites and diagnostics
- expose direct vs consumer-root validation in human output and JSON report schema v5
- fail closed when dependency validation cannot be attributed to a consumer root

## Root cause

Closure validation treated every dependency module as a deployable entry contract. Stateful modules such as Snekmate's `erc20.vy` deliberately rely on initialization supplied by their consumer, so standalone source and target compilation failed even though every real consumer contract validated successfully.

## Validation

- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py`
- `uv run --locked pytest` (`875 passed`)
- focused unit and real-compiler coverage for stateful modules, multi-root attribution, missing-root fail-closed behavior, annotated-AST fallback, report schema, and emitted closure output
- exact `curvefi/twocrypto-ng` reproduction from issue #32 with source Vyper 0.4.1, target Vyper 0.5.0a3, 3 consumer roots, and 15 dependencies
  - all three roots passed source and target compilation
  - ABI, method identifiers, and storage layout remained unchanged
  - all dependency reports passed through their actual consumer roots
  - closure output was written and all three emitted entry contracts compiled independently with the target compiler
- freshly built wheel installed in an offline isolated environment and passed the same Twocrypto reproduction

Fixes #32
