### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
+## 0.7.0 - 2026-07-25
+
 - Added opt-in `--strip-pragma` output that removes version pragmas from
   migrated source without changing target compiler selection or validation.
-- Analyze upgraded dependency modules with compiler-annotated ASTs, validate
-  them through their consumer contracts instead of as standalone contracts,
-  and report that consumer-root evidence explicitly in JSON schema v5.
+- Added compiler-annotated AST analysis for upgraded dependency modules,
+  validating them through their consumer contracts instead of as standalone
+  contracts and reporting that consumer-root evidence explicitly in JSON
+  schema v5.
 
 ## 0.6.2 - 2026-07-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "vyupgrade"
-version = "0.6.2"
+version = "0.7.0"
 description = "Compiler-backed tool for upgrading Vyper contracts."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 from uv import find_uv_bin
 
+from vyupgrade import __version__
 from vyupgrade.cli import main
 from vyupgrade.compiler import (
     CompileResult,
@@ -1156,7 +1157,7 @@ def decimals() -> uint8:
 
     report_data = json.loads(report.read_text(encoding="utf-8"))
     assert report_data["schema_version"] == 5
-    assert report_data["producer"] == {"name": "vyupgrade", "version": "0.6.2"}
+    assert report_data["producer"] == {"name": "vyupgrade", "version": __version__}
     validation = report_data["files"][0]["validation"]
     attestation = validation["source_attestation"]
     declarations = attestation["declared_spec"]["compiler_declarations"]

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "vyupgrade"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary

- promote the dependency consumer-root validation and `--strip-pragma` work into the `0.7.0` changelog section
- bump `pyproject.toml` and the editable project entry in `uv.lock` to `0.7.0`
- make the report producer integration assertion follow installed package metadata so future release bumps do not require a hardcoded test edit

## Validation

- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py`
- `uv run --locked pytest` (`883 passed`)
- `scripts/smoke-wheel.sh`
- `uv run --locked python scripts/release_preflight.py v0.7.0 --dist dist`
