### PR TITLE
chore: prepare 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.7.1 - 2026-07-27
+
 - Added per-file Vyper exception class names to JSON compiler failure reports
   as schema v6. Compiler return codes remain available in each validation
   attestation's exit status.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "vyupgrade"
-version = "0.7.0"
+version = "0.7.1"
 description = "Compiler-backed tool for upgrading Vyper contracts."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "vyupgrade"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary

- promote the structured compiler error reporting work into the `0.7.1` changelog section
- bump `pyproject.toml` and the editable project entry in `uv.lock` to `0.7.1`

## Validation

- `uv run --locked ruff check src tests scripts/corpus.py scripts/release_notes.py scripts/release_preflight.py`
- `uv run --locked pytest` (`887 passed`)
- `scripts/smoke-wheel.sh`
- `uv run --locked python scripts/release_preflight.py v0.7.1 --dist dist`
