### PR TITLE
feat: support stripping version pragmas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added opt-in `--strip-pragma` output that removes version pragmas from
+  migrated source without changing target compiler selection or validation.
 - Analyze upgraded dependency modules with compiler-annotated ASTs, validate
   them through their consumer contracts instead of as standalone contracts,
   and report that consumer-root evidence explicitly in JSON schema v5.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ stderr; environment-manager or adapter diagnostics remain separate.
 
 - `--target-version` — target Vyper version or spec (default `0.4.3`).
 - `--source-version` — override the per-file inferred source version.
+- `--strip-pragma` — remove version pragmas from migrated source instead of rewriting or adding one; target compiler selection and compiler-backed validation are unchanged.
 - `--diff` — print a unified diff instead of the report.
 - `--write` — apply changes in place only after the validation decision passes.
 - `--check` — exit non-zero if any file would change; write nothing.
@@ -158,6 +159,7 @@ flags take precedence.
 paths = ["contracts/"]
 target-version = "0.4.3"
 source-version = "infer"
+strip-pragma = false
 report-json = "vyupgrade-report.json"
 aggressive = false
 split-interfaces = false

--- a/src/vyupgrade/cli.py
+++ b/src/vyupgrade/cli.py
@@ -34,6 +34,7 @@ def main(argv: list[str] | None = None) -> int:
         paths=tuple(paths),
         target_version=args.target_version or pyproject.get("target-version", "0.4.3"),
         source_version=args.source_version or _none_if_infer(pyproject.get("source-version")),
+        strip_pragma=args.strip_pragma or bool(pyproject.get("strip-pragma", False)),
         write=args.write,
         check=args.check,
         diff=args.diff,
@@ -276,6 +277,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("paths", nargs="*")
     parser.add_argument("--target-version")
     parser.add_argument("--source-version")
+    parser.add_argument("--strip-pragma", action="store_true")
     parser.add_argument("--write", action="store_true")
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--diff", action="store_true")

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -365,6 +365,7 @@ class Config:
     allow_method_id_change: bool = False
     allow_storage_layout_change: bool = False
     source_ast: dict[str, Any] | None = None
+    strip_pragma: bool = False
 
 
 @dataclass

--- a/src/vyupgrade/rule_groups/legacy.py
+++ b/src/vyupgrade/rule_groups/legacy.py
@@ -38,6 +38,9 @@ from ..versions import VyperVersion
 def _pragma(rule_context: RuleContext) -> tuple[str, list[Fix], list[Diagnostic]]:
     source = rule_context.source
     config = rule_context.config
