### PR TITLE
feat: report structured compiler error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added per-file Vyper exception class names to JSON compiler failure reports
+  as schema v6. Compiler return codes remain available in each validation
+  attestation's exit status.
+
 ## 0.7.0 - 2026-07-25
 
 - Added opt-in `--strip-pragma` output that removes version pragmas from

--- a/README.md
+++ b/README.md
@@ -134,20 +134,23 @@ stderr; environment-manager or adapter diagnostics remain separate.
 - `--allow-storage-layout-change` — write despite a storage-layout comparison mismatch.
 - `--config PATH` — read configuration from a specific `pyproject.toml`.
 
-JSON reports include a top-level `schema_version`. Version `5` distinguishes
-direct contract validation from dependency validation attributed through one or
-more consumer roots. Dependency reports list those roots and summarize their
-compile outcomes without claiming standalone compiler attestations. Version `4`
-provides producer identity plus separate source and target validation
-attestations. Each
-attestation records the declared source snapshot and compiler declarations,
-compiler authority and identity, dependency context, process completion and
-exit status, validated sources, the exact compile attempt, typed failure origin,
-and compiler output when validation fails. Version `2` added a per-file `role`
-and a top-level `closure` object; version `3` first introduced source-validation
-evidence and is superseded by versions `4` and `5`. Consumers should treat a
-missing version as the legacy unversioned format and require a new schema
-version before relying on renamed, removed, or type-changed fields.
+JSON reports include a top-level `schema_version`. Version `6` adds per-file
+`source_error_type` and `target_error_type` fields containing the Vyper
+exception class name when the managed compiler exposes one. Compiler process
+return codes remain available in each source or target attestation's
+`exit_status.code`. Version `5` distinguishes direct contract validation from
+dependency validation attributed through one or more consumer roots. Dependency
+reports list those roots and summarize their compile outcomes without claiming
+standalone compiler attestations. Version `4` provides producer identity plus
+separate source and target validation attestations. Each attestation records the
+declared source snapshot and compiler declarations, compiler authority and
+identity, dependency context, process completion and exit status, validated
+sources, the exact compile attempt, typed failure origin, and compiler output
+when validation fails. Version `2` added a per-file `role` and a top-level
+`closure` object; version `3` first introduced source-validation evidence and is
+superseded by versions `4`, `5`, and `6`. Consumers should treat a missing
+version as the legacy unversioned format and require a new schema version before
+relying on renamed, removed, or type-changed fields.
 
 ### Configuration
 

--- a/src/vyupgrade/compiler.py
+++ b/src/vyupgrade/compiler.py
@@ -119,6 +119,7 @@ class CompileResult:
     dependency_context: DependencyContext | None = None
     compiler_started: bool = False
     failure_origin: FailureOrigin | None = None
+    error_type: str | None = None
     compiler_output: CompilerOutput | None = None
     compiler_identity: ResolvedCompiler | None = None
     compiler_authority: CompilerAuthority = "default"
@@ -138,6 +139,7 @@ class _CompilerProcess:
     resolved_compiler: str | None = None
     compiler_started: bool = False
     failure_origin: FailureOrigin | None = None
+    error_type: str | None = None
     error: str | None = None
     compiler_identity: ResolvedCompiler | None = None
     compiler_authority: CompilerAuthority = "default"
@@ -2012,6 +2014,7 @@ def _failed_compile_result(
         dependency_context=process.context,
         compiler_started=process.compiler_started,
         failure_origin=process.failure_origin or "adapter",
+        error_type=process.error_type,
         compiler_output=compiler_output,
         compiler_identity=process.compiler_identity,
         compiler_authority=process.compiler_authority,
@@ -2307,6 +2310,7 @@ def _compiler_process_from_payload(
         resolved_compiler=_payload_string(payload, "resolved_compiler"),
         compiler_started=payload.get("compiler_started") is True,
         failure_origin=origin,
+        error_type=_payload_string(payload, "error_type"),
         error=_payload_string(payload, "error"),
         compiler_identity=_payload_compiler_identity(payload),
         compiler_authority=compiler_authority,

--- a/src/vyupgrade/compiler_runner.py
+++ b/src/vyupgrade/compiler_runner.py
@@ -107,6 +107,7 @@ def main() -> None:
             "state": "complete",
             "compiler_started": True,
             "failure_origin": process["failure_origin"],
+            "error_type": process.get("error_type"),
             "completion_status": process["completion_status"],
             "returncode": process["returncode"],
             "stdout": process["stdout"],
@@ -169,9 +170,10 @@ def _managed_compiler_result(command: list[str]) -> dict[str, object]:
         tempfile.TemporaryFile("w+", encoding="utf-8") as stderr,
     ):
         with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            error_type = None
             try:
                 vyper_compile = importlib.import_module("vyper.cli.vyper_compile")
-                exception_type = importlib.import_module("vyper.exceptions").VyperException
+                vyper_exception_type = importlib.import_module("vyper.exceptions").VyperException
                 vyper_compile._parse_args(command[1:])
                 returncode = 0
                 origin = None
@@ -179,8 +181,9 @@ def _managed_compiler_result(command: list[str]) -> dict[str, object]:
                 returncode = exc.code if type(exc.code) is int else 1
                 origin = None if returncode == 0 else "adapter"
             except BaseException as exc:
-                if "exception_type" in locals() and isinstance(exc, exception_type):
+                if "vyper_exception_type" in locals() and isinstance(exc, vyper_exception_type):
                     origin = "compiler"
+                    error_type = type(exc).__name__
                 else:
                     origin = "compiler-internal"
                 traceback.print_exception(exc, file=stderr)
@@ -190,6 +193,7 @@ def _managed_compiler_result(command: list[str]) -> dict[str, object]:
         return {
             "returncode": returncode,
             "failure_origin": origin,
+            "error_type": error_type,
             "completion_status": "completed",
             "stdout": stdout.read(),
             "stderr": stderr.read(),

--- a/src/vyupgrade/engine.py
+++ b/src/vyupgrade/engine.py
@@ -208,6 +208,11 @@ def prepare_migrations(requests: Iterable[MigrationRequest], config: Config) -> 
                 if source_compile.status == "failed"
                 else None
             ),
+            source_error_type=(
+                None
+                if contextual_validation or source_compile.status != "failed"
+                else source_compile.error_type
+            ),
             source_attestation=_validation_attestation(
                 source_compile,
                 _declared_spec(snapshot_sources, source_compile.compiler_declarations),
@@ -490,6 +495,9 @@ def _record_target_compile(
     report.target_unavailable_artifacts = unavailable_validation_artifacts(target_compile)
     report.target_unavailable_formats = list(getattr(target_compile, "unavailable_formats", ()))
     report.target_error = target_compile.stderr if target_compile.status == "failed" else None
+    report.target_error_type = (
+        target_compile.error_type if target_compile.status == "failed" else None
+    )
     report_source = next(
         (source for source in declared_spec.sources if source.path == str(report.path.resolve())),
         declared_spec.sources[0],
@@ -514,6 +522,7 @@ def _reset_target_validation(report: FileReport, validation_diagnostics: list[Di
     report.target_unavailable_artifacts.clear()
     report.target_unavailable_formats.clear()
     report.target_error = None
+    report.target_error_type = None
     report.target_attestation = None
     report.abi_equal = None
     report.method_ids_equal = None

--- a/src/vyupgrade/models.py
+++ b/src/vyupgrade/models.py
@@ -52,7 +52,7 @@ ValidationIssueCode = Literal[
     "method_identifiers_changed",
     "storage_layout_changed",
 ]
-REPORT_SCHEMA_VERSION = 5
+REPORT_SCHEMA_VERSION = 6
 
 
 @dataclass(frozen=True)
@@ -292,9 +292,11 @@ class FileReport:
     source_compile: str = "skipped"
     target_compile: str = "skipped"
     source_error: str | None = None
+    source_error_type: str | None = None
     source_attestation: ValidationAttestation | None = None
     target_attestation: ValidationAttestation | None = None
     target_error: str | None = None
+    target_error_type: str | None = None
     abi_equal: bool | None = None
     method_ids_equal: bool | None = None
     storage_layout_equal: bool | None = None
@@ -452,7 +454,9 @@ class RunReport:
                         "decision": file.validation_decision.to_json_obj(),
                     },
                     "source_error": file.source_error,
+                    "source_error_type": file.source_error_type,
                     "target_error": file.target_error,
+                    "target_error_type": file.target_error_type,
                 }
                 for file in self.files
             ],

--- a/src/vyupgrade/validation.py
+++ b/src/vyupgrade/validation.py
@@ -72,6 +72,8 @@ def _decide_consumer_root_validation(
     report.source_compiler = compilers.pop() if len(compilers) == 1 else None
     report.source_error = None
     report.target_error = None
+    report.source_error_type = None
+    report.target_error_type = None
     report.source_attestation = None
     report.target_attestation = None
     report.source_unavailable_artifacts.clear()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1678,7 +1678,7 @@ def test_overlay_layout_conflict_exits_4(tmp_path: Path, passing_compiler, capsy
     assert str(second.resolve()) in stderr
 
 
-def test_report_json_schema_v5(tmp_path: Path, passing_compiler) -> None:
+def test_report_json_schema_v6(tmp_path: Path, passing_compiler) -> None:
     project, dependency, search_path, json_dependency = _write_dependency_cli_fixture(
         tmp_path, include_json=True
     )
@@ -1710,11 +1710,13 @@ def test_report_json_schema_v5(tmp_path: Path, passing_compiler) -> None:
     assert closure_code == 0
     project_data = json.loads(project_report.read_text())
     closure_data = json.loads(closure_report.read_text())
-    assert project_data["schema_version"] == 5
+    assert project_data["schema_version"] == 6
     assert project_data["producer"]["name"] == "vyupgrade"
     assert project_data["producer"]["version"]
     assert project_data["closure"] is None
     assert all(file["role"] == "project" for file in project_data["files"])
+    assert project_data["files"][0]["source_error_type"] is None
+    assert project_data["files"][0]["target_error_type"] is None
     source_attestation = project_data["files"][0]["validation"]["source_attestation"]
     assert {
         "declared_spec",
@@ -1729,7 +1731,7 @@ def test_report_json_schema_v5(tmp_path: Path, passing_compiler) -> None:
         "failure_origin",
         "compiler_output",
     } == source_attestation.keys()
-    assert closure_data["schema_version"] == 5
+    assert closure_data["schema_version"] == 6
     assert closure_data["closure"] == {
         "requested": True,
         "dependencies": sorted([str(dependency.resolve()), str(json_dependency.resolve())]),

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1156,7 +1156,7 @@ def decimals() -> uint8:
     )
 
     report_data = json.loads(report.read_text(encoding="utf-8"))
-    assert report_data["schema_version"] == 5
+    assert report_data["schema_version"] == 6
     assert report_data["producer"] == {"name": "vyupgrade", "version": __version__}
     validation = report_data["files"][0]["validation"]
     attestation = validation["source_attestation"]
@@ -1652,6 +1652,33 @@ except subprocess.TimeoutExpired:
     raise SystemExit(0)
 raise SystemExit("managed compiler did not time out")
 """,
+    )
+
+    assert process.returncode == 0, process.stderr
+
+
+def test_managed_compiler_reports_vyper_exception_type(tmp_path: Path) -> None:
+    site, _bin_dir = _write_managed_vyper_environment(
+        tmp_path,
+        """from vyper.exceptions import VyperException
+
+class TypeMismatch(VyperException):
+    pass
+
+def _parse_args(_arguments):
+    raise TypeMismatch("incompatible types")
+"""
+    )
+
+    process = _run_managed_compiler_harness(
+        site,
+        """from vyupgrade.compiler_runner import _run_managed_compiler
+
+result = _run_managed_compiler(["vyper"], 5)
+assert result["failure_origin"] == "compiler", result
+assert result["error_type"] == "TypeMismatch", result
+assert result["returncode"] == 1, result
+"""
     )
 
     assert process.returncode == 0, process.stderr

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -45,6 +45,7 @@ def _compiler_process(
     stdout: str = TARGET_COMPILER_OUTPUT,
     stderr: str = "",
     failure_origin: FailureOrigin | None = None,
+    error_type: str | None = None,
     error: str | None = None,
 ) -> _CompilerProcess:
     return _CompilerProcess(
@@ -56,6 +57,7 @@ def _compiler_process(
         resolved_compiler="0.4.3",
         compiler_started=True,
         failure_origin=failure_origin or ("compiler" if returncode else None),
+        error_type=error_type,
         error=error,
     )
 
@@ -623,6 +625,25 @@ def test_compile_preserves_typed_timeout_failure(monkeypatch) -> None:
     assert result.stderr == "compiler timed out after 120 seconds"
     assert result.failure_origin == "timeout"
     assert result.compiler_started is True
+
+
+def test_compile_preserves_vyper_exception_type(monkeypatch) -> None:
+    def fake_run(command, *_args, **_kwargs):
+        return _compiler_process(
+            command,
+            returncode=1,
+            stderr="vyper.exceptions.TypeMismatch: incompatible types",
+            error_type="TypeMismatch",
+        )
+
+    monkeypatch.setattr("vyupgrade.compiler._run_compiler_process", fake_run)
+
+    result = _run_compile(
+        ["vyper"], Path("/tmp/contract.vy"), Config(paths=(Path("/tmp/contract.vy"),))
+    )
+
+    assert result.status == "failed"
+    assert result.error_type == "TypeMismatch"
 
 
 def test_compile_source_ast_prefers_annotated_ast(monkeypatch, tmp_path) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -481,7 +481,9 @@ def test_source_failure_uses_typed_waiver(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         engine,
         "compile_source_file",
-        lambda *_args: CompileResult("failed", stderr="source failed"),
+        lambda *_args: CompileResult(
+            "failed", stderr="source failed", error_type="UnknownAttribute"
+        ),
     )
     monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
     monkeypatch.setattr(
@@ -496,6 +498,31 @@ def test_source_failure_uses_typed_waiver(monkeypatch, tmp_path: Path) -> None:
 
     assert decision.status == "waived"
     assert [issue.code for issue in decision.waivers] == ["source_compile_failed"]
+    assert batch.files[0].report.source_error_type == "UnknownAttribute"
+
+
+def test_target_failure_preserves_vyper_exception_type(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "Contract.vy"
+    monkeypatch.setattr(
+        engine,
+        "compile_source_file",
+        lambda *_args: CompileResult("passed", artifacts=SOURCE_ARTIFACTS),
+    )
+    monkeypatch.setattr(engine, "apply_rules", _unchanged_rewrite)
+    monkeypatch.setattr(
+        engine,
+        "compile_target_source",
+        lambda *_args: CompileResult(
+            "failed", stderr="target failed", error_type="TypeMismatch"
+        ),
+    )
+    config = _config(tmp_path)
+    batch = engine.prepare_migrations((_request(path),), config)
+
+    decision = engine.validate_migrations(batch, config)
+
+    assert decision.status == "blocked"
+    assert batch.files[0].report.target_error_type == "TypeMismatch"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -50,15 +50,34 @@ def test_render_text_includes_compile_errors() -> None:
     assert 'Version specification "0.2.11" is not compatible' in text
 
 
-def test_json_report_declares_attestation_schema_version() -> None:
+def test_json_report_declares_structured_error_schema_version() -> None:
     report = RunReport(source_version=None, target_version="0.4.3", files=[])
 
     data = report.to_json_obj()
 
-    assert data["schema_version"] == 5
+    assert data["schema_version"] == 6
     assert data["files"] == []
     assert data["target_version"] == "0.4.3"
     assert data["closure"] is None
+
+
+def test_json_report_includes_structured_compiler_error_types() -> None:
+    file_report = FileReport(
+        path=Path("bad.vy"),
+        source_compile="failed",
+        source_error="source failed",
+        source_error_type="TypeMismatch",
+        target_compile="failed",
+        target_error="target failed",
+        target_error_type="UnknownAttribute",
+    )
+
+    file_data = RunReport(
+        source_version="0.3.10", target_version="0.4.3", files=[file_report]
+    ).to_json_obj()["files"][0]
+
+    assert file_data["source_error_type"] == "TypeMismatch"
+    assert file_data["target_error_type"] == "UnknownAttribute"
 
 
 def test_closure_summary_reports_upgraded_dependency_count() -> None:


### PR DESCRIPTION
_co-authored by gpt 5.6 sol_

## Summary

- add `source_error_type` and `target_error_type` to JSON report schema v6
- capture the concrete Vyper exception class at the managed compiler boundary, leaving the fields null when no typed exception is available
- preserve the existing verbatim error text and existing compiler return codes under each attestation's `exit_status.code`

Fixes #40