+    if config.strip_pragma:
+        return _strip_version_pragmas(rule_context)
+
     fixes: list[Fix] = []
     mask = rule_context.code_mask
     pattern = re.compile(
@@ -70,6 +73,35 @@ def _pragma(rule_context: RuleContext) -> tuple[str, list[Fix], list[Diagnostic]
     pragma = f"#pragma version {config.target_version}\n"
     fixes.append(Fix("VY001", 1, "added version pragma", "", pragma.rstrip()))
     return pragma + rewritten, fixes, []
+
+
+def _strip_version_pragmas(
+    rule_context: RuleContext,
+) -> tuple[str, list[Fix], list[Diagnostic]]:
+    source = rule_context.source
+    mask = rule_context.code_mask
+    edits: list[TextEdit] = []
+    fixes: list[Fix] = []
+    pattern = re.compile(
+        r"^[ \t]*#[ \t]*(?:@version|pragma[ \t]+version)[ \t]+[^\r\n]*"
+        r"(?:\r\n|\n|\r|$)",
+        re.MULTILINE,
+    )
+    for match in pattern.finditer(source):
+        if not _line_match_starts_outside_string(source, mask, match.start()):
+            continue
+        before = match.group(0).rstrip("\r\n")
+        edits.append(TextEdit(match.start(), match.end(), ""))
+        fixes.append(
+            Fix(
+                "VY001",
+                line_number(source, match.start()),
+                "removed version pragma",
+                before,
+                "",
+            )
+        )
+    return apply_edits(source, edits), fixes, []
 
 
 def _legacy_decorators(rule_context: RuleContext) -> tuple[str, list[Fix], list[Diagnostic]]:

--- a/tests/rule_groups/test_legacy.py
+++ b/tests/rule_groups/test_legacy.py
@@ -293,6 +293,55 @@ def f():
     assert result.source.startswith("#pragma version 0.4.3\n")
 
 
+def test_pragma_can_be_stripped_without_leaving_a_blank_line(config) -> None:
+    source = """# @version 0.3.10
+@external
+def f():
+    pass
+"""
+
+    result = apply_rules(source, config(strip_pragma=True))
+
+    assert result.source == """@external
+def f():
+    pass
+"""
+    assert [(fix.rule, fix.message) for fix in result.fixes] == [
+        ("VY001", "removed version pragma")
+    ]
+    assert apply_rules(result.source, config(strip_pragma=True)).source == result.source
+
+
+def test_strip_pragma_does_not_add_a_missing_pragma_or_touch_docstrings(config) -> None:
+    source = '''@external
+def f():
+    """
+    # @version 0.3.10
+    """
+    pass
+'''
+
+    result = apply_rules(
+        source,
+        config(strip_pragma=True, source_version="0.3.10"),
+    )
+
+    assert result.source == source
+    assert not [fix for fix in result.fixes if fix.rule == "VY001"]
+
+
+def test_strip_pragma_removes_every_source_directive(config) -> None:
+    source = """# @version 0.3.10
+#pragma version >=0.3.10,<0.5.0
+x: uint256
+"""
+
+    result = apply_rules(source, config(strip_pragma=True))
+
+    assert result.source == "x: uint256\n"
+    assert [fix.line for fix in result.fixes if fix.rule == "VY001"] == [1, 2]
+
+
 def test_legacy_0_2_1_syntax_rewrites_are_granular(config) -> None:
     source = """# @version 0.2.1
 Transfer: event({_from: indexed(address), _to: indexed(address), _value: uint256})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,33 @@ def __init__():
     assert json.loads(second_report.read_text())["files"][0]["changed"] is False
 
 
+def test_write_mode_can_strip_version_pragma(tmp_path: Path, passing_compiler) -> None:
+    contract = tmp_path / "Contract.vy"
+    contract.write_text(
+        "# @version 0.3.10\n@external\ndef value() -> uint256:\n    return 1\n",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--strip-pragma",
+            "--report-json",
+            str(report),
+        ]
+    )
+
+    assert code == 0
+    assert contract.read_text(encoding="utf-8").startswith("@external\n")
+    fixes = json.loads(report.read_text())["files"][0]["fixes"]
+    assert any(
+        fix["rule"] == "VY001" and fix["message"] == "removed version pragma"
+        for fix in fixes
+    )
+
+
 def test_broad_pragma_source_validation_uses_target_bounded_compiler(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -1175,6 +1202,27 @@ report-json = "{report}"
     assert report.exists()
 
 
+def test_pyproject_can_strip_version_pragma(
+    tmp_path: Path, monkeypatch, passing_compiler
+) -> None:
+    contract = tmp_path / "Contract.vy"
+    contract.write_text("# @version 0.3.10\nx: uint256\n", encoding="utf-8")
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        f'''[tool.vyupgrade]
+paths = ["{contract}"]
+strip-pragma = true
+''',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    code = main(["--write"])
+
+    assert code == 0
+    assert contract.read_text(encoding="utf-8") == "x: uint256\n"
+
+
 def test_pyproject_can_waive_unvalidated_source(
     tmp_path: Path, monkeypatch, passing_compiler
 ) -> None:
@@ -1784,6 +1832,35 @@ def test_write_include_dependencies_with_closure_output_commits_both(
     assert "#pragma version 0.4.3" in (output / "depkg" / "mod.vy").read_text()
     assert dependency.read_bytes() == dependency_original
     assert not (search_path / "main.vy").exists()
+
+
+def test_strip_pragma_applies_to_closure_output(
+    tmp_path: Path, passing_compiler
+) -> None:
+    project, dependency, search_path, _json_dependency = _write_dependency_cli_fixture(tmp_path)
+    output = tmp_path / "output"
+    dependency_original = dependency.read_bytes()
+
+    code = main(
+        [
+            str(project),
+            "--write",
+            "--strip-pragma",
+            "--include-dependencies",
+            "--compiler-search-paths",
+            str(search_path),
+            "--closure-output",
+            str(output),
+        ]
+    )
+
+    assert code == 0
+    assert project.read_text(encoding="utf-8") == "from depkg import mod\n"
+    assert (output / "main.vy").read_text(encoding="utf-8") == "from depkg import mod\n"
+    assert (output / "depkg" / "mod.vy").read_text(
+        encoding="utf-8"
+    ) == "VALUE: constant(uint256) = 1\n"
+    assert dependency.read_bytes() == dependency_original
 
 
 def test_closure_output_blocked_when_validation_blocks(

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -669,6 +669,53 @@ def test_target_validation_does_not_normalize_selected_candidate(tmp_path: Path)
     assert contract.read_text(encoding="utf-8") == original
 
 
+def test_real_compiler_validates_and_writes_source_without_pragma(tmp_path: Path) -> None:
+    contract = tmp_path / "Contract.vy"
+    contract.write_text(
+        """# @version 0.3.10
+@external
+def value() -> uint256:
+    return 1
+""",
+        encoding="utf-8",
+    )
+    report = tmp_path / "report.json"
+    second_report = tmp_path / "second-report.json"
+
+    code = main(
+        [
+            str(contract),
+            "--write",
+            "--strip-pragma",
+            "--report-json",
+            str(report),
+        ]
+    )
+    second_code = main(
+        [
+            str(contract),
+            "--check",
+            "--strip-pragma",
+            "--report-json",
+            str(second_report),
+        ]
+    )
+
+    assert code == 0
+    assert second_code == 0
+    assert contract.read_text(encoding="utf-8") == """@external
+def value() -> uint256:
+    return 1
+"""
+    file = json.loads(report.read_text())["files"][0]
+    assert file["validation"]["source_compile"] == "passed"
+    assert file["validation"]["target_compile"] == "passed"
+    assert file["validation"]["abi_equal"] is True
+    assert file["validation"]["method_ids_equal"] is True
+    assert file["validation"]["storage_layout_equal"] is True
+    assert json.loads(second_report.read_text())["files"][0]["changed"] is False
+
+
 def test_real_compiler_include_dependencies_upgrades_closure(
     tmp_path: Path,
 ) -> None:
@@ -859,8 +906,10 @@ def __init__():
     assert (output / "token.vy").is_file()
 
 
+@pytest.mark.parametrize("strip_pragma", [False, True])
 def test_real_compiler_closure_output_tree_compiles_standalone(
     tmp_path: Path,
+    strip_pragma: bool,
 ) -> None:
     project_root = tmp_path / "project"
     project = project_root / "main.vy"
@@ -890,6 +939,8 @@ def test_real_compiler_closure_output_tree_compiles_standalone(
         "--closure-output",
         str(output),
     ]
+    if strip_pragma:
+        arguments.append("--strip-pragma")
 
     code = main(arguments)
     first_hash = _tree_sha256(output)
@@ -911,6 +962,11 @@ def test_real_compiler_closure_output_tree_compiles_standalone(
     assert project.read_text(encoding="utf-8") == project_source
     assert dependency.read_text(encoding="utf-8") == dependency_source
     assert (output / "depkg" / "mod.vy").is_file()
+    if strip_pragma:
+        assert not entry.read_text(encoding="utf-8").startswith(("# @version", "#pragma"))
+        assert not (output / "depkg" / "mod.vy").read_text(
+            encoding="utf-8"
+        ).startswith(("# @version", "#pragma"))
     assert _tree_sha256(output) == first_hash
 
 


### PR DESCRIPTION
## Summary

- add `--strip-pragma` and `[tool.vyupgrade].strip-pragma` as an opt-in output policy
- remove source version directives through VY001 without adding a replacement or touching pragma-like docstring content
- keep target compiler selection, validation overlays, and ABI/method ID/storage-layout comparison unchanged
- apply the policy consistently to in-place writes and materialized dependency closures

## Validation

- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py`
- `uv run --locked pytest` (883 passed)
- `scripts/smoke-wheel.sh`
- real-compiler coverage for stripped single-file writes, repeat runs, and standalone closure output

Closes #1